### PR TITLE
fix: Use prepareStep to guarantee final text response after tool calls

### DIFF
--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -764,6 +764,7 @@ export const chatStream = httpAction(
         }
 
         // Start streaming with appropriate configuration
+        const MAX_TOOL_STEPS = 5;
         const result =
           modelSupportsTools && exaApiKey && !isAnonymousUser
             ? streamText({
@@ -773,7 +774,13 @@ export const chatStream = httpAction(
                   webSearch: createWebSearchTool(exaApiKey),
                 },
                 toolChoice: "auto",
-                stopWhen: stepCountIs(3),
+                prepareStep: ({ stepNumber }: { stepNumber: number }) => {
+                  if (stepNumber >= MAX_TOOL_STEPS) {
+                    return { toolChoice: "none" };
+                  }
+                  return {};
+                },
+                stopWhen: stepCountIs(MAX_TOOL_STEPS + 1),
               })
             : streamText({
                 ...streamOptionsBase,


### PR DESCRIPTION
## Summary
- Use AI SDK v6's `prepareStep` callback to force `toolChoice: "none"` after 5 tool-calling steps, ensuring the model always generates a final text response
- Previously `stepCountIs(3)` would abruptly kill the stream after 3 steps — when the model made 3 web searches, all steps were consumed by tool calls and no final response was ever generated
- `stopWhen` is kept as a safety net (`MAX_TOOL_STEPS + 1`) but `prepareStep` handles the graceful transition to text generation
- Updated in `streaming_core.ts`, `chat.ts`, and `lib/conversation/streaming.ts`

## Test plan
- [ ] Send a query that triggers multiple web searches (e.g. a question requiring 3+ searches)
- [ ] Verify the model generates a final text response after completing tool calls
- [ ] Verify the model still stops naturally when it's done (doesn't loop endlessly)
- [ ] Test with fewer tool calls (1-2) to confirm normal behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)