### PR TITLE
Fix image gallery horizontal scrolling issue

### DIFF
--- a/src/components/chat/virtualized-chat-messages.tsx
+++ b/src/components/chat/virtualized-chat-messages.tsx
@@ -597,7 +597,8 @@ export const VirtualizedChatMessages = memo(
             style={{
               height: "100%",
               width: "100%",
-              overflow: "auto",
+              overflowX: "clip",
+              overflowY: "auto",
               contain: "layout style size",
               paddingTop: resolvedTopInset,
               paddingBottom: resolvedBottomInset,


### PR DESCRIPTION
Use overflow-x: clip instead of overflow: auto on VList scroll container to clip horizontal overflow from gallery images while maintaining vertical scrolling. This prevents the 100vw gallery width from causing horizontal scrollbar on platforms with visible scrollbars.