### PR TITLE
feat: Undo for destructive actions

### DIFF
--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -356,6 +356,7 @@ export function CommandPalette({
         managedToast.success("Conversation archived", {
           id: `archive-${conversationId}`,
           duration: 5000,
+          isUndo: true,
           action: {
             label: "Undo",
             onClick: () => {
@@ -423,6 +424,7 @@ export function CommandPalette({
       managedToast.success("Conversation deleted", {
         id: `delete-${conversationId}`,
         duration: 5000,
+        isUndo: true,
         action: {
           label: "Undo",
           onClick: () => {

--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -366,10 +366,7 @@ export function CommandPalette({
         });
       } else {
         // Unarchiving (from conversation browser)
-        await patchConversation({
-          id: conversationId as Id<"conversations">,
-          updates: { isArchived: false },
-        });
+        await unarchiveConversation(conversationId as ConversationId);
       }
 
       if (navigation.currentMenu === "conversation-actions") {
@@ -386,7 +383,6 @@ export function CommandPalette({
     navigation.currentMenu,
     performArchive,
     unarchiveConversation,
-    patchConversation,
     managedToast,
     navigateBack,
     handleClose,
@@ -432,9 +428,15 @@ export function CommandPalette({
             unarchiveConversation(conversationId as ConversationId);
           },
         },
-        onAutoClose: () => {
+        onAutoClose: async () => {
           if (!undone) {
-            performDelete(conversationId as ConversationId);
+            try {
+              await performDelete(conversationId as ConversationId);
+            } catch {
+              managedToast.error("Failed to delete conversation", {
+                id: `delete-error-${conversationId}`,
+              });
+            }
           }
         },
       });

--- a/src/components/navigation/sidebar/conversation-item.tsx
+++ b/src/components/navigation/sidebar/conversation-item.tsx
@@ -192,6 +192,7 @@ const ConversationItemComponent = ({
       managedToast.success("Conversation archived", {
         id: `archive-${conversation._id}`,
         duration: 5000,
+        isUndo: true,
         action: {
           label: "Undo",
           onClick: () => {
@@ -229,6 +230,7 @@ const ConversationItemComponent = ({
           managedToast.success("Conversation deleted", {
             id: `delete-${conversation._id}`,
             duration: 5000,
+            isUndo: true,
             action: {
               label: "Undo",
               onClick: () => {

--- a/src/components/navigation/sidebar/conversation-item.tsx
+++ b/src/components/navigation/sidebar/conversation-item.tsx
@@ -238,9 +238,15 @@ const ConversationItemComponent = ({
                 unarchiveConversation(conversation._id);
               },
             },
-            onAutoClose: () => {
+            onAutoClose: async () => {
               if (!undone) {
-                performDelete(conversation._id);
+                try {
+                  await performDelete(conversation._id);
+                } catch {
+                  managedToast.error("Failed to delete conversation", {
+                    id: `delete-error-${conversation._id}`,
+                  });
+                }
               }
             },
           });

--- a/src/globals.css
+++ b/src/globals.css
@@ -1811,6 +1811,40 @@ pre {
   animation: spin-reverse 1s linear infinite;
 }
 
+/* Toast countdown progress bar for undo actions */
+.toast-countdown {
+  position: relative;
+  overflow: hidden;
+}
+
+.toast-countdown::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: currentColor;
+  opacity: 0.25;
+  animation: toast-countdown var(--toast-duration, 5000ms) linear forwards;
+}
+
+.toast-countdown[data-expanded="true"]::after,
+.toast-countdown:focus-within::after {
+  animation-play-state: paused;
+}
+
+@keyframes toast-countdown {
+  from {
+    transform: scaleX(1);
+    transform-origin: left;
+  }
+  to {
+    transform: scaleX(0);
+    transform-origin: left;
+  }
+}
+
 /* Legacy citation link styles - kept for fallback */
 .citation-link {
   display: inline-flex;

--- a/src/hooks/use-archive-conversation.ts
+++ b/src/hooks/use-archive-conversation.ts
@@ -42,5 +42,16 @@ export function useArchiveConversation(
     [options?.currentConversationId, navigate, patchConversation]
   );
 
-  return { archiveConversation };
+  const unarchiveConversation = useCallback(
+    async (id: ConversationId) => {
+      await patchConversation({
+        id: id as Id<"conversations">,
+        updates: { isArchived: false },
+      });
+      del(CACHE_KEYS.conversations);
+    },
+    [patchConversation]
+  );
+
+  return { archiveConversation, unarchiveConversation };
 }

--- a/src/hooks/use-bulk-actions.ts
+++ b/src/hooks/use-bulk-actions.ts
@@ -228,6 +228,7 @@ export function useBulkActions(options?: {
               `Archived ${successCount} conversation${successCount !== 1 ? "s" : ""}`,
               {
                 id: `bulk-archive-success-${Date.now()}`,
+                isUndo: true,
                 action: {
                   label: "Undo",
                   onClick: async () => {
@@ -241,6 +242,7 @@ export function useBulkActions(options?: {
                         // Best-effort undo
                       }
                     }
+                    del(CACHE_KEYS.conversations);
                   },
                 },
               }

--- a/src/providers/toast-context.tsx
+++ b/src/providers/toast-context.tsx
@@ -64,6 +64,8 @@ export function ToastProvider({ children }: ToastProviderProps) {
     ) => {
       const hasCountdown = !!(options.action && options.duration);
 
+      let toastId: string | number;
+
       const sonnerOptions: Record<string, unknown> = {};
       if (options.description !== undefined) {
         sonnerOptions.description = options.description;
@@ -87,17 +89,19 @@ export function ToastProvider({ children }: ToastProviderProps) {
         sonnerOptions.onAutoClose = options.onAutoClose;
       }
       if (options.isUndo) {
+        // Closure reads toastId lazily at dismiss time (after assignment below)
         sonnerOptions.onDismiss = () => {
+          const resolvedId = options.id ?? toastId;
           if (
             lastUndoRef.current &&
-            lastUndoRef.current.toastId === (options.id ?? toastId)
+            lastUndoRef.current.toastId === resolvedId
           ) {
             lastUndoRef.current = null;
           }
         };
       }
 
-      const toastId = toast.success(message, sonnerOptions);
+      toastId = toast.success(message, sonnerOptions);
 
       // Only track as undoable via Cmd+Z when explicitly marked as undo
       if (options.isUndo && options.action) {


### PR DESCRIPTION
## Summary
- **Archive**: Removes confirmation dialog, archives immediately, shows undo toast with 5s countdown progress bar
- **Delete**: Keeps confirmation dialog, then soft-deletes via archive + undo toast (5s grace period), hard deletes on expiry
- **Bulk archive**: Adds undo button to success toast that restores all archived conversations
- **Cmd/Ctrl+Z**: Global keyboard shortcut triggers the most recent undo action (skips when focus is in text inputs)
- **Countdown animation**: 2px progress bar at bottom of undo toasts, pauses on hover/focus in sync with Sonner's timer

## Test plan
- [ ] Archive from sidebar context menu: no dialog, toast with Undo + progress bar, clicking Undo restores
- [ ] Archive from command palette: same behavior
- [ ] Delete from sidebar: confirm dialog, then toast with Undo for 5s, Undo restores, letting it expire hard deletes
- [ ] Delete from command palette: same behavior
- [ ] Bulk archive: after confirm, success toast has Undo that restores all
- [ ] Cmd+Z while undo toast is visible: triggers undo and dismisses toast
- [ ] Cmd+Z in a text input: does NOT trigger undo (browser native undo works)
- [ ] Hover over undo toast: progress bar pauses, Sonner timer pauses
- [ ] Archive current conversation: navigates home, Undo restores and conversation reappears in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)