### PR TITLE
Fix persona delete confirmation bypass and test

### DIFF
--- a/src/components/settings/personas-tab.test.tsx
+++ b/src/components/settings/personas-tab.test.tsx
@@ -113,7 +113,9 @@ describe("PersonasTab - Delete Confirmation", () => {
       </MemoryRouter>
     );
 
-    const deleteButton = screen.getByRole("button", { name: /delete persona/i });
+    const deleteButton = screen.getByRole("button", {
+      name: /delete persona/i,
+    });
     fireEvent.click(deleteButton);
 
     await waitFor(() => {
@@ -122,7 +124,9 @@ describe("PersonasTab - Delete Confirmation", () => {
       ).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/are you sure you want to delete/i)
+    ).toBeInTheDocument();
   });
 
   it("does not delete persona when cancel is clicked", async () => {
@@ -132,7 +136,9 @@ describe("PersonasTab - Delete Confirmation", () => {
       </MemoryRouter>
     );
 
-    const deleteButton = screen.getByRole("button", { name: /delete persona/i });
+    const deleteButton = screen.getByRole("button", {
+      name: /delete persona/i,
+    });
     fireEvent.click(deleteButton);
 
     await waitFor(() => {
@@ -162,7 +168,9 @@ describe("PersonasTab - Delete Confirmation", () => {
       </MemoryRouter>
     );
 
-    const deleteButton = screen.getByRole("button", { name: /delete persona/i });
+    const deleteButton = screen.getByRole("button", {
+      name: /delete persona/i,
+    });
     fireEvent.click(deleteButton);
 
     await waitFor(() => {

--- a/src/components/settings/personas-tab.test.tsx
+++ b/src/components/settings/personas-tab.test.tsx
@@ -1,0 +1,184 @@
+import type { Doc } from "@convex/_generated/dataModel";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("convex/react", () => ({
+  useMutation: vi.fn(),
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@convex/_generated/api", () => ({
+  api: {
+    personas: {
+      list: vi.fn(),
+      listAllBuiltIn: vi.fn(),
+      remove: vi.fn(),
+      toggleBuiltInPersona: vi.fn(),
+    },
+    userSettings: {
+      getUserSettings: vi.fn(),
+      togglePersonasEnabled: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/hooks/use-user-settings", () => ({
+  useUserSettings: vi.fn(),
+}));
+
+vi.mock("@/providers/user-data-context", () => ({
+  useUserDataContext: vi.fn(),
+}));
+
+vi.mock("@/providers/toast-context", () => ({
+  useToast: vi.fn(),
+}));
+
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@convex/_generated/api";
+
+import { PersonasTab } from "./personas-tab";
+import { useUserSettings } from "@/hooks/use-user-settings";
+import { useUserDataContext } from "@/providers/user-data-context";
+import { useToast } from "@/providers/toast-context";
+
+const useMutationMock = vi.mocked(useMutation);
+const useQueryMock = vi.mocked(useQuery);
+const useUserSettingsMock = vi.mocked(useUserSettings);
+const useUserDataContextMock = vi.mocked(useUserDataContext);
+const useToastMock = vi.mocked(useToast);
+
+describe("PersonasTab - Delete Confirmation", () => {
+  const mockUser = {
+    _id: "user-1",
+  } as unknown as Doc<"users">;
+
+  const mockPersona = {
+    _id: "persona-1" as unknown as Doc<"personas">["_id"],
+    name: "Test Persona",
+    description: "A test persona",
+    prompt: "You are a helpful assistant",
+    icon: "??",
+    isBuiltIn: false,
+    userId: "user-1",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    _creationTime: Date.now(),
+  } as unknown as Doc<"personas">;
+
+  const mockRemovePersonaMutation = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useUserDataContextMock.mockReturnValue({
+      user: mockUser,
+    } as unknown as ReturnType<typeof useUserDataContext>);
+
+    useUserSettingsMock.mockReturnValue({
+      personasEnabled: true,
+    } as unknown as ReturnType<typeof useUserSettings>);
+
+    useQueryMock.mockImplementation((query: unknown) => {
+      if (query === api.personas.list) {
+        return [mockPersona];
+      }
+      if (query === api.personas.listAllBuiltIn) {
+        return [];
+      }
+      if (query === api.userSettings.getUserSettings) {
+        return [];
+      }
+      return undefined;
+    });
+
+    useMutationMock.mockImplementation((mutation: unknown) => {
+      if (mutation === api.personas.remove) {
+        return mockRemovePersonaMutation;
+      }
+      return vi.fn();
+    });
+
+    useToastMock.mockReturnValue({
+      error: vi.fn(),
+      success: vi.fn(),
+      info: vi.fn(),
+    } as unknown as ReturnType<typeof useToast>);
+  });
+
+  it("opens confirmation dialog when delete button is clicked", async () => {
+    render(
+      <MemoryRouter>
+        <PersonasTab />
+      </MemoryRouter>
+    );
+
+    const deleteButton = screen.getByRole("button", { name: /delete persona/i });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: /delete persona/i })
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument();
+  });
+
+  it("does not delete persona when cancel is clicked", async () => {
+    render(
+      <MemoryRouter>
+        <PersonasTab />
+      </MemoryRouter>
+    );
+
+    const deleteButton = screen.getByRole("button", { name: /delete persona/i });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: /delete persona/i })
+      ).toBeInTheDocument();
+    });
+
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: /delete persona/i })
+      ).not.toBeInTheDocument();
+    });
+
+    expect(mockRemovePersonaMutation).not.toHaveBeenCalled();
+  });
+
+  it("deletes persona when confirm is clicked", async () => {
+    mockRemovePersonaMutation.mockResolvedValue(undefined);
+
+    render(
+      <MemoryRouter>
+        <PersonasTab />
+      </MemoryRouter>
+    );
+
+    const deleteButton = screen.getByRole("button", { name: /delete persona/i });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: /delete persona/i })
+      ).toBeInTheDocument();
+    });
+
+    const confirmButton = screen.getByRole("button", { name: /^delete$/i });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockRemovePersonaMutation).toHaveBeenCalledWith({
+        id: mockPersona._id,
+      });
+    });
+  });
+});

--- a/src/components/settings/personas-tab.test.tsx
+++ b/src/components/settings/personas-tab.test.tsx
@@ -1,7 +1,7 @@
 import type { Doc } from "@convex/_generated/dataModel";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("convex/react", () => ({
   useMutation: vi.fn(),
@@ -35,13 +35,13 @@ vi.mock("@/providers/toast-context", () => ({
   useToast: vi.fn(),
 }));
 
-import { useMutation, useQuery } from "convex/react";
 import { api } from "@convex/_generated/api";
+import { useMutation, useQuery } from "convex/react";
 
-import { PersonasTab } from "./personas-tab";
 import { useUserSettings } from "@/hooks/use-user-settings";
 import { useUserDataContext } from "@/providers/user-data-context";
 import { useToast } from "@/providers/toast-context";
+import { PersonasTab } from "./personas-tab";
 
 const useMutationMock = vi.mocked(useMutation);
 const useQueryMock = vi.mocked(useQuery);

--- a/src/components/settings/personas-tab.test.tsx
+++ b/src/components/settings/personas-tab.test.tsx
@@ -37,10 +37,9 @@ vi.mock("@/providers/toast-context", () => ({
 
 import { api } from "@convex/_generated/api";
 import { useMutation, useQuery } from "convex/react";
-
 import { useUserSettings } from "@/hooks/use-user-settings";
-import { useUserDataContext } from "@/providers/user-data-context";
 import { useToast } from "@/providers/toast-context";
+import { useUserDataContext } from "@/providers/user-data-context";
 import { PersonasTab } from "./personas-tab";
 
 const useMutationMock = vi.mocked(useMutation);

--- a/src/components/settings/personas-tab.tsx
+++ b/src/components/settings/personas-tab.tsx
@@ -73,7 +73,6 @@ export const PersonasTab = () => {
 
   const handleDeletePersona = useCallback(
     async (personaId: Id<"personas">) => {
-      setDeletingPersona(personaId);
       try {
         await removePersonaMutation({ id: personaId });
       } catch (_error) {
@@ -275,7 +274,7 @@ export const PersonasTab = () => {
                                 className="text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive dark:hover:bg-destructive/20"
                                 size="sm"
                                 variant="ghost"
-                                onClick={() => handleDeletePersona(persona._id)}
+                                onClick={() => setDeletingPersona(persona._id)}
                               >
                                 <TrashIcon className="h-3 w-3" />
                               </Button>


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-2d3997a8-3a91-48eb-b168-54b54401bcfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d3997a8-3a91-48eb-b168-54b54401bcfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route persona deletion through a confirmation dialog and add tests to verify open, cancel, and confirm behaviors.
> 
> - **Settings UI (`src/components/settings/personas-tab.tsx`)**:
>   - Delete action now opens confirmation by setting `deletingPersona` via button click instead of immediate deletion.
>   - `handleDeletePersona` no longer sets `deletingPersona` before mutation; cleanup still clears it after.
>   - `ConfirmationDialog` wired to `onConfirm` to call `handleDeletePersona` and `onOpenChange` to reset state.
> - **Tests (`src/components/settings/personas-tab.test.tsx`)**:
>   - Add tests to cover dialog open on delete, cancel without deletion, and confirm triggering `api.personas.remove`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 895601286de05e0872e3334233446234e6defc89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->