### PR TITLE
Debug blank Vercel deployment page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,13 @@
   "outputDirectory": "dist",
   "devCommand": "bun run dev",
   "installCommand": "bun install",
-  "rewrites": [
+  "routes": [
     {
-      "source": "/(.*)",
-      "destination": "/index.html"
+      "handle": "filesystem"
+    },
+    {
+      "src": "/.*",
+      "dest": "/index.html"
     }
   ],
   "headers": [

--- a/vercel.json
+++ b/vercel.json
@@ -6,22 +6,21 @@
   "installCommand": "bun install",
   "routes": [
     {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/.*",
-      "dest": "/index.html"
-    }
-  ],
-  "headers": [
-    {
-      "source": "/assets/(.*)",
+      "src": "/assets/(.*)",
       "headers": [
         {
           "key": "Cache-Control",
           "value": "public, max-age=31536000, immutable"
         }
-      ]
+      ],
+      "continue": true
+    },
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/.*",
+      "dest": "/index.html"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,13 +6,6 @@
   "installCommand": "bun install",
   "routes": [
     {
-      "src": "/assets/(.*)",
-      "headers": {
-        "Cache-Control": "public, max-age=31536000, immutable"
-      },
-      "continue": true
-    },
-    {
       "handle": "filesystem"
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -7,12 +7,9 @@
   "routes": [
     {
       "src": "/assets/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
-      ],
+      "headers": {
+        "Cache-Control": "public, max-age=31536000, immutable"
+      },
       "continue": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": null,
-  "buildCommand": "bun run build",
+  "buildCommand": "bun run build:frontend",
   "outputDirectory": "dist",
   "devCommand": "bun run dev",
   "installCommand": "bun install",


### PR DESCRIPTION
Fix blank page on Vercel by updating `vercel.json` to serve static assets before the SPA fallback.

Vercel was rewriting all requests, including for JavaScript bundles, to `index.html`, causing the browser to render a blank page. This change ensures that actual files are served directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-85c32a29-ea8a-4329-ac72-4cc8bd5890dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85c32a29-ea8a-4329-ac72-4cc8bd5890dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

