### PR TITLE
Fix overflow menu on mobile sidebar

### DIFF
--- a/src/components/sidebar/conversation-actions.tsx
+++ b/src/components/sidebar/conversation-actions.tsx
@@ -82,7 +82,7 @@ export const ConversationActions = ({
   return (
     <>
       {isMobile ? (
-        <div className="flex-shrink-0">
+        <div className="flex-shrink-0 pointer-events-auto">
           <Drawer
             open={isMobilePopoverOpen}
             onOpenChange={onMobilePopoverChange}


### PR DESCRIPTION
The three-dot overflow menu on mobile was closing the sidebar instead of opening the actions drawer. The issue was that the parent container had pointer-events-none, but the mobile drawer trigger wrapper was missing pointer-events-auto to re-enable clicks on the button.