### PR TITLE
refactor: Rebuild Select component

### DIFF
--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -50,8 +50,6 @@ export {
   SelectGroup,
   SelectItem,
   SelectLabel,
-  SelectScrollDownButton,
-  SelectScrollUpButton,
   SelectSeparator,
   SelectTrigger,
   SelectValue,


### PR DESCRIPTION
## Summary
- Rebuild Select from scratch following Base UI's reference implementation
- Add `TriggerWidthContext` so popup `minWidth` matches trigger width (needed because `alignItemWithTrigger` disables `--anchor-width` CSS var)
- Use `Select.List` wrapper with `max-h-[var(--available-height)]` for proper scroll containment
- Inset highlight pseudo-elements (`before:bg-muted` with `before:inset-x-1`) instead of flat background
- Grid-based items with `CheckIcon` indicator from Phosphor
- Open/close transitions via `data-[starting-style]`/`data-[ending-style]`, suppressed in overlay mode (`data-[side=none]`)
- Remove `SelectScrollUpButton`/`SelectScrollDownButton` exports (inlined into `SelectContent`)

## Test plan
- [x] `bun run check` passes (lint + types + build)
- [x] `bun test src/components/ui/select.test.tsx` — 8/8 tests pass
- [ ] Visual: settings page auto-archive dropdown — width matches trigger, selected item alignment works
- [ ] Visual: VoiceSelect multi-line items render correctly with `min-h-8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)