### PR TITLE
feat: Unify container styling to match chat input

### DIFF
--- a/src/components/chat/activity-stream.tsx
+++ b/src/components/chat/activity-stream.tsx
@@ -146,7 +146,7 @@ export function ActivityStream({
   // While streaming: card with live items
   if (!isComplete) {
     return (
-      <div className="mb-3 -mx-3 sm:-mx-6 rounded-xl border border-border bg-surface-variant shadow-sm px-4 sm:px-6 py-3">
+      <div className="mb-3 -mx-3 sm:-mx-6 rounded-[1.65rem] border border-input-border bg-muted shadow-sm px-4 sm:px-6 py-3">
         {streamContent}
       </div>
     );
@@ -184,7 +184,7 @@ export function ActivityStream({
         style={{ gridTemplateRows: expanded ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden">
-          <div className="mt-2 rounded-xl border border-border bg-surface-variant shadow-sm px-4 sm:px-6 py-3">
+          <div className="mt-2 rounded-[1.65rem] border border-input-border bg-muted shadow-sm px-4 sm:px-6 py-3 overflow-hidden">
             {streamContent}
           </div>
         </div>

--- a/src/components/chat/message/assistant-bubble.tsx
+++ b/src/components/chat/message/assistant-bubble.tsx
@@ -190,7 +190,7 @@ const TextMessageBubble = ({
               <StreamingMarkdown
                 isStreaming={isActive}
                 messageId={message.id}
-                className="text-[15px] leading-[1.75] sm:text-[16px] sm:leading-[1.8] max-w-[74ch]"
+                className="text-[15px] leading-[1.75] sm:text-[16px] sm:leading-[1.8]"
               >
                 {displayContent}
               </StreamingMarkdown>

--- a/src/components/chat/unified-chat-view/index.tsx
+++ b/src/components/chat/unified-chat-view/index.tsx
@@ -421,7 +421,6 @@ export const UnifiedChatView = memo(
       setFooterInset(footerOverlayRef.current?.offsetHeight ?? 0);
     }, []);
 
-    const overlayScrollbarOffset = "calc(env(safe-area-inset-right) + 12px)";
     const handleMessagesContainerRef = useCallback(
       (node: HTMLDivElement | null) => {
         messagesContainerRef.current = node;
@@ -509,7 +508,7 @@ export const UnifiedChatView = memo(
               className={cn(
                 "flex h-full w-full flex-col overflow-hidden",
                 "**:data-vlist-id:overscroll-contain md:**:data-vlist-id:overscroll-auto",
-                "[&_[data-vlist-id]]:scrollbar-thin"
+                "[&_[data-vlist-id]]:scrollbar-thin [&_[data-vlist-id]]:[scrollbar-gutter:stable]"
               )}
             >
               {renderMessageArea()}
@@ -537,10 +536,7 @@ export const UnifiedChatView = memo(
             <div className="pointer-events-none absolute inset-x-0 bottom-0">
               <div
                 ref={footerOverlayRef}
-                className="pointer-events-auto px-3 pt-3 sm:px-5"
-                style={{
-                  right: overlayScrollbarOffset,
-                }}
+                className="pointer-events-auto px-4 pt-3 sm:px-8 me-[11px]"
               >
                 <div className="mx-auto w-full max-w-3xl stack-md">
                   <ArchivedBanner

--- a/src/components/ui/code-block.tsx
+++ b/src/components/ui/code-block.tsx
@@ -158,9 +158,9 @@ const CodeBlockComponent = ({
       )}
       ref={componentRef}
     >
-      <div className="rounded-xl border border-border bg-card/95 shadow-sm backdrop-blur-xs dark:bg-card/95">
+      <div className="rounded-[1.65rem] border border-input-border bg-muted shadow-sm">
         {/* Header with language and actions */}
-        <div className="flex h-9 items-center justify-between rounded-t-xl border-b border-border/70 bg-muted/60 px-3 text-xs text-muted-foreground sm:px-6">
+        <div className="flex h-9 items-center justify-between rounded-t-[1.65rem] border-b border-input-border/70 bg-muted/60 px-3 text-xs text-muted-foreground sm:px-6">
           <span className="font-mono font-medium text-muted-foreground">
             {processedLanguage || "text"}
           </span>

--- a/src/components/ui/markdown-block.tsx
+++ b/src/components/ui/markdown-block.tsx
@@ -113,7 +113,7 @@ const MarkdownBlockComponent: LLMOutputComponent = ({ blockMatch }) => {
   }, [messageId]);
 
   return (
-    <div className="prose prose-sm sm:prose-base max-w-none prose-headings:font-semibold prose-p:leading-[1.75] prose-li:my-1.5 prose-ul:my-3 prose-ol:my-3 prose-hr:my-6 prose-a:underline-offset-2 hover:prose-a:underline prose-code:rounded-md prose-code:px-1.5 prose-code:py-0.5 prose-pre:bg-surface-variant prose-pre:text-foreground prose-pre:rounded-xl prose-pre:border prose-pre:border-border prose-pre:shadow-sm prose-pre:p-0 prose-pre:mt-2 prose-pre:mb-2 prose-pre:w-[calc(100%+24px)] prose-pre:max-w-none sm:prose-pre:w-[calc(100%+48px)] prose-pre:-mx-[12px] sm:prose-pre:-mx-[24px] prose-pre:overflow-x-auto prose-blockquote:border-l-border prose-blockquote:text-muted-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>p:first-of-type]:mt-0 tracking-tight">
+    <div className="prose prose-sm sm:prose-base max-w-[74ch] prose-headings:font-semibold prose-p:leading-[1.75] prose-li:my-1.5 prose-ul:my-3 prose-ol:my-3 prose-hr:my-6 prose-a:underline-offset-2 hover:prose-a:underline prose-code:rounded-md prose-code:px-1.5 prose-code:py-0.5 prose-pre:bg-muted prose-pre:text-foreground prose-pre:rounded-[1.65rem] prose-pre:border prose-pre:border-input-border prose-pre:shadow-sm prose-pre:p-0 prose-pre:mt-2 prose-pre:mb-2 prose-pre:overflow-x-auto prose-blockquote:border-l-border prose-blockquote:text-muted-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>p:first-of-type]:mt-0 tracking-tight">
       <Markdown
         options={{
           disableParsingRawHTML: true,

--- a/src/components/ui/streaming-markdown.tsx
+++ b/src/components/ui/streaming-markdown.tsx
@@ -188,7 +188,7 @@ const StreamingMarkdownInner = memo(
     return (
       <StreamingContext.Provider value={contextValue}>
         <div
-          className={`${className ?? ""} selectable-text break-words text-[15px] leading-[1.75] sm:text-[16px] sm:leading-[1.8] max-w-[72ch]`}
+          className={`${className ?? ""} selectable-text break-words text-[15px] leading-[1.75] sm:text-[16px] sm:leading-[1.8]`}
         >
           {renderedBlocks}
         </div>


### PR DESCRIPTION
## Summary
- Unified thinking container, code blocks, and markdown prose overrides to use the same visual treatment as the chat input: `rounded-[1.65rem]`, `bg-muted`, `border-input-border`
- Fixed footer/message alignment by matching padding (`px-4 sm:px-8`) and adding `scrollbar-gutter: stable` + `me-[11px]` compensation on the footer overlay
- Made code blocks full-width by moving `max-w-[74ch]` from the StreamingMarkdown wrapper to the MarkdownBlock prose div, so `CodeBlockWrapperLLM` siblings can expand with negative margins

## Test plan
- [ ] Verify thinking/reasoning container visually matches chat input border-radius, background, and border
- [ ] Verify code blocks render full-width and match the same styling
- [ ] Check footer overlay aligns cleanly with message content (no hairline offset)
- [ ] Test on both light and dark themes
- [ ] Confirm streaming markdown still renders correctly during active streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)