### PR TITLE
Redesign file selector with list layout and inline preview

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -32,6 +32,7 @@ export {
   cleanAttachmentsForConvex,
   cn,
   formatDate,
+  formatFileSize,
   generateHeadingId,
   resizeGoogleImageUrl,
   stripCitations,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -86,7 +86,7 @@ export function stripCitations(text: string): string {
  * This ensures compatibility with the Convex attachment schema
  */
 export function formatFileSize(bytes: number): string {
-  if (bytes === 0) {
+  if (bytes <= 0) {
     return "0 B";
   }
   const units = ["B", "KB", "MB", "GB"];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -85,6 +85,19 @@ export function stripCitations(text: string): string {
  * Cleans attachments for Convex by removing client-side fields not in the schema
  * This ensures compatibility with the Convex attachment schema
  */
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1
+  );
+  const value = bytes / 1024 ** i;
+  return `${value < 10 && i > 0 ? value.toFixed(1) : Math.round(value)} ${units[i]}`;
+}
+
 export function cleanAttachmentsForConvex(attachments?: Attachment[]) {
   if (!attachments) {
     return undefined;


### PR DESCRIPTION
## Summary
- Replace grid card layout with a unified list row design — checkbox, thumbnail, name, metadata (conversation, date, size)
- Desktop: 60/40 split layout with inline preview panel (image, video, audio, PDF, text)
- Mobile: plain scrollable list with IntersectionObserver for load-more (replaces Virtuoso on mobile)
- Add search input with debounced query filtering
- Replace dropdown Select with chip-style type filter buttons
- Add `formatFileSize` utility and export from `@/lib`
- Remove unused components: `FileCard`, `VirtuosoGrid` infrastructure, `AttachmentGalleryDialog` dependency

## Test plan
- [ ] Desktop: open file selector — list on left, preview panel on right
- [ ] Click a file row — preview appears in right panel
- [ ] Click checkbox — toggles selection without changing preview
- [ ] Search files — results filter with debounce
- [ ] Type filter chips — filter by image/PDF/text/audio/video
- [ ] Mobile: open file selector — full-width list, no preview panel
- [ ] Scroll to bottom — loads more files
- [ ] Select files and confirm — attachments added correctly
- [ ] File metadata shows conversation name, date, and size

🤖 Generated with [Claude Code](https://claude.com/claude-code)