### PR TITLE
feat: Migrate Checkbox, Collapsible, Progress, Separator to Base UI

### DIFF
--- a/src/components/data-list/select-all-checkbox.tsx
+++ b/src/components/data-list/select-all-checkbox.tsx
@@ -1,8 +1,9 @@
-import { CheckIcon } from "@phosphor-icons/react";
+import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 
 interface SelectAllCheckboxProps {
   checked: boolean;
+  indeterminate?: boolean;
   onToggle: () => void;
   className?: string;
   disabled?: boolean;
@@ -10,33 +11,24 @@ interface SelectAllCheckboxProps {
 
 export function SelectAllCheckbox({
   checked,
+  indeterminate,
   onToggle,
   className,
   disabled,
 }: SelectAllCheckboxProps) {
   return (
-    <div className={cn(className)}>
-      {/* biome-ignore lint/a11y/useSemanticElements: matches shadcn/ui custom checkbox pattern */}
-      <button
-        onClick={e => {
-          e.stopPropagation();
-          if (!disabled) {
-            onToggle();
-          }
-        }}
-        className={cn(
-          "flex h-4 w-4 items-center justify-center rounded border",
-          disabled && "opacity-50 cursor-not-allowed"
-        )}
-        type="button"
-        role="checkbox"
-        aria-checked={checked}
+    <div
+      className={cn(className)}
+      onClick={e => e.stopPropagation()}
+      onKeyDown={e => e.stopPropagation()}
+    >
+      <Checkbox
+        checked={checked}
+        indeterminate={indeterminate}
+        onCheckedChange={() => onToggle()}
         aria-label={checked ? "Deselect all" : "Select all"}
-        aria-disabled={disabled}
         disabled={disabled}
-      >
-        {checked && <CheckIcon className="size-3" />}
-      </button>
+      />
     </div>
   );
 }

--- a/src/components/data-list/selection-checkbox.tsx
+++ b/src/components/data-list/selection-checkbox.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon } from "@phosphor-icons/react";
+import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 
 interface SelectionCheckboxProps {
@@ -15,21 +15,16 @@ export function SelectionCheckbox({
   className,
 }: SelectionCheckboxProps) {
   return (
-    <div className={cn(className)}>
-      {/* biome-ignore lint/a11y/useSemanticElements: Custom shadcn/ui checkbox pattern */}
-      <button
-        onClick={e => {
-          e.stopPropagation();
-          onToggle();
-        }}
-        className="flex h-4 w-4 items-center justify-center rounded border"
-        type="button"
-        role="checkbox"
-        aria-checked={checked}
+    <div
+      className={cn(className)}
+      onClick={e => e.stopPropagation()}
+      onKeyDown={e => e.stopPropagation()}
+    >
+      <Checkbox
+        checked={checked}
+        onCheckedChange={() => onToggle()}
         aria-label={label || (checked ? "Deselect item" : "Select item")}
-      >
-        {checked && <CheckIcon className="size-3" />}
-      </button>
+      />
     </div>
   );
 }

--- a/src/components/data-list/virtualized-data-list.tsx
+++ b/src/components/data-list/virtualized-data-list.tsx
@@ -276,6 +276,12 @@ export function VirtualizedDataList<TItem, TField extends string = string>({
               results.length > 0 &&
               selection.isAllSelected(results)
             }
+            indeterminate={
+              !isLoading &&
+              results.length > 0 &&
+              selection.selectedKeys.size > 0 &&
+              !selection.isAllSelected(results)
+            }
             onToggle={() =>
               !isLoading && results.length > 0 && selection.toggleAll(results)
             }

--- a/src/components/files/file-selector-dialog.tsx
+++ b/src/components/files/file-selector-dialog.tsx
@@ -1,7 +1,6 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import {
-  CheckIcon,
   FileCodeIcon,
   FilePdfIcon,
   FileTextIcon,
@@ -16,6 +15,7 @@ import { usePaginatedQuery, useQuery } from "convex/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { ListEmptyState } from "@/components/data-list";
+import { SelectionCheckbox } from "@/components/data-list/selection-checkbox";
 import { ImageThumbnail } from "@/components/files/file-display";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -136,14 +136,6 @@ const FileListRow = memo(
       }
     }, [file, onToggle, onPreview]);
 
-    const handleCheckboxClick = useCallback(
-      (e: React.MouseEvent) => {
-        e.stopPropagation();
-        onToggle(file);
-      },
-      [file, onToggle]
-    );
-
     return (
       <div
         onClick={handleRowClick}
@@ -163,21 +155,11 @@ const FileListRow = memo(
         )}
       >
         {/* Checkbox — click toggles selection */}
-        <button
-          type="button"
-          onClick={handleCheckboxClick}
-          className={cn(
-            "h-5 w-5 shrink-0 rounded border-2 flex items-center justify-center transition-all",
-            selected
-              ? "bg-primary border-primary"
-              : "border-border hover:border-primary/50"
-          )}
-          aria-label={selected ? "Deselect file" : "Select file"}
-        >
-          {selected && (
-            <CheckIcon className="size-3.5 text-primary-foreground" />
-          )}
-        </button>
+        <SelectionCheckbox
+          checked={selected}
+          onToggle={() => onToggle(file)}
+          label={selected ? "Deselect file" : "Select file"}
+        />
 
         {/* Thumbnail / Icon */}
         <div className="h-10 w-10 shrink-0 rounded-md overflow-hidden bg-muted/30 flex items-center justify-center">

--- a/src/components/navigation/sidebar/conversation-group.tsx
+++ b/src/components/navigation/sidebar/conversation-group.tsx
@@ -1,5 +1,10 @@
 import { CaretRightIcon, PushPinIcon } from "@phosphor-icons/react";
-import { Children, type ReactNode, useRef, useState } from "react";
+import { Children, type ReactNode, useRef } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 
 type ConversationGroupProps = {
@@ -20,72 +25,73 @@ export const ConversationGroup = ({
   collapsible = true,
   defaultExpanded = true,
 }: ConversationGroupProps) => {
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const isPinned = title === "Pinned";
   const hasToggled = useRef(false);
 
   // Pinned group is never collapsible
   const isCollapsible = collapsible && !isPinned;
 
-  const handleToggle = () => {
-    if (isCollapsible) {
-      hasToggled.current = true;
-      setIsExpanded(prev => !prev);
-    }
-  };
+  const headingStyles =
+    "px-2.5 pt-2 pb-1.5 text-xs font-bold uppercase tracking-wider text-sidebar-muted flex items-center gap-1 w-full text-left";
+
+  const staggeredChildren = (
+    <div className="stack-xs">
+      {hasToggled.current
+        ? Children.map(children, (child, index) => (
+            <div
+              className="animate-list-item-in"
+              style={{
+                animationDelay: `${Math.min(index * 25, 250)}ms`,
+              }}
+            >
+              {child}
+            </div>
+          ))
+        : children}
+    </div>
+  );
+
+  // Pinned groups render without Collapsible wrapper
+  if (!isCollapsible) {
+    return (
+      <div className="stack-sm mt-4 first:mt-0">
+        <div className={cn(headingStyles, "cursor-default")}>
+          {isPinned && (
+            <PushPinIcon className="size-3.5 mr-0.5" weight="fill" />
+          )}
+          <span>{title}</span>
+        </div>
+        <div className="stack-xs">{children}</div>
+      </div>
+    );
+  }
 
   return (
-    <div className="stack-sm mt-4 first:mt-0">
-      <button
-        type="button"
-        onClick={handleToggle}
-        disabled={!isCollapsible}
-        aria-expanded={isCollapsible ? isExpanded : undefined}
+    <Collapsible
+      defaultOpen={defaultExpanded}
+      onOpenChange={() => {
+        hasToggled.current = true;
+      }}
+      className="group/collapsible stack-sm mt-4 first:mt-0"
+    >
+      <CollapsibleTrigger
         className={cn(
-          "px-2.5 pt-2 pb-1.5 text-xs font-bold uppercase tracking-wider text-sidebar-muted flex items-center gap-1 w-full text-left",
-          isCollapsible &&
-            "hover:text-sidebar-foreground transition-colors cursor-pointer",
-          !isCollapsible && "cursor-default"
+          headingStyles,
+          "hover:text-sidebar-foreground transition-colors cursor-pointer"
         )}
       >
-        {isCollapsible && (
-          <CaretRightIcon
-            className={cn(
-              "size-3 flex-shrink-0 transition-transform duration-200",
-              isExpanded && "rotate-90"
-            )}
-            aria-hidden="true"
-          />
-        )}
-        {isPinned && <PushPinIcon className="size-3.5 mr-0.5" weight="fill" />}
+        <CaretRightIcon
+          className="size-3 flex-shrink-0 transition-transform duration-200 group-data-[open]/collapsible:rotate-90"
+          aria-hidden="true"
+        />
         <span>{title}</span>
-        {isCollapsible && count !== undefined && (
-          <span
-            className={cn(
-              "ml-auto inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-sidebar-accent text-overline font-medium text-sidebar-foreground tabular-nums transition-opacity duration-200",
-              isExpanded ? "opacity-0" : "opacity-100"
-            )}
-          >
+        {count !== undefined && (
+          <span className="ml-auto inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-sidebar-accent text-overline font-medium text-sidebar-foreground tabular-nums transition-opacity duration-200 group-data-[open]/collapsible:opacity-0">
             {count}
           </span>
         )}
-      </button>
-      {isExpanded && (
-        <div className="stack-xs">
-          {hasToggled.current
-            ? Children.map(children, (child, index) => (
-                <div
-                  className="animate-list-item-in"
-                  style={{
-                    animationDelay: `${Math.min(index * 25, 250)}ms`,
-                  }}
-                >
-                  {child}
-                </div>
-              ))
-            : children}
-        </div>
-      )}
-    </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>{staggeredChildren}</CollapsibleContent>
+    </Collapsible>
   );
 };

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,40 @@
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
+import { CheckIcon, MinusIcon } from "@phosphor-icons/react";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type CheckboxProps = Omit<
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>,
+  "children"
+> & {
+  ref?: React.Ref<React.ComponentRef<typeof CheckboxPrimitive.Root>>;
+};
+
+function Checkbox({ className, ref, ...props }: CheckboxProps) {
+  return (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      className={cn(
+        "group/checkbox flex h-4 w-4 items-center justify-center rounded border transition-all",
+        "data-[checked]:bg-primary data-[checked]:border-primary data-[checked]:text-primary-foreground",
+        "data-[indeterminate]:bg-primary data-[indeterminate]:border-primary data-[indeterminate]:text-primary-foreground",
+        "data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed",
+        "hover:border-primary/50 data-[checked]:hover:border-primary data-[indeterminate]:hover:border-primary",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        keepMounted
+        className="flex items-center justify-center data-[unchecked]:hidden"
+      >
+        <CheckIcon className="size-3 group-data-[indeterminate]/checkbox:hidden" />
+        <MinusIcon className="size-3 hidden group-data-[indeterminate]/checkbox:block" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,30 @@
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Collapsible = CollapsiblePrimitive.Root;
+
+const CollapsibleTrigger = CollapsiblePrimitive.Trigger;
+
+type CollapsibleContentProps = React.ComponentPropsWithoutRef<
+  typeof CollapsiblePrimitive.Panel
+> & {
+  ref?: React.Ref<React.ComponentRef<typeof CollapsiblePrimitive.Panel>>;
+};
+
+function CollapsibleContent({
+  className,
+  ref,
+  ...props
+}: CollapsibleContentProps) {
+  return (
+    <CollapsiblePrimitive.Panel
+      ref={ref}
+      className={cn("overflow-hidden", className)}
+      {...props}
+    />
+  );
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -36,6 +36,7 @@ export {
 } from "./button";
 export type { ChatInputIconButtonProps } from "./chat-input-icon-button";
 export { ChatInputIconButton } from "./chat-input-icon-button";
+export { Checkbox } from "./checkbox";
 export { EnhancedSlider } from "./enhanced-slider";
 export { Input } from "./input";
 export { Label } from "./label";
@@ -73,6 +74,11 @@ export {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "./alert-dialog";
+export {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./collapsible";
 export {
   Command,
   CommandDialog,
@@ -159,6 +165,7 @@ export type {
   MultiJobProgressProps,
 } from "./progress";
 export { JobProgressCard, MultiJobProgress, Progress } from "./progress";
+export { Separator } from "./separator";
 export { Skeleton } from "./skeleton";
 export { SkeletonText } from "./skeleton-text";
 export { ThemeToggle } from "./theme-toggle";

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,3 +1,4 @@
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress";
 import {
   CheckCircleIcon,
   ClockIcon,
@@ -17,47 +18,43 @@ type ProgressProps = {
   className?: string;
   variant?: "default" | "success" | "error" | "warning";
   ref?: React.Ref<HTMLDivElement>;
-} & React.HTMLAttributes<HTMLDivElement>;
+};
+
+const progressColorMap = {
+  success:
+    "bg-gradient-to-r from-success to-success-hover shadow-sm shadow-success/20",
+  error:
+    "bg-gradient-to-r from-danger to-danger-hover shadow-sm shadow-danger/20",
+  warning:
+    "bg-gradient-to-r from-warning to-warning-hover shadow-sm shadow-warning/20",
+  default:
+    "bg-gradient-to-r from-blue-500 via-purple-500 to-blue-600 shadow-sm shadow-blue-500/20",
+} as const;
 
 function Progress({
   className,
   value = 0,
   variant = "default",
   ref,
-  ...props
 }: ProgressProps) {
-  const getProgressColor = () => {
-    switch (variant) {
-      case "success":
-        return "bg-gradient-to-r from-success to-success-hover shadow-sm shadow-success/20";
-      case "error":
-        return "bg-gradient-to-r from-danger to-danger-hover shadow-sm shadow-danger/20";
-      case "warning":
-        return "bg-gradient-to-r from-warning to-warning-hover shadow-sm shadow-warning/20";
-      default:
-        return "bg-gradient-to-r from-blue-500 via-purple-500 to-blue-600 shadow-sm shadow-blue-500/20";
-    }
-  };
-
   return (
-    <div
+    <ProgressPrimitive.Root
       ref={ref}
+      value={value}
       className={cn(
         "relative h-2 w-full overflow-hidden rounded-full bg-secondary",
         className
       )}
-      {...props}
     >
-      <div
-        className={cn(
-          "h-full rounded-full transition-all duration-500 ease-out",
-          getProgressColor()
-        )}
-        style={{
-          width: `${Math.min(100, Math.max(0, value))}%`,
-        }}
-      />
-    </div>
+      <ProgressPrimitive.Track>
+        <ProgressPrimitive.Indicator
+          className={cn(
+            "h-full rounded-full transition-all duration-500 ease-out",
+            progressColorMap[variant]
+          )}
+        />
+      </ProgressPrimitive.Track>
+    </ProgressPrimitive.Root>
   );
 }
 

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,32 @@
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SeparatorProps = React.ComponentPropsWithoutRef<
+  typeof SeparatorPrimitive
+> & {
+  ref?: React.Ref<React.ComponentRef<typeof SeparatorPrimitive>>;
+};
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ref,
+  ...props
+}: SeparatorProps) {
+  return (
+    <SeparatorPrimitive
+      ref={ref}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };


### PR DESCRIPTION
## Summary

- **Checkbox**: New `src/components/ui/checkbox.tsx` wrapping `@base-ui/react/checkbox` with checked, indeterminate, and disabled states. Migrated `SelectionCheckbox`, `SelectAllCheckbox`, and `FileSelectorDialog` inline checkbox to use it — removes 2 `biome-ignore` suppressions and gains proper semantics + keyboard handling.
- **Collapsible**: New `src/components/ui/collapsible.tsx` wrapping `@base-ui/react/collapsible`. Migrated `ConversationGroup` from manual `useState` + `aria-expanded` to Base UI primitives while preserving staggered entrance animations and pinned group behavior.
- **Progress**: Rewrote `Progress` internals to use `@base-ui/react/progress` (Root + Track + Indicator), gaining `role="progressbar"` and `aria-valuenow/min/max` for free. Preserved variant prop and gradient color system — `JobProgressCard` and `MultiJobProgress` unchanged.
- **Separator**: New `src/components/ui/separator.tsx` wrapping `@base-ui/react/separator` with orientation support, available for future use.
- Added `indeterminate` support to `SelectAllCheckbox` and wired it in `VirtualizedDataList` for partial selection state.

## Test plan

- [x] `bun run check` passes (lint + types + build)
- [x] `bun run test` passes (1322 tests, 0 failures)
- [ ] Verify checkbox selection/deselection in data list views
- [ ] Verify indeterminate state shows when some (not all) items selected
- [ ] Verify sidebar conversation groups expand/collapse with animation
- [ ] Verify pinned groups remain non-collapsible
- [ ] Verify progress bar renders correctly in job cards
- [ ] Verify keyboard interaction (Space/Enter) on checkboxes and collapsible triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)