### PR TITLE
Add minimal CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,40 @@
+language:
+  typescript:
+    review_general_suggestions: false
+    review_optional_chains: false
+    review_naming_conventions: false
+  javascript:
+    review_general_suggestions: false
+    review_optional_chains: false
+    review_naming_conventions: false
+
+reviews:
+  high_level_summary: false
+  estimate_effort: false
+  estimate_benefit: false
+  review_comment_language: concise
+
+ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "convex/_generated/**"
+  - "build/**"
+  - "dist/**"
+  - "node_modules/**"
+
+path_filters:
+  - "!**/*.test.*"
+  - "!**/*.spec.*"
+  - "!convex/_generated/**"
+  - "!build/**"
+  - "!dist/**"
+
+min_severity: medium
+
+disable:
+  - format
+  - documentation
+  - test_coverage
+


### PR DESCRIPTION
This PR adds a minimal CodeRabbit configuration to reduce noise from CodeRabbit reviews while still catching important issues like security vulnerabilities, bugs, and architectural concerns. The configuration disables style-related reviews (Biome already handles formatting/linting), ignores test files and generated directories, sets minimum severity to medium, disables format and documentation reviews, and uses concise review comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration to refine automated analysis settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->