### PR TITLE
feat: Support clipboard image paste in chat input

### DIFF
--- a/src/components/chat/input/chat-input-field.tsx
+++ b/src/components/chat/input/chat-input-field.tsx
@@ -16,6 +16,7 @@ interface ChatInputFieldProps {
   isTransitioning?: boolean;
   disableAutoResize?: boolean;
   onHeightChange?: (isMultiline: boolean) => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
 
   navigation?: {
     onHistoryNavigation?: () => boolean;
@@ -39,6 +40,7 @@ export const ChatInputField = memo(function ChatInputField({
   isTransitioning = false,
   disableAutoResize = false,
   onHeightChange,
+  onPaste,
   navigation,
 }: ChatInputFieldProps) {
   const { onHistoryNavigation, onHistoryNavigationDown } = navigation || {};
@@ -184,6 +186,7 @@ export const ChatInputField = memo(function ChatInputField({
         value={value}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
+        onPaste={onPaste}
         inputMode="text"
         tabIndex={0}
         aria-label="Chat message input"

--- a/src/components/chat/input/index.tsx
+++ b/src/components/chat/input/index.tsx
@@ -11,6 +11,7 @@ import {
 import {
   useChatInputDragDrop,
   useChatInputImageGeneration,
+  useChatInputPaste,
   useChatInputState,
   useChatInputSubmission,
   useSpeechInput,
@@ -157,6 +158,13 @@ const ChatInputInner = ({
       isStreaming,
       onProcessFiles: handleFileUpload,
     });
+
+  const { handlePaste } = useChatInputPaste({
+    canSend: canSendMessage,
+    isLoading,
+    isStreaming,
+    onProcessFiles: handleFileUpload,
+  });
 
   // Force back to text mode if in private mode (image gen not supported)
   // Allow image mode if user has Replicate key OR selected model is free
@@ -433,6 +441,7 @@ const ChatInputInner = ({
             selectedImageModel={selectedImageModel}
             quote={activeQuote ?? undefined}
             onClearQuote={() => setActiveQuote(null)}
+            onPaste={handlePaste}
           />
 
           <ChatInputBottomBar

--- a/src/components/chat/input/text-input-section.tsx
+++ b/src/components/chat/input/text-input-section.tsx
@@ -31,6 +31,7 @@ interface TextInputSectionProps {
   disableAutoResize?: boolean;
   quote?: string;
   onClearQuote?: () => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
 }
 
 export function TextInputSection({
@@ -51,6 +52,7 @@ export function TextInputSection({
   disableAutoResize,
   quote,
   onClearQuote,
+  onPaste,
 }: TextInputSectionProps) {
   const { attachments } = useChatAttachments(conversationId);
   const handleRemoveAttachment = useCallback(
@@ -127,6 +129,7 @@ export function TextInputSection({
               autoFocus={autoFocus}
               className={textareaClassNameOverride}
               disableAutoResize={disableAutoResize}
+              onPaste={onPaste}
               navigation={{
                 onHistoryNavigation: stableHistoryNavigation,
                 onHistoryNavigationDown: stableHistoryNavigationDown,

--- a/src/hooks/chat-ui/index.ts
+++ b/src/hooks/chat-ui/index.ts
@@ -1,5 +1,6 @@
 export { useChatInputDragDrop } from "./use-chat-input-drag-drop";
 export { useChatInputImageGeneration } from "./use-chat-input-image-generation";
+export { useChatInputPaste } from "./use-chat-input-paste";
 export {
   useChatInputControls,
   useChatInputState,

--- a/src/hooks/chat-ui/use-chat-input-paste.ts
+++ b/src/hooks/chat-ui/use-chat-input-paste.ts
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+
+interface UseChatInputPasteProps {
+  canSend: boolean;
+  isLoading: boolean;
+  isStreaming: boolean;
+  onProcessFiles: (files: FileList) => Promise<void>;
+}
+
+export function useChatInputPaste({
+  canSend,
+  isLoading,
+  isStreaming,
+  onProcessFiles,
+}: UseChatInputPasteProps) {
+  const handlePaste = useCallback(
+    async (e: React.ClipboardEvent) => {
+      if (!canSend || isLoading || isStreaming) {
+        return;
+      }
+
+      const files = e.clipboardData.files;
+      if (files.length > 0) {
+        e.preventDefault();
+        await onProcessFiles(files);
+      }
+    },
+    [canSend, isLoading, isStreaming, onProcessFiles]
+  );
+
+  return { handlePaste };
+}


### PR DESCRIPTION
## Summary
- Add `useChatInputPaste` hook that handles clipboard paste events on the chat textarea
- Reuses the existing `handleFileUpload` pipeline (same as drag-and-drop and file picker)
- Text-only pastes pass through unaffected — files are intercepted with `preventDefault()`

## Test plan
- [ ] Copy an image/screenshot to clipboard, paste into chat input → attachment appears
- [ ] Paste plain text → normal text paste behavior unchanged
- [ ] Paste while loading/streaming → no files processed (guard check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)