### PR TITLE
fix: Prevent duplicate assistant responses on new conversation setup

### DIFF
--- a/src/pages/chat-conversation-page.tsx
+++ b/src/pages/chat-conversation-page.tsx
@@ -140,8 +140,17 @@ export default function ConversationRoute() {
     initialMessageRef.current = null;
   }
 
-  // Clear transition flag once streaming is complete
-  if (hasTransitionedRef.current && !messageIsStreaming) {
+  // Clear transition flag once the initial assistant message exists and streaming is complete.
+  // We must wait for the assistant message before clearing — otherwise, in the intermediate
+  // state where only the user message has arrived (assistant not yet created by startConversation),
+  // the flag clears immediately (messageIsStreaming is false) and auto-retry fires, creating
+  // a duplicate assistant response.
+  const hasAssistantMessage = realMessages.some(m => m.role === "assistant");
+  if (
+    hasTransitionedRef.current &&
+    !messageIsStreaming &&
+    hasAssistantMessage
+  ) {
     hasTransitionedRef.current = false;
   }
 


### PR DESCRIPTION
## Summary
- Fix race condition where auto-retry creates a duplicate assistant response during new conversation setup
- The previous guard (`hasTransitionedRef`) cleared too early — in the intermediate state where only the user message has arrived but the assistant message hasn't been created yet, `messageIsStreaming` is `false`, so the flag was immediately cleared and auto-retry could still fire
- Now the transition flag stays active until the assistant message actually exists and streaming completes

## Test plan
- [ ] Create a new conversation and verify only one assistant response appears
- [ ] Verify existing conversations still work normally
- [ ] Verify auto-retry still works for conversations where the last message is from the user with no pending assistant response