### PR TITLE
fix: Mobile container overflow and border radius

### DIFF
--- a/src/components/chat/activity-stream.tsx
+++ b/src/components/chat/activity-stream.tsx
@@ -146,7 +146,7 @@ export function ActivityStream({
   // While streaming: card with live items
   if (!isComplete) {
     return (
-      <div className="mb-3 -mx-3 sm:-mx-6 rounded-[1.65rem] border border-input-border bg-muted shadow-sm px-4 sm:px-6 py-3">
+      <div className="mb-3 mx-0 sm:-mx-6 rounded-xl sm:rounded-[1.65rem] border border-input-border bg-muted shadow-sm px-4 sm:px-6 py-3">
         {streamContent}
       </div>
     );
@@ -180,11 +180,11 @@ export function ActivityStream({
       </button>
 
       <div
-        className="-mx-3 sm:-mx-6 grid transition-[grid-template-rows] duration-200 ease-out"
+        className="mx-0 sm:-mx-6 grid transition-[grid-template-rows] duration-200 ease-out"
         style={{ gridTemplateRows: expanded ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden">
-          <div className="mt-2 rounded-[1.65rem] border border-input-border bg-muted shadow-sm px-4 sm:px-6 py-3 overflow-hidden">
+          <div className="mt-2 rounded-xl sm:rounded-[1.65rem] border border-input-border bg-muted shadow-sm px-4 sm:px-6 py-3 overflow-hidden">
             {streamContent}
           </div>
         </div>

--- a/src/components/chat/unified-chat-view/index.tsx
+++ b/src/components/chat/unified-chat-view/index.tsx
@@ -508,7 +508,7 @@ export const UnifiedChatView = memo(
               className={cn(
                 "flex h-full w-full flex-col overflow-hidden",
                 "**:data-vlist-id:overscroll-contain md:**:data-vlist-id:overscroll-auto",
-                "[&_[data-vlist-id]]:scrollbar-thin [&_[data-vlist-id]]:[scrollbar-gutter:stable]"
+                "[&_[data-vlist-id]]:scrollbar-thin sm:[&_[data-vlist-id]]:[scrollbar-gutter:stable]"
               )}
             >
               {renderMessageArea()}
@@ -536,7 +536,7 @@ export const UnifiedChatView = memo(
             <div className="pointer-events-none absolute inset-x-0 bottom-0">
               <div
                 ref={footerOverlayRef}
-                className="pointer-events-auto px-4 pt-3 sm:px-8 me-[11px]"
+                className="pointer-events-auto px-4 pt-3 sm:px-8 sm:me-[11px]"
               >
                 <div className="mx-auto w-full max-w-3xl stack-md">
                   <ArchivedBanner

--- a/src/components/ui/code-block.tsx
+++ b/src/components/ui/code-block.tsx
@@ -152,15 +152,15 @@ const CodeBlockComponent = ({
   return (
     <div
       className={cn(
-        "group relative mt-2 w-[calc(100%+24px)] max-w-none sm:w-[calc(100%+48px)]",
-        "mx-[-12px] sm:mx-[-24px]",
+        "group relative mt-2 w-full sm:w-[calc(100%+48px)] max-w-none",
+        "mx-0 sm:mx-[-24px]",
         className
       )}
       ref={componentRef}
     >
-      <div className="rounded-[1.65rem] border border-input-border bg-muted shadow-sm">
+      <div className="rounded-xl sm:rounded-[1.65rem] border border-input-border bg-muted shadow-sm">
         {/* Header with language and actions */}
-        <div className="flex h-9 items-center justify-between rounded-t-[1.65rem] border-b border-input-border/70 bg-muted/60 px-3 text-xs text-muted-foreground sm:px-6">
+        <div className="flex h-9 items-center justify-between rounded-t-xl sm:rounded-t-[1.65rem] border-b border-input-border/70 bg-muted/60 px-3 text-xs text-muted-foreground sm:px-6">
           <span className="font-mono font-medium text-muted-foreground">
             {processedLanguage || "text"}
           </span>
@@ -255,7 +255,7 @@ const CodeBlockComponent = ({
                   <pre
                     className={cn(
                       highlightClassName,
-                      "m-0 overflow-x-auto py-4 px-3 text-[14px] leading-[1.7] font-mono sm:px-6 sm:text-[15px]",
+                      "m-0 overflow-x-auto py-4 px-3 text-[13px] leading-[1.7] font-mono sm:px-6 sm:text-[15px]",
                       wordWrap &&
                         "whitespace-pre-wrap break-words overflow-x-visible"
                     )}
@@ -283,7 +283,7 @@ const CodeBlockComponent = ({
             ) : (
               <pre
                 className={cn(
-                  "m-0 overflow-x-auto py-4 px-3 text-[14px] font-mono leading-[1.7] opacity-60 sm:px-6 sm:text-[15px]",
+                  "m-0 overflow-x-auto py-4 px-3 text-[13px] font-mono leading-[1.7] opacity-60 sm:px-6 sm:text-[15px]",
                   wordWrap &&
                     "whitespace-pre-wrap break-words overflow-x-visible"
                 )}

--- a/src/components/ui/markdown-block.tsx
+++ b/src/components/ui/markdown-block.tsx
@@ -113,7 +113,7 @@ const MarkdownBlockComponent: LLMOutputComponent = ({ blockMatch }) => {
   }, [messageId]);
 
   return (
-    <div className="prose prose-sm sm:prose-base max-w-[74ch] prose-headings:font-semibold prose-p:leading-[1.75] prose-li:my-1.5 prose-ul:my-3 prose-ol:my-3 prose-hr:my-6 prose-a:underline-offset-2 hover:prose-a:underline prose-code:rounded-md prose-code:px-1.5 prose-code:py-0.5 prose-pre:bg-muted prose-pre:text-foreground prose-pre:rounded-[1.65rem] prose-pre:border prose-pre:border-input-border prose-pre:shadow-sm prose-pre:p-0 prose-pre:mt-2 prose-pre:mb-2 prose-pre:overflow-x-auto prose-blockquote:border-l-border prose-blockquote:text-muted-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>p:first-of-type]:mt-0 tracking-tight">
+    <div className="prose prose-sm sm:prose-base max-w-[74ch] prose-headings:font-semibold prose-p:leading-[1.75] prose-li:my-1.5 prose-ul:my-3 prose-ol:my-3 prose-hr:my-6 prose-a:underline-offset-2 hover:prose-a:underline prose-code:rounded-md prose-code:px-1.5 prose-code:py-0.5 prose-pre:bg-muted prose-pre:text-foreground prose-pre:rounded-xl sm:prose-pre:rounded-[1.65rem] prose-pre:border prose-pre:border-input-border prose-pre:shadow-sm prose-pre:p-0 prose-pre:mt-2 prose-pre:mb-2 prose-pre:overflow-x-auto prose-blockquote:border-l-border prose-blockquote:text-muted-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>p:first-of-type]:mt-0 tracking-tight">
       <Markdown
         options={{
           disableParsingRawHTML: true,

--- a/src/globals.css
+++ b/src/globals.css
@@ -1625,11 +1625,17 @@ pre {
   position: relative;
   overflow: hidden;
   z-index: var(--z-chat-input);
-  border-radius: 1.65rem;
+  border-radius: 0.75rem;
   padding: 0.6rem 0.5rem;
   background: var(--color-muted);
   border: 1px solid var(--color-input-border);
   box-shadow: var(--shadow-sm);
+}
+
+@media (min-width: 640px) {
+  .chat-input-container {
+    border-radius: 1.65rem;
+  }
 }
 
 /* Dark mode chat input - Clean, minimal (Grok-inspired) */


### PR DESCRIPTION
## Summary
- Reduce border radius on mobile (`rounded-xl` / `0.75rem`) for code blocks, activity stream, chat input — full `1.65rem` at `sm+`
- Remove negative-margin full-bleed on mobile for code blocks and activity stream (`mx-0` on mobile, `-mx-6` at `sm+`)
- Make `scrollbar-gutter: stable` and `me-[11px]` scrollbar compensation `sm+` only (mobile uses overlay scrollbars)
- Smaller code font on mobile (`13px` → `15px` at `sm+`)

## Test plan
- [ ] Mobile viewport (~375px): code blocks and activity stream have `12px` radius and stay within content padding
- [ ] Desktop (>640px): unchanged — full-bleed containers with `1.65rem` radius
- [ ] Chat input border radius matches containers at both breakpoints
- [ ] No horizontal overflow on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)