### PR TITLE
fix: Improve mobile image upload reliability

### DIFF
--- a/convex/ai/message_converter.test.ts
+++ b/convex/ai/message_converter.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { makeConvexCtx } from "../../test/convex-ctx";
 import type { Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
@@ -7,9 +7,20 @@ import {
   convertLegacyPartToAISDK,
   convertStoredMessageToAISDK,
   convertStoredMessagesToAISDK,
+  resetRetryConfig,
+  setRetryConfig,
   type ConversionOptions,
   type StoredAttachment,
 } from "./message_converter";
+
+// Disable retry delays for all tests to avoid timeouts
+beforeEach(() => {
+  setRetryConfig({ maxRetries: 0, baseDelayMs: 0 });
+});
+
+afterEach(() => {
+  resetRetryConfig();
+});
 
 // Default conversion options
 const defaultOptions: ConversionOptions = {

--- a/convex/ai/message_converter.ts
+++ b/convex/ai/message_converter.ts
@@ -243,7 +243,7 @@ export async function convertStoredMessagesToAISDK(
  * Fetch storage with retry logic to handle eventual consistency
  * Retries with exponential backoff using retryConfig settings
  */
-async function fetchStorageWithRetry(
+export async function fetchStorageWithRetry(
   ctx: ActionCtx,
   storageId: Id<"_storage">
 ): Promise<Blob> {

--- a/convex/ai/pdf.ts
+++ b/convex/ai/pdf.ts
@@ -6,6 +6,7 @@ import type { ActionCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import { action } from "../_generated/server";
 import { v } from "convex/values";
+import { fetchStorageWithRetry } from "./message_converter";
 
 
 // ==================== Capability Detection ====================
@@ -69,11 +70,7 @@ export async function getStoredPdfText(
   textFileId: Id<"_storage">
 ): Promise<string | null> {
   try {
-    const textBlob = await ctx.storage.get(textFileId);
-    if (!textBlob) {
-      return null;
-    }
-
+    const textBlob = await fetchStorageWithRetry(ctx, textFileId);
     return await textBlob.text();
   } catch (error) {
     console.error("Failed to retrieve stored text:", error);

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -256,8 +256,15 @@ export async function createHandler(
   const estimateTokens = (text: string) =>
     Math.max(1, Math.ceil((text || "").length / 4));
 
+  // Strip large fields from attachments before storing in database
+  // thumbnail: Base64 preview (can be >1MB on iOS), regenerate from storageId when needed
+  // content: Text file content, fetch from storageId when needed
+  // These fields are only needed for UI during upload, not for storage
+  const attachmentsForStorage = args.attachments?.map(({ thumbnail, content, ...attachment }) => attachment);
+
   const messageId = await ctx.db.insert("messages", {
     ...args,
+    attachments: attachmentsForStorage,
     userId,
     isMainBranch: args.isMainBranch ?? true,
     createdAt: Date.now(),

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -260,7 +260,9 @@ export async function createHandler(
   // thumbnail: Base64 preview (can be >1MB on iOS), regenerate from storageId when needed
   // content: Text file content, fetch from storageId when needed
   // These fields are only needed for UI during upload, not for storage
-  const attachmentsForStorage = args.attachments?.map(({ thumbnail, content, ...attachment }) => attachment);
+  const attachmentsForStorage = args.attachments?.map(
+    ({ thumbnail, content, ...attachment }) => attachment
+  );
 
   const messageId = await ctx.db.insert("messages", {
     ...args,


### PR DESCRIPTION
## Summary
- Add exponential backoff retry logic (5 attempts, 500ms→4s delays) for Convex storage operations to handle eventual consistency delays during mobile uploads
- Strip `thumbnail` and `content` fields from attachments before database storage to prevent bloated records (iOS base64 thumbnails can exceed 1MB)

## Test plan
- [ ] Upload image on iOS device and verify it processes correctly
- [ ] Upload image on Android device and verify it processes correctly
- [ ] Verify existing desktop upload flow still works
- [ ] Check that attachments in DB no longer contain large thumbnail/content fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)