### PR TITLE
fix: Move theme init to external script to comply with CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,48 +77,7 @@
         transition-delay: 0s !important;
       }
     </style>
-    <script>
-      // Apply theme immediately to prevent flash — runs before external CSS
-      (() => {
-        document.documentElement.classList.add("disable-animations");
-
-        const themeKey = "polly:theme/v1";
-        const storedTheme = localStorage.getItem(themeKey);
-        let resolvedTheme = "system";
-
-        if (storedTheme) {
-          try {
-            const parsed = JSON.parse(storedTheme);
-            if (
-              parsed &&
-              typeof parsed === "object" &&
-              "version" in parsed &&
-              "data" in parsed
-            ) {
-              resolvedTheme = parsed.data;
-            }
-          } catch (e) {
-            resolvedTheme = "system";
-          }
-        }
-
-        let actualTheme;
-        if (resolvedTheme === "light" || resolvedTheme === "dark") {
-          actualTheme = resolvedTheme;
-        } else {
-          const prefersDark = window.matchMedia(
-            "(prefers-color-scheme: dark)",
-          ).matches;
-          actualTheme = prefersDark ? "dark" : "light";
-        }
-
-        document.documentElement.classList.add(actualTheme);
-
-        setTimeout(() => {
-          document.documentElement.classList.remove("disable-animations");
-        }, 100);
-      })();
-    </script>
+    <script src="/theme-init.js"></script>
     <link rel="stylesheet" href="/src/globals.css" />
   </head>
   <body>

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,42 @@
+// Apply theme immediately to prevent flash of wrong theme.
+// This file MUST be loaded as a blocking <script> (not type="module")
+// before any stylesheet, so the correct class is on <html> before first paint.
+(() => {
+  document.documentElement.classList.add("disable-animations");
+
+  const themeKey = "polly:theme/v1";
+  const storedTheme = localStorage.getItem(themeKey);
+  let resolvedTheme = "system";
+
+  if (storedTheme) {
+    try {
+      const parsed = JSON.parse(storedTheme);
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        "version" in parsed &&
+        "data" in parsed
+      ) {
+        resolvedTheme = parsed.data;
+      }
+    } catch (e) {
+      resolvedTheme = "system";
+    }
+  }
+
+  let actualTheme;
+  if (resolvedTheme === "light" || resolvedTheme === "dark") {
+    actualTheme = resolvedTheme;
+  } else {
+    const prefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)"
+    ).matches;
+    actualTheme = prefersDark ? "dark" : "light";
+  }
+
+  document.documentElement.classList.add(actualTheme);
+
+  setTimeout(() => {
+    document.documentElement.classList.remove("disable-animations");
+  }, 100);
+})();


### PR DESCRIPTION
## Summary
- The inline `<script>` that detects the user's theme from localStorage and adds the `dark` class to `<html>` was being **silently blocked** by the Content-Security-Policy header (`script-src 'self'` does not permit inline scripts)
- The inline `<style>` for critical theme CSS was unaffected (`style-src` includes `'unsafe-inline'`), but without the script running, the `dark` class was never applied before first paint
- Moved the theme detection logic to an external file (`public/theme-init.js`) which is allowed under the `'self'` CSP policy

## Test plan
- [ ] Deploy to preview and verify no light-mode flash on initial load with dark theme set
- [ ] Verify theme detection works for all three modes: explicit dark, explicit light, and system preference
- [ ] Check browser console for CSP violations (there should be none)
- [ ] Verify `theme-init.js` is present in the build output (`dist/theme-init.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)