### PR TITLE
feat: Improve sidebar resize handle discoverability

### DIFF
--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -48,7 +48,7 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
   const [bottomShadow, setBottomShadow] = useState(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const resizeRef = useRef<HTMLDivElement>(null);
-  const lastDragEndRef = useRef(0);
+  const didDragRef = useRef(false);
   const [isScrollHovered, setIsScrollHovered] = useState(false);
   const {
     isSidebarVisible,
@@ -267,19 +267,23 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
     (e: React.MouseEvent) => {
       e.preventDefault();
       setIsResizing(true);
+      didDragRef.current = false;
 
       const startX = e.clientX;
       const startWidth = sidebarWidth;
+      const dragThreshold = 3;
 
       const handleMouseMove = (e: MouseEvent) => {
         const deltaX = e.clientX - startX;
+        if (Math.abs(deltaX) > dragThreshold) {
+          didDragRef.current = true;
+        }
         const newWidth = startWidth + deltaX;
         setSidebarWidth(newWidth);
       };
 
       const handleMouseUp = () => {
         setIsResizing(false);
-        lastDragEndRef.current = Date.now();
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
       };
@@ -291,8 +295,8 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
   );
 
   const handleDoubleClick = useCallback(() => {
-    // Ignore double-click if a drag just ended (within 300ms)
-    if (Date.now() - lastDragEndRef.current < 300) {
+    // Ignore double-click if the pointer moved during the interaction (actual drag)
+    if (didDragRef.current) {
       return;
     }
     setSidebarVisible(false);

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -48,6 +48,7 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
   const [bottomShadow, setBottomShadow] = useState(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const resizeRef = useRef<HTMLDivElement>(null);
+  const lastDragEndRef = useRef(0);
   const [isScrollHovered, setIsScrollHovered] = useState(false);
   const {
     isSidebarVisible,
@@ -278,6 +279,7 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
 
       const handleMouseUp = () => {
         setIsResizing(false);
+        lastDragEndRef.current = Date.now();
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
       };
@@ -289,6 +291,10 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
   );
 
   const handleDoubleClick = useCallback(() => {
+    // Ignore double-click if a drag just ended (within 300ms)
+    if (Date.now() - lastDragEndRef.current < 300) {
+      return;
+    }
     setSidebarVisible(false);
   }, [setSidebarVisible]);
 
@@ -551,15 +557,15 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
         {!isMobile && isSidebarVisible && (
           <div
             ref={resizeRef}
-            className="absolute -right-1 top-0 bottom-0 w-3 cursor-col-resize z-10 group flex items-center justify-center"
+            className="absolute right-0 top-0 bottom-0 w-3 cursor-col-resize z-10 group flex items-center justify-center"
             data-sidebar-interactive="true"
             onMouseDown={handleResizeStart}
             onDoubleClick={handleDoubleClick}
           >
             {/* Visible line indicator */}
-            <div className="absolute right-[5px] top-0 bottom-0 w-[1px] bg-transparent group-hover:bg-border transition-colors" />
+            <div className="absolute right-0 top-0 bottom-0 w-[1px] bg-transparent group-hover:bg-border transition-colors" />
             {/* Grip dots - visible on hover */}
-            <div className="absolute right-[3px] top-1/2 -translate-y-1/2 flex flex-col gap-[3px] opacity-0 group-hover:opacity-100 transition-opacity">
+            <div className="absolute right-[2px] top-1/2 -translate-y-1/2 flex flex-col gap-[3px] opacity-0 group-hover:opacity-100 transition-opacity">
               <div className="w-[3px] h-[3px] rounded-full bg-muted-foreground/40" />
               <div className="w-[3px] h-[3px] rounded-full bg-muted-foreground/40" />
               <div className="w-[3px] h-[3px] rounded-full bg-muted-foreground/40" />

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -551,12 +551,19 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
         {!isMobile && isSidebarVisible && (
           <div
             ref={resizeRef}
-            className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/10 active:bg-primary/20 transition-colors z-10 group"
+            className="absolute -right-1 top-0 bottom-0 w-3 cursor-col-resize z-10 group flex items-center justify-center"
             data-sidebar-interactive="true"
             onMouseDown={handleResizeStart}
             onDoubleClick={handleDoubleClick}
           >
-            <div className="absolute right-0 top-0 bottom-0 w-[1px] bg-transparent group-hover:bg-border/50 transition-colors" />
+            {/* Visible line indicator */}
+            <div className="absolute right-[5px] top-0 bottom-0 w-[1px] bg-transparent group-hover:bg-border transition-colors" />
+            {/* Grip dots - visible on hover */}
+            <div className="absolute right-[3px] top-1/2 -translate-y-1/2 flex flex-col gap-[3px] opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="w-[3px] h-[3px] rounded-full bg-muted-foreground/40" />
+              <div className="w-[3px] h-[3px] rounded-full bg-muted-foreground/40" />
+              <div className="w-[3px] h-[3px] rounded-full bg-muted-foreground/40" />
+            </div>
           </div>
         )}
       </motion.div>


### PR DESCRIPTION
## Summary
- Widen resize handle hit target from 4px to 12px for easier grabbing
- Add three grip dots that appear on hover as a visual affordance
- Visible border line on hover to indicate the resize boundary
- Double-click to collapse behavior preserved

## Test plan
- [ ] Hover over the sidebar right edge — grip dots and line should appear
- [ ] Drag to resize — should work smoothly with wider hit target
- [ ] Double-click handle to collapse sidebar — still works
- [ ] Grip dots don't overlap sidebar content or main content area
- [ ] Handle only appears on desktop (not mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)