### PR TITLE
feat: Enhance page transition animations

### DIFF
--- a/src/components/layouts/settings-main-layout.tsx
+++ b/src/components/layouts/settings-main-layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 
 import { SettingsContainer } from "@/components/settings/settings-container";
 import { SettingsHeader } from "@/components/settings/settings-header";

--- a/src/components/layouts/settings-main-layout.tsx
+++ b/src/components/layouts/settings-main-layout.tsx
@@ -1,14 +1,18 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 
 import { SettingsContainer } from "@/components/settings/settings-container";
 import { SettingsHeader } from "@/components/settings/settings-header";
 
 export default function SettingsMainLayout() {
+  const location = useLocation();
+
   return (
-    <div className="flex h-[100dvh] flex-col">
+    <div className="flex h-[100dvh] flex-col animate-page-enter">
       <SettingsHeader backLink="/" backText="Back to Chat" />
       <SettingsContainer>
-        <Outlet />
+        <div key={location.pathname} className="animate-page-enter">
+          <Outlet />
+        </div>
       </SettingsContainer>
     </div>
   );

--- a/src/components/layouts/settings-main-layout.tsx
+++ b/src/components/layouts/settings-main-layout.tsx
@@ -7,7 +7,7 @@ export default function SettingsMainLayout() {
   const location = useLocation();
 
   return (
-    <div className="flex h-[100dvh] flex-col animate-page-enter">
+    <div className="flex h-[100dvh] flex-col">
       <SettingsHeader backLink="/" backText="Back to Chat" />
       <SettingsContainer>
         <div key={location.pathname} className="animate-page-enter">

--- a/src/globals.css
+++ b/src/globals.css
@@ -1223,14 +1223,16 @@ pre {
 @keyframes page-enter {
   from {
     opacity: 0;
+    transform: translateY(4px);
   }
   to {
     opacity: 1;
+    transform: translateY(0);
   }
 }
 
 .animate-page-enter {
-  animation: page-enter 0.15s ease-out;
+  animation: page-enter 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* List item entrance - used for staggered list animations */


### PR DESCRIPTION
## Summary
- Enhance page-enter keyframe with subtle slide-up (4px translateY) for more polished feel
- Use cubic-bezier easing (0.16, 1, 0.3, 1) for natural deceleration
- Apply animation consistently to settings layout with per-tab transitions

## Test plan
- [ ] Navigate between / and /chat/:id — should see subtle fade+slide transition
- [ ] Navigate between settings tabs — each tab should animate in
- [ ] Enter settings from chat — settings layout should animate in
- [ ] Test with reduced motion preference — animations suppressed
- [ ] No layout shift or content flash during transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)