### PR TITLE
feat: Enable sticky comment reviews in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,3 +43,6 @@ jobs:
 
           # For label-triggered reviews, provide a focused review prompt
           prompt: ${{ github.event_name == 'pull_request' && 'Review this PR. Flag bugs, security issues, and correctness problems. Skip style nits (Biome handles that). Be concise.' || '' }}
+
+          # Post reviews as PR comments instead of only in Actions summary
+          use_sticky_comment: true


### PR DESCRIPTION
## Summary

- Enable `use_sticky_comment: true` in the Claude Code workflow
- This will post code reviews as PR comments instead of only in Actions summary
- Makes reviews more visible and easier to interact with

## Changes

**`.github/workflows/claude.yml`:**
- Added `use_sticky_comment: true` configuration option (line 48)
- Reviews triggered by `claude-review` label or `@claude` mentions will now appear as PR comments

## Testing

This PR has the `claude-review` label attached, so Claude will review it and post the results as a comment on this PR itself - demonstrating the new functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)