### PR TITLE
fix: Prevent long URLs from overflowing user message bubble

### DIFF
--- a/src/components/chat/message/user-bubble.tsx
+++ b/src/components/chat/message/user-bubble.tsx
@@ -186,7 +186,7 @@ export const UserBubble = memo(
                 </div>
               </div>
             ) : (
-              <div className="whitespace-pre-wrap break-words text-[15px] leading-[1.75] transition-all duration-300 ease-out sm:text-[16px] sm:leading-[1.8] selectable-text max-w-[74ch] min-w-0">
+              <div className="whitespace-pre-wrap [overflow-wrap:anywhere] text-[15px] leading-[1.75] transition-all duration-300 ease-out sm:text-[16px] sm:leading-[1.8] selectable-text max-w-[74ch] min-w-0">
                 {message.content}
                 <AttachmentStrip
                   attachments={message.attachments?.filter(


### PR DESCRIPTION
## Summary
- Replace `break-words` (`overflow-wrap: break-word`) with `[overflow-wrap:anywhere]` on the user message text container
- `break-word` doesn't affect min-content intrinsic sizing, so `w-fit` on the parent bubble computes width based on the full URL length, causing overflow on mobile
- `anywhere` factors break opportunities into sizing calculations, allowing the bubble to properly constrain to its parent's max-width

## Test plan
- [ ] Paste a long URL (200+ chars) as a user message on mobile viewport
- [ ] Verify the bubble stays within viewport bounds and the URL wraps correctly
- [ ] Verify normal text messages still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)