### PR TITLE
fix: Add missing duration to bulk-archive undo toast

### DIFF
--- a/src/hooks/use-bulk-actions.ts
+++ b/src/hooks/use-bulk-actions.ts
@@ -228,6 +228,7 @@ export function useBulkActions(options?: {
               `Archived ${successCount} conversation${successCount !== 1 ? "s" : ""}`,
               {
                 id: `bulk-archive-success-${Date.now()}`,
+                duration: 5000,
                 isUndo: true,
                 action: {
                   label: "Undo",


### PR DESCRIPTION
## Summary
- The bulk-archive success toast had `isUndo: true` and an undo `action` but was missing `duration: 5000`, unlike every other undo toast in the app. This meant the toast could stay open indefinitely and Cmd/Ctrl+Z could keep triggering the undo callback long after the intended window.
- Adds `duration: 5000` to match the existing archive and delete undo toasts.

## Test plan
- [ ] Bulk-archive conversations and verify the undo toast auto-dismisses after 5 seconds
- [ ] Verify Cmd/Ctrl+Z no longer works after the toast dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)