### PR TITLE
fix: Prevent duplicate assistant responses on new conversation setup

### DIFF
--- a/src/pages/chat-conversation-page.tsx
+++ b/src/pages/chat-conversation-page.tsx
@@ -257,6 +257,12 @@ export default function ConversationRoute() {
     if (!messages || messages.length === 0) {
       return;
     }
+    // Don't auto-retry during the transition from optimistic to real messages.
+    // This prevents a race condition where the query returns with only the user message
+    // before the startConversation action has created the assistant message.
+    if (hasTransitionedRef.current) {
+      return;
+    }
     if (initialLoadHandledRef.current === resolvedId) {
       return;
     }


### PR DESCRIPTION
## Summary
- Fix race condition causing duplicate assistant responses when starting new conversations
- Add guard to skip auto-retry during optimistic-to-real message transition
- Prevents scenario where query returns user message before assistant message is created

## Test plan
- [ ] Start a new conversation from home page
- [ ] Verify only one assistant response appears
- [ ] Test rapid message sending to verify no duplicate responses
- [ ] Verify auto-retry still works for genuinely incomplete conversations (e.g., returning to a conversation with unanswered user message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)