### PR TITLE
feat: Add stagger animations to conversation list and setup checklist

### DIFF
--- a/src/components/chat/chat-zero-state.tsx
+++ b/src/components/chat/chat-zero-state.tsx
@@ -66,7 +66,10 @@ const SetupChecklist = () => {
             Next Steps
           </h3>
           <div className="stack-sm">
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 text-xs text-left">
+            <div
+              className="flex flex-col sm:flex-row sm:items-center gap-2 text-xs text-left animate-list-item-in"
+              style={{ animationDelay: "50ms" }}
+            >
               {hasUserApiKeys ? (
                 <CheckCircleIcon className="size-3 shrink-0 text-success" />
               ) : (
@@ -93,7 +96,10 @@ const SetupChecklist = () => {
                 </Link>
               )}
             </div>
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 text-xs text-left">
+            <div
+              className="flex flex-col sm:flex-row sm:items-center gap-2 text-xs text-left animate-list-item-in"
+              style={{ animationDelay: "100ms" }}
+            >
               {hasUserModels ? (
                 <CheckCircleIcon className="size-3 shrink-0 text-success" />
               ) : (

--- a/src/components/navigation/sidebar/conversation-list-content.tsx
+++ b/src/components/navigation/sidebar/conversation-list-content.tsx
@@ -200,6 +200,9 @@ export const ConversationListContent = ({
     return <div />;
   }
 
+  // Track visible group index for stagger animation offset
+  let visibleGroupIndex = 0;
+
   return (
     <div className="pb-3 pt-3">
       {activeGroups.map(groupKey => {
@@ -208,24 +211,33 @@ export const ConversationListContent = ({
           return null;
         }
 
+        const groupIndex = visibleGroupIndex++;
+
         return (
-          <ConversationGroup
+          <div
             key={groupKey}
-            title={GROUP_LABELS[groupKey]}
-            count={groupConversations.length}
-            collapsible={groupKey !== "pinned"}
+            className="animate-list-item-in"
+            style={{
+              animationDelay: `${groupIndex * 50}ms`,
+            }}
           >
-            {groupConversations.map(conversation => (
-              <ConversationItem
-                key={conversation._id}
-                conversation={conversation}
-                currentConversationId={currentConversationId}
-                allVisibleIds={allVisibleIds}
-                isMobile={isMobile}
-                onCloseSidebar={onCloseSidebar}
-              />
-            ))}
-          </ConversationGroup>
+            <ConversationGroup
+              title={GROUP_LABELS[groupKey]}
+              count={groupConversations.length}
+              collapsible={groupKey !== "pinned"}
+            >
+              {groupConversations.map(conversation => (
+                <ConversationItem
+                  key={conversation._id}
+                  conversation={conversation}
+                  currentConversationId={currentConversationId}
+                  allVisibleIds={allVisibleIds}
+                  isMobile={isMobile}
+                  onCloseSidebar={onCloseSidebar}
+                />
+              ))}
+            </ConversationGroup>
+          </div>
         );
       })}
     </div>


### PR DESCRIPTION
## Summary
- Stagger conversation group sections in sidebar with 50ms delay between groups
- Stagger setup checklist items in zero state with 50ms/100ms delays
- Uses existing `animate-list-item-in` keyframe (subtle 4px slide-up + fade)
- Respects reduced motion preferences (already handled in globals.css)

## Test plan
- [ ] Open app with sidebar visible — conversation groups cascade in sequentially
- [ ] Visit home page as new user — setup checklist items stagger in
- [ ] Verify stagger doesn't feel slow (total cascade < 300ms)
- [ ] Test with reduced motion preference — no animations
- [ ] Expanding/collapsing groups still staggers items (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)