### PR TITLE
Enable keyboard navigation in attachment carousel

### DIFF
--- a/src/components/ui/attachment-gallery-dialog.tsx
+++ b/src/components/ui/attachment-gallery-dialog.tsx
@@ -148,8 +148,9 @@ export const AttachmentGalleryDialog = ({
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () =>
+      document.removeEventListener("keydown", handleKeyDown, { capture: true });
   }, [
     open,
     goToPrevious,


### PR DESCRIPTION
Ensures left/right arrow key navigation works reliably by using the capture phase, which runs before any element handlers can stop event propagation.