### PR TITLE
Exclude Elevenlabs from provider summary cards

### DIFF
--- a/.cursor/rules/commits-and-prs.mdc
+++ b/.cursor/rules/commits-and-prs.mdc
@@ -174,5 +174,9 @@ Closes #123
    ```bash
    gh pr create --title "Descriptive PR title" --body "PR description with context"
    ```
+   If needed, specify head and base explicitly:
+   ```bash
+   gh pr create --head <branch-name> --base main --title "Descriptive PR title" --body "PR description"
+   ```
 6. **Review**: Address feedback and update commits as needed
 7. **Merge**: Use appropriate merge strategy (squash for feature branches)

--- a/.cursor/rules/commits-and-prs.mdc
+++ b/.cursor/rules/commits-and-prs.mdc
@@ -170,6 +170,9 @@ Closes #123
 2. **Make changes**: Write code following project standards
 3. **Commit**: Use conventional commit format with title only
 4. **Push**: `git push -u origin <branch-name>`
-5. **Create PR**: Use concise, descriptive title (no Conventional Commits format required)
+5. **Create PR**: Use `gh pr create` with concise, descriptive title (no Conventional Commits format required)
+   ```bash
+   gh pr create --title "Descriptive PR title" --body "PR description with context"
+   ```
 6. **Review**: Address feedback and update commits as needed
 7. **Merge**: Use appropriate merge strategy (squash for feature branches)

--- a/AGENT.md
+++ b/AGENT.md
@@ -46,6 +46,10 @@
   ```bash
   gh pr create --title "Descriptive PR title" --body "PR description with context"
   ```
+  If needed, specify head and base explicitly:
+  ```bash
+  gh pr create --head <branch-name> --base main --title "Descriptive PR title" --body "PR description"
+  ```
 - See `.cursor/rules/commits-and-prs.mdc` for detailed guidelines
 
 ## UI Styling Guidelines (Tailwind + shadcn)

--- a/AGENT.md
+++ b/AGENT.md
@@ -42,7 +42,10 @@
 - **Title Only**: Commit messages MUST contain only a title (no body/description)
 - **Splitting**: Split commits when changes affect different areas or have different purposes
 - **Branch Names**: Use `<type>/<description>` format (e.g., `feat/add-commit-rules`, `fix/message-flicker`)
-- **PR Titles**: Concise and descriptive (no Conventional Commits format required); provide context in PR description
+- **PR Creation**: Use `gh pr create` CLI tool with concise, descriptive title (no Conventional Commits format required)
+  ```bash
+  gh pr create --title "Descriptive PR title" --body "PR description with context"
+  ```
 - See `.cursor/rules/commits-and-prs.mdc` for detailed guidelines
 
 ## UI Styling Guidelines (Tailwind + shadcn)

--- a/src/components/settings/models-tab/ProviderSummary.tsx
+++ b/src/components/settings/models-tab/ProviderSummary.tsx
@@ -105,9 +105,12 @@ export const ProviderSummary = memo(
       return null;
     }
 
+    const availableProvidersSet = new Set(availableProviders);
+
     return (
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
         {Object.entries(stats.providerCounts)
+          .filter(([provider]) => availableProvidersSet.has(provider))
           .sort(([a], [b]) => {
             const providerOrder = Object.keys(PROVIDER_NAMES);
             const aIndex = providerOrder.indexOf(a);


### PR DESCRIPTION
Fixes an issue where provider cards were making room for Elevenlabs even though it should be excluded from the models-tab page entirely.

The ProviderSummary component was rendering all providers from stats.providerCounts without filtering by availableProviders. This fix adds a filter to only show providers that are in the availableProviders list, ensuring Elevenlabs (and Replicate) don't appear in the provider cards.