### PR TITLE
chore: Update convex to 1.31.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "convex": "^1.31.3",
+        "convex": "^1.31.7",
         "date-fns": "^4.1.0",
         "dedent": "^1.7.1",
         "embla-carousel-react": "^8.6.0",
@@ -645,7 +645,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "convex": ["convex@1.31.3", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-SkpLjhFFnml2xKB4vNOaZ+MtqyhVmDdk5AIF2m8rW8Z7nZsMtuO1Tpn2BnDHCysZkZPJj9xopnsF5RtAINQ0Eg=="],
+    "convex": ["convex@1.31.7", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-PtNMe1mAIOvA8Yz100QTOaIdgt2rIuWqencVXrb4McdhxBHZ8IJ1eXTnrgCC9HydyilGT1pOn+KNqT14mqn9fQ=="],
 
     "convex-test": ["convex-test@0.0.41", "", { "peerDependencies": { "convex": "^1.16.4" } }, "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "convex": "^1.31.3",
+    "convex": "^1.31.7",
     "date-fns": "^4.1.0",
     "dedent": "^1.7.1",
     "embla-carousel-react": "^8.6.0",


### PR DESCRIPTION
## Summary
- Updates Convex from 1.31.3 to 1.31.7

## Notable changes in this update
- **New size functions**: `getConvexSize` and `getDocumentSize` for calculating value sizes in bytes
- **Performance**: Code push only uploads changed modules, faster `convex dev` and `convex deploy`
- **React Native fix**: Fixed "window.addEventListener is not a function"
- **Better reconnection**: Improved behavior after going offline
- **Breaking**: Node.js 18 support dropped (we already require Node.js 20+)

## Test plan
- [x] `bun run check` passes (lint + types + build)
- [x] `bun run test` passes (1285 tests)
- [ ] Manual: AI streaming works correctly
- [ ] Manual: File uploads/storage operations work
- [ ] Manual: Auth flow works

🤖 Generated with [Claude Code](https://claude.ai/code)