### PR TITLE
Improve code block readability in light mode

### DIFF
--- a/src/components/ui/markdown-block.tsx
+++ b/src/components/ui/markdown-block.tsx
@@ -382,7 +382,7 @@ const MarkdownBlockComponent: LLMOutputComponent = ({ blockMatch }) => {
   }, [messageId]);
 
   return (
-    <div className="prose prose-sm sm:prose-base dark:prose-invert max-w-none prose-headings:tracking-tight prose-headings:font-semibold prose-p:leading-[1.75] prose-li:my-1.5 prose-ul:my-3 prose-ol:my-3 prose-hr:my-6 prose-a:underline-offset-2 hover:prose-a:underline prose-code:rounded-md prose-code:px-1.5 prose-code:py-0.5 prose-pre:bg-muted prose-pre:rounded-lg prose-pre:p-4 prose-blockquote:border-l-border prose-blockquote:text-muted-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>p:first-of-type]:mt-0">
+    <div className="prose prose-sm sm:prose-base dark:prose-invert max-w-none prose-headings:tracking-tight prose-headings:font-semibold prose-p:leading-[1.75] prose-li:my-1.5 prose-ul:my-3 prose-ol:my-3 prose-hr:my-6 prose-a:underline-offset-2 hover:prose-a:underline prose-code:rounded-md prose-code:px-1.5 prose-code:py-0.5 prose-pre:bg-surface-variant/90 dark:prose-pre:bg-surface/70 prose-pre:text-foreground prose-pre:rounded-xl prose-pre:border prose-pre:border-border/60 prose-pre:shadow-sm prose-pre:p-0 prose-pre:mt-2 prose-pre:mb-2 prose-pre:w-[calc(100%+24px)] prose-pre:max-w-none sm:prose-pre:w-[calc(100%+48px)] prose-pre:-mx-[12px] sm:prose-pre:-mx-[24px] prose-pre:overflow-x-auto prose-blockquote:border-l-border prose-blockquote:text-muted-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>p:first-of-type]:mt-0">
       <Markdown
         options={{
           disableParsingRawHTML: true,

--- a/src/globals.css
+++ b/src/globals.css
@@ -2271,7 +2271,7 @@ pre {
 }
 
 .zen-prose .prose :where(blockquote)::before {
-  content: "?";
+  content: """;
   font-family: "Playfair Display", Georgia, serif;
   font-size: clamp(
     calc(2.2rem * var(--zen-font-scale, 1)),

--- a/src/globals.css
+++ b/src/globals.css
@@ -2271,7 +2271,7 @@ pre {
 }
 
 .zen-prose .prose :where(blockquote)::before {
-  content: """;
+  content: "?";
   font-family: "Playfair Display", Georgia, serif;
   font-size: clamp(
     calc(2.2rem * var(--zen-font-scale, 1)),

--- a/src/globals.css
+++ b/src/globals.css
@@ -1018,7 +1018,30 @@ pre {
 }
 
 /* Code block styling */
- 
+.prose pre {
+  padding: 1rem 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .prose pre {
+    padding: 1rem 1.5rem;
+  }
+}
+
+.prose pre code {
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 0.875rem;
+  line-height: 1.7;
+}
+
+@media (min-width: 640px) {
+  .prose pre code {
+    font-size: 0.9375rem;
+  }
+}
+
 
 /* Math rendering */
 .katex-display {
@@ -2248,7 +2271,7 @@ pre {
 }
 
 .zen-prose .prose :where(blockquote)::before {
-  content: "“";
+  content: "?";
   font-family: "Playfair Display", Georgia, serif;
   font-size: clamp(
     calc(2.2rem * var(--zen-font-scale, 1)),


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-6c0d6f4a-10fc-4e1f-bacb-d909faa8942a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c0d6f4a-10fc-4e1f-bacb-d909faa8942a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines code block presentation in markdown (backgrounds, spacing, overflow) and adds global pre/code styles; updates zen-prose blockquote marker.
> 
> - **UI (Markdown rendering)**:
>   - Update `src/components/ui/markdown-block.tsx` container classes for `prose-pre` to adjust backgrounds (light/dark), text color, rounded corners, border/shadow, zero inner padding, margins, expanded width with negative margins, and horizontal overflow.
> - **CSS (globals)**:
>   - Add `.prose pre` responsive padding and `.prose pre code` resets (no padding/background, inherit color) with responsive font sizing and line-height.
> - **Typography**:
>   - Change `zen-prose` blockquote decorative marker from `“` to `?` in `src/globals.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1e6894d39ef035aef1ac5cdcad0ac545df386e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->