### PR TITLE
fix: Remove redundant inner toggle for single reasoning blocks

### DIFF
--- a/src/components/chat/activity-stream.tsx
+++ b/src/components/chat/activity-stream.tsx
@@ -114,6 +114,10 @@ export function ActivityStream({
     thinkingDurationMs
   );
 
+  // When there's only one reasoning segment and no tool calls, the outer
+  // ActivityStream toggle already shows "Thought for Xs" — skip the inner one.
+  const isSoloReasoning = reasoningCount === 1 && toolCallCount === 0;
+
   const streamContent = (
     <div className="stack-sm">
       {items.map((item, i) => {
@@ -124,6 +128,7 @@ export function ActivityStream({
               key={`reasoning-${item.index}`}
               text={item.part.text}
               isActive={isActive && isLast}
+              bare={isSoloReasoning}
               thinkingDurationMs={
                 !isActive && isLast ? thinkingDurationMs : undefined
               }

--- a/src/components/chat/reasoning-segment.tsx
+++ b/src/components/chat/reasoning-segment.tsx
@@ -8,6 +8,8 @@ const ICON_SIZE = "h-4 w-4";
 type ReasoningSegmentProps = {
   text: string;
   isActive: boolean;
+  /** Render content only, no toggle — used when a parent already provides one. */
+  bare?: boolean;
   thinkingDurationMs?: number;
 };
 
@@ -21,6 +23,7 @@ type ReasoningSegmentProps = {
 export function ReasoningSegment({
   text,
   isActive,
+  bare = false,
   thinkingDurationMs,
 }: ReasoningSegmentProps) {
   const [expanded, setExpanded] = useState(false);
@@ -71,6 +74,31 @@ export function ReasoningSegment({
 
   const isOpen = expanded || isActive;
 
+  const reasoningContent = (
+    <div className="relative max-w-[74ch]">
+      <div className="py-1 text-[13px] leading-relaxed text-muted-foreground">
+        <Markdown
+          options={{
+            forceBlock: true,
+            overrides: markdownOverrides,
+          }}
+        >
+          {text}
+        </Markdown>
+      </div>
+
+      {/* Bottom gradient fade — hints at more content */}
+      {!isActive && text.length > 600 && !expanded && !bare && (
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-muted/80 to-transparent" />
+      )}
+    </div>
+  );
+
+  // Bare mode: content only, no toggle — parent provides the chrome
+  if (bare) {
+    return reasoningContent;
+  }
+
   return (
     <div>
       {/* Trigger */}
@@ -108,23 +136,8 @@ export function ReasoningSegment({
         style={{ gridTemplateRows: isOpen ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden">
-          <div className="relative mt-1 ml-1.5 border-l-2 border-muted-foreground/15 pl-4 max-w-[74ch]">
-            {/* Content */}
-            <div className="py-1 text-[13px] leading-relaxed text-muted-foreground">
-              <Markdown
-                options={{
-                  forceBlock: true,
-                  overrides: markdownOverrides,
-                }}
-              >
-                {text}
-              </Markdown>
-            </div>
-
-            {/* Bottom gradient fade — hints at more content */}
-            {!isActive && text.length > 600 && !expanded && (
-              <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-muted/80 to-transparent" />
-            )}
+          <div className="mt-1 ml-1.5 border-l-2 border-muted-foreground/15 pl-4">
+            {reasoningContent}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- When a message has only one reasoning segment and no tool calls, the inner `ReasoningSegment` toggle ("Thought for Xs") was duplicating the outer `ActivityStream` toggle
- Added a `bare` prop to `ReasoningSegment` that renders just the markdown content without its own toggle/expand chrome
- `ActivityStream` passes `bare` when it detects a solo reasoning item, so the outer card/toggle remains the single point of interaction

## Test plan
- [ ] Send a message to a thinking model (e.g. Claude with extended thinking) that produces only reasoning and no tool calls — should show a single "Thought for Xs" toggle, not a nested one
- [ ] Send a message that produces reasoning interleaved with tool calls — each reasoning segment should still have its own inner toggle
- [ ] Verify expand/collapse works correctly in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)