### PR TITLE
fix: Centralize conversation archive with proper redirect handling

### DIFF
--- a/src/components/chat/chat-header.tsx
+++ b/src/components/chat/chat-header.tsx
@@ -51,6 +51,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useArchiveConversation } from "@/hooks/use-archive-conversation";
 import { useOnline } from "@/hooks/use-online";
 import {
   downloadFile,
@@ -234,6 +235,9 @@ const ChatHeaderComponent = ({
 
   const patchConversation = useMutation(api.conversations.patch);
   const deleteConversation = useMutation(api.conversations.remove);
+  const { archiveConversation: performArchive } = useArchiveConversation({
+    currentConversationId: conversationId,
+  });
 
   const handleExport = (format: "json" | "md") => {
     // Handle private chat export
@@ -754,16 +758,7 @@ const ChatHeaderComponent = ({
           confirmText="Archive"
           onConfirm={async () => {
             try {
-              // Navigate away first if archiving the current conversation view
-              navigate(ROUTES.HOME);
-              await new Promise(resolve => setTimeout(resolve, 100));
-
-              await patchConversation({
-                id: conversationId as Id<"conversations">,
-                updates: { isArchived: true },
-              });
-
-              del(CACHE_KEYS.conversations);
+              await performArchive(conversationId as ConversationId);
               managedToast.success("Conversation archived", {
                 description: "The conversation has been moved to archive.",
                 id: `archive-${conversationId}`,

--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -329,17 +329,21 @@ export function CommandPalette({
     }
 
     try {
+      const isArchiving = !conversation.conversation.isArchived;
+
+      // Compare resolved IDs to determine if we're archiving the current conversation
+      const currentResolvedId = currentConversation?.resolvedId;
+      if (isArchiving && conversationId === currentResolvedId) {
+        navigate("/");
+        await new Promise<void>(resolve => {
+          setTimeout(resolve, 0);
+        });
+      }
+
       await patchConversation({
         id: conversationId as Id<"conversations">,
-        updates: { isArchived: !conversation.conversation.isArchived },
+        updates: { isArchived: isArchiving },
       });
-
-      if (
-        !conversation.conversation.isArchived &&
-        conversationId === currentConversationId
-      ) {
-        navigate("/");
-      }
 
       if (navigation.currentMenu === "conversation-actions") {
         navigateBack();
@@ -353,7 +357,7 @@ export function CommandPalette({
     actionConversationId,
     resolvedActionContext,
     navigation.currentMenu,
-    currentConversationId,
+    currentConversation?.resolvedId,
     patchConversation,
     navigate,
     navigateBack,

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -486,7 +486,7 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
 
               <div>
                 {isSelectionMode || hasSelection ? (
-                  <BatchActions />
+                  <BatchActions currentConversationId={currentConversationId} />
                 ) : (
                   <SidebarSearch
                     searchQuery={searchQuery}

--- a/src/components/navigation/sidebar/batch-actions.tsx
+++ b/src/components/navigation/sidebar/batch-actions.tsx
@@ -14,11 +14,18 @@ import {
 } from "@/components/ui/tooltip";
 import { useBulkActions } from "@/hooks/use-bulk-actions";
 import { useBatchSelection } from "@/providers/batch-selection-context";
+import type { ConversationId } from "@/types";
 
-export const BatchActions = () => {
+type BatchActionsProps = {
+  currentConversationId?: ConversationId;
+};
+
+export const BatchActions = ({ currentConversationId }: BatchActionsProps) => {
   const { isSelectionMode, hasSelection, selectionCount, clearSelection } =
     useBatchSelection();
-  const { performBulkAction, confirmationDialog } = useBulkActions();
+  const { performBulkAction, confirmationDialog } = useBulkActions({
+    currentConversationId,
+  });
 
   const shouldShow = isSelectionMode || hasSelection;
   if (!shouldShow) {

--- a/src/components/navigation/sidebar/conversation-actions.tsx
+++ b/src/components/navigation/sidebar/conversation-actions.tsx
@@ -35,7 +35,7 @@ import {
 import { useBulkActions } from "@/hooks/use-bulk-actions";
 import { cn } from "@/lib/utils";
 import { useBatchSelection } from "@/providers/batch-selection-context";
-import type { Conversation } from "@/types";
+import type { Conversation, ConversationId } from "@/types";
 
 type ConversationActionsProps = {
   conversation: Conversation;
@@ -215,6 +215,7 @@ export const ConversationActions = memo(
 export const ConversationContextMenu = memo(
   ({
     conversation,
+    currentConversationId,
     exportingFormat,
     isDeleteJobInProgress,
     onPinToggle,
@@ -225,6 +226,7 @@ export const ConversationContextMenu = memo(
     onDelete,
   }: {
     conversation: Conversation;
+    currentConversationId?: ConversationId;
     exportingFormat: "json" | "md" | null;
     isDeleteJobInProgress: boolean;
     onPinToggle: () => void;
@@ -236,7 +238,7 @@ export const ConversationContextMenu = memo(
   }) => {
     const { hasSelection, selectionCount, isSelected, selectConversation } =
       useBatchSelection();
-    const { performBulkAction } = useBulkActions();
+    const { performBulkAction } = useBulkActions({ currentConversationId });
     const isCurrentSelected = isSelected(conversation._id);
     const showBatchActions = hasSelection && selectionCount > 1;
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -70,6 +70,7 @@ export { useSelectedModel } from "./use-selected-model";
 // Conversation Hooks
 // =============================================================================
 
+export { useArchiveConversation } from "./use-archive-conversation";
 export { usePaginatedConversations } from "./use-paginated-conversations";
 
 // =============================================================================

--- a/src/hooks/use-archive-conversation.ts
+++ b/src/hooks/use-archive-conversation.ts
@@ -1,0 +1,46 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useMutation } from "convex/react";
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { CACHE_KEYS, del } from "@/lib/local-storage";
+import { ROUTES } from "@/lib/routes";
+import type { ConversationId } from "@/types";
+
+type UseArchiveConversationOptions = {
+  currentConversationId?: ConversationId;
+};
+
+/**
+ * Centralized hook for archiving conversations with proper redirect handling.
+ *
+ * Coordinates: navigate away if needed → archive → invalidate cache.
+ * Does NOT include toasts — callers handle their own UX.
+ */
+export function useArchiveConversation(
+  options?: UseArchiveConversationOptions
+) {
+  const navigate = useNavigate();
+  const patchConversation = useMutation(api.conversations.patch);
+
+  const archiveConversation = useCallback(
+    async (id: ConversationId) => {
+      const currentId = options?.currentConversationId;
+      if (currentId && (currentId as string) === (id as string)) {
+        navigate(ROUTES.HOME);
+        await new Promise<void>(resolve => {
+          setTimeout(resolve, 0);
+        });
+      }
+
+      await patchConversation({
+        id: id as Id<"conversations">,
+        updates: { isArchived: true },
+      });
+      del(CACHE_KEYS.conversations);
+    },
+    [options?.currentConversationId, navigate, patchConversation]
+  );
+
+  return { archiveConversation };
+}


### PR DESCRIPTION
  - src/hooks/use-archive-conversation.ts — new centralized hook
  - src/hooks/index.ts — barrel export
  - src/components/navigation/sidebar/conversation-item.tsx — use hook, remove setTimeout hack
  - src/components/chat/chat-header.tsx — use hook, remove setTimeout hack
  - src/components/navigation/command-palette.tsx — fix broken ID comparison, add redirect
  - src/hooks/use-bulk-actions.ts — redirect before bulk archive when current conversation is in batch
  - src/components/navigation/sidebar/batch-actions.tsx — pass currentConversationId prop
  - src/components/navigation/sidebar/conversation-actions.tsx — pass through to useBulkActions
  - src/components/navigation/sidebar.tsx — pass currentConversationId to <BatchActions>