### PR TITLE
Add minimal CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,8 +17,3 @@ path_filters:
   - "!dist/**"
   - "!node_modules/**"
 
-disable:
-  - format
-  - documentation
-  - test_coverage
-

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,23 +2,12 @@ language: en-US
 
 reviews:
   high_level_summary: false
-  estimate_effort: false
-  estimate_benefit: false
-  review_comment_language: concise
+  estimate_code_review_effort: false
+  assess_linked_issues: false
   profile: chill
   path_instructions:
     - path: "**/*.{ts,tsx,js,jsx}"
       instructions: "Focus on security vulnerabilities, bugs, and architectural concerns. Skip style suggestions, formatting, naming conventions, and optional chaining suggestions as Biome handles these. Do not suggest code style improvements."
-
-ignore:
-  - "**/*.test.ts"
-  - "**/*.test.tsx"
-  - "**/*.spec.ts"
-  - "**/*.spec.tsx"
-  - "convex/_generated/**"
-  - "build/**"
-  - "dist/**"
-  - "node_modules/**"
 
 path_filters:
   - "!**/*.test.*"
@@ -26,8 +15,7 @@ path_filters:
   - "!convex/_generated/**"
   - "!build/**"
   - "!dist/**"
-
-min_severity: medium
+  - "!node_modules/**"
 
 disable:
   - format

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,18 +1,14 @@
-language:
-  typescript:
-    review_general_suggestions: false
-    review_optional_chains: false
-    review_naming_conventions: false
-  javascript:
-    review_general_suggestions: false
-    review_optional_chains: false
-    review_naming_conventions: false
+language: en-US
 
 reviews:
   high_level_summary: false
   estimate_effort: false
   estimate_benefit: false
   review_comment_language: concise
+  profile: chill
+  path_instructions:
+    - path: "**/*.{ts,tsx,js,jsx}"
+      instructions: "Focus on security vulnerabilities, bugs, and architectural concerns. Skip style suggestions, formatting, naming conventions, and optional chaining suggestions as Biome handles these. Do not suggest code style improvements."
 
 ignore:
   - "**/*.test.ts"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,40 @@
+language:
+  typescript:
+    review_general_suggestions: false
+    review_optional_chains: false
+    review_naming_conventions: false
+  javascript:
+    review_general_suggestions: false
+    review_optional_chains: false
+    review_naming_conventions: false
+
+reviews:
+  high_level_summary: false
+  estimate_effort: false
+  estimate_benefit: false
+  review_comment_language: concise
+
+ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "convex/_generated/**"
+  - "build/**"
+  - "dist/**"
+  - "node_modules/**"
+
+path_filters:
+  - "!**/*.test.*"
+  - "!**/*.spec.*"
+  - "!convex/_generated/**"
+  - "!build/**"
+  - "!dist/**"
+
+min_severity: medium
+
+disable:
+  - format
+  - documentation
+  - test_coverage
+


### PR DESCRIPTION
This PR adds a minimal CodeRabbit configuration to reduce noise from CodeRabbit reviews while still catching important issues like security vulnerabilities, bugs, and architectural concerns. The configuration disables style-related reviews (Biome already handles formatting/linting), ignores test files and generated directories, sets minimum severity to medium, disables format and documentation reviews, and uses concise review comments.