### PR TITLE
chore: Remove dead code and consolidate duplicated logic

### DIFF
--- a/convex/conversations.ts
+++ b/convex/conversations.ts
@@ -67,8 +67,7 @@ import {
   stopConversationStreaming,
   validateAuthenticatedUser,
   validateConversationAccess,
-  validateMonthlyMessageLimit,
-  validateMonthlyMessageLimitForAction,
+  validateFreeModelUsage,
   validateTitleLength,
   validateUserMessageLength,
 } from "./lib/shared_utils";
@@ -120,7 +119,7 @@ export async function createConversationHandler(
   const isBuiltInModelResult = fullModel.free === true;
 
   if (isBuiltInModelResult && !user.hasUnlimitedCalls) {
-    await validateMonthlyMessageLimit(ctx, user);
+    validateFreeModelUsage(user);
   }
 
   // Always start with a neutral placeholder so title generation logic can update it
@@ -2648,7 +2647,7 @@ export const createBranchingConversation = action({
     const isBuiltInModelResult = selectedModel.free === true;
 
     if (isBuiltInModelResult && !user.hasUnlimitedCalls) {
-      await validateMonthlyMessageLimitForAction(ctx, user);
+      validateFreeModelUsage(user);
     }
 
     // Fetch persona prompt if personaId is provided but personaPrompt is not

--- a/convex/lib/shared_utils.test.ts
+++ b/convex/lib/shared_utils.test.ts
@@ -10,7 +10,7 @@ import {
   hasConversationAccess,
   validateAuthenticatedUser,
   validateConversationAccess,
-  validateMonthlyMessageLimit,
+  validateFreeModelUsage,
   sanitizeSchema,
   getConversationMessages,
   stopConversationStreaming,
@@ -255,9 +255,8 @@ describe("validateConversationAccess", () => {
   });
 });
 
-describe("validateMonthlyMessageLimit", () => {
-  test("does not throw when under limit", async () => {
-    const ctx = makeConvexCtx();
+describe("validateFreeModelUsage", () => {
+  test("does not throw when under limit", () => {
     const user = {
       _id: "user-123" as Id<"users">,
       _creationTime: Date.now(),
@@ -265,13 +264,11 @@ describe("validateMonthlyMessageLimit", () => {
       monthlyMessagesSent: 50,
     };
 
-    await validateMonthlyMessageLimit(ctx as any, user as any);
-    // If we get here without throwing, the test passes
+    validateFreeModelUsage(user as any);
     expect(true).toBe(true);
   });
 
-  test("throws when at limit", async () => {
-    const ctx = makeConvexCtx();
+  test("throws when at limit", () => {
     const user = {
       _id: "user-123" as Id<"users">,
       _creationTime: Date.now(),
@@ -279,13 +276,12 @@ describe("validateMonthlyMessageLimit", () => {
       monthlyMessagesSent: 100,
     };
 
-    await expect(
-      validateMonthlyMessageLimit(ctx as any, user as any)
-    ).rejects.toThrow("You've reached your monthly limit of 100 free messages");
+    expect(() => validateFreeModelUsage(user as any)).toThrow(
+      "You've reached your monthly limit of 100 free messages"
+    );
   });
 
-  test("throws when over limit", async () => {
-    const ctx = makeConvexCtx();
+  test("throws when over limit", () => {
     const user = {
       _id: "user-123" as Id<"users">,
       _creationTime: Date.now(),
@@ -293,21 +289,19 @@ describe("validateMonthlyMessageLimit", () => {
       monthlyMessagesSent: 150,
     };
 
-    await expect(
-      validateMonthlyMessageLimit(ctx as any, user as any)
-    ).rejects.toThrow("You've reached your monthly limit of 100 free messages");
+    expect(() => validateFreeModelUsage(user as any)).toThrow(
+      "You've reached your monthly limit of 100 free messages"
+    );
   });
 
-  test("uses default limit when monthlyLimit is undefined", async () => {
-    const ctx = makeConvexCtx();
+  test("uses default limit when monthlyLimit is undefined", () => {
     const user = {
       _id: "user-123" as Id<"users">,
       _creationTime: Date.now(),
       monthlyMessagesSent: 499, // Under the default 500 limit
     };
 
-    await validateMonthlyMessageLimit(ctx as any, user as any);
-    // If we get here without throwing, the test passes
+    validateFreeModelUsage(user as any);
     expect(true).toBe(true);
   });
 });

--- a/convex/lib/shared_utils.ts
+++ b/convex/lib/shared_utils.ts
@@ -254,21 +254,7 @@ export function validateFreeModelUsage(user: Doc<"users">): void {
   }
 }
 
-// Validate monthly message limits (legacy - use validateFreeModelUsage instead)
-export async function validateMonthlyMessageLimit(
-  _ctx: MutationCtx | QueryCtx,
-  user: Doc<"users">,
-): Promise<void> {
-  validateFreeModelUsage(user);
-}
 
-// Validate monthly message limits for actions
-export async function validateMonthlyMessageLimitForAction(
-  _ctx: ActionCtx,
-  user: Doc<"users">,
-): Promise<void> {
-  validateFreeModelUsage(user);
-}
 
 // Create default conversation fields
 export function createDefaultConversationFields(

--- a/convex/lib/streaming_utils.test.ts
+++ b/convex/lib/streaming_utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { Id } from "../_generated/dataModel";
-import { findStreamingMessage, isConversationStreaming } from "./streaming_utils";
+import { isConversationStreaming } from "./streaming_utils";
 import { makeConvexCtx } from "../../test/convex-ctx";
 
 describe("isConversationStreaming", () => {
@@ -160,81 +160,3 @@ describe("isConversationStreaming", () => {
   });
 });
 
-describe("findStreamingMessage", () => {
-  test("returns null when no messages in conversation", async () => {
-    const conversationId = "conv-123" as Id<"conversations">;
-
-    const mockQuery = {
-      withIndex: mock(function() { return this; }),
-      filter: mock(function() { return this; }),
-      order: mock(function() { return this; }),
-      first: mock(() => Promise.resolve(null)),
-    };
-
-    const ctx = makeConvexCtx({
-      db: {
-        query: mock(() => mockQuery),
-      },
-    });
-
-    const result = await findStreamingMessage(ctx as any, conversationId);
-    expect(result).toBeNull();
-  });
-
-  test("returns null when latest assistant message is not streaming", async () => {
-    const conversationId = "conv-123" as Id<"conversations">;
-
-    const mockMessage = {
-      _id: "msg-1" as Id<"messages">,
-      role: "assistant",
-      metadata: { finishReason: "stop" },
-      status: "completed",
-    };
-
-    const mockQuery = {
-      withIndex: mock(function() { return this; }),
-      filter: mock(function() { return this; }),
-      order: mock(function() { return this; }),
-      first: mock(() => Promise.resolve(mockMessage)),
-    };
-
-    const ctx = makeConvexCtx({
-      db: {
-        query: mock(() => mockQuery),
-      },
-    });
-
-    const result = await findStreamingMessage(ctx as any, conversationId);
-    expect(result).toBeNull();
-  });
-
-  test("returns streaming message info when message is streaming", async () => {
-    const conversationId = "conv-123" as Id<"conversations">;
-
-    const mockMessage = {
-      _id: "msg-1" as Id<"messages">,
-      role: "assistant",
-      metadata: {},
-      status: "streaming",
-    };
-
-    const mockQuery = {
-      withIndex: mock(function() { return this; }),
-      filter: mock(function() { return this; }),
-      order: mock(function() { return this; }),
-      first: mock(() => Promise.resolve(mockMessage)),
-    };
-
-    const ctx = makeConvexCtx({
-      db: {
-        query: mock(() => mockQuery),
-      },
-    });
-
-    const result = await findStreamingMessage(ctx as any, conversationId);
-    expect(result).toEqual({
-      id: "msg-1",
-      isStreaming: true,
-    });
-  });
-});

--- a/convex/lib/streaming_utils.ts
+++ b/convex/lib/streaming_utils.ts
@@ -34,30 +34,3 @@ export async function isConversationStreaming(
     recentMessage.status !== "error";
   return result;
 }
-
-/**
- * Find the currently streaming message in a conversation
- */
-export async function findStreamingMessage(
-  ctx: AnyCtx,
-  conversationId: Id<"conversations">,
-): Promise<{ id: string; isStreaming: boolean } | null> {
-  const recentMessage = await ctx.db
-    .query("messages")
-    .withIndex("by_conversation", (q) => q.eq("conversationId", conversationId))
-    .filter((q) => q.eq(q.field("role"), "assistant"))
-    .order("desc")
-    .first();
-
-  if (!recentMessage) {
-    return null;
-  }
-
-  const metadata = recentMessage.metadata as any;
-  const isStreaming =
-    !metadata?.finishReason &&
-    !metadata?.stopped &&
-    recentMessage.status !== "error";
-
-  return isStreaming ? { id: recentMessage._id, isStreaming: true } : null;
-}

--- a/src/hooks/chat-ui/use-chat-input-image-generation.ts
+++ b/src/hooks/chat-ui/use-chat-input-image-generation.ts
@@ -8,6 +8,7 @@ import { useEnabledImageModels } from "@/hooks/use-enabled-image-models";
 import { useImageParams } from "@/hooks/use-generation";
 import { useReplicateSchema } from "@/hooks/use-replicate-schema";
 import { handleImageGeneration } from "@/lib/ai/image-generation-handlers";
+import { base64ToUint8Array } from "@/lib/file-utils";
 import { ROUTES } from "@/lib/routes";
 import { usePrivateMode } from "@/providers/private-mode-context";
 import type {
@@ -152,13 +153,9 @@ export function useChatInputImageGeneration({
 
       if (att.content && att.mimeType && !att.storageId) {
         try {
-          const byteCharacters = atob(att.content);
-          const byteNumbers = new Array(byteCharacters.length);
-          for (let i = 0; i < byteCharacters.length; i++) {
-            byteNumbers[i] = byteCharacters.charCodeAt(i);
-          }
-          const byteArray = new Uint8Array(byteNumbers);
-          const file = new File([byteArray], att.name, { type: att.mimeType });
+          const file = new File([base64ToUint8Array(att.content)], att.name, {
+            type: att.mimeType,
+          });
           const uploaded = await uploadFile(file);
           uploadedAttachments.push(uploaded);
         } catch (_e) {

--- a/src/hooks/chat-ui/use-chat-input-submission.ts
+++ b/src/hooks/chat-ui/use-chat-input-submission.ts
@@ -5,6 +5,7 @@ import { useCallback, useState } from "react";
 import { useConvexFileUpload } from "@/hooks/use-convex-file-upload";
 import { useNotificationDialog } from "@/hooks/use-dialog-management";
 import { useReasoningConfig } from "@/hooks/use-reasoning";
+import { base64ToUint8Array } from "@/lib/file-utils";
 import { usePrivateMode } from "@/providers/private-mode-context";
 import type {
   Attachment,
@@ -83,13 +84,7 @@ export function useChatInputSubmission({
           uploaded.push(att);
         } else if (att.content && att.mimeType) {
           try {
-            const byteCharacters = atob(att.content);
-            const byteNumbers = new Array(byteCharacters.length);
-            for (let i = 0; i < byteCharacters.length; i++) {
-              byteNumbers[i] = byteCharacters.charCodeAt(i);
-            }
-            const byteArray = new Uint8Array(byteNumbers);
-            const file = new File([byteArray], att.name, {
+            const file = new File([base64ToUint8Array(att.content)], att.name, {
               type: att.mimeType,
             });
             const res = await uploadFile(file);

--- a/src/lib/ai/chat-handlers.ts
+++ b/src/lib/ai/chat-handlers.ts
@@ -1,5 +1,4 @@
 import type { Id } from "@convex/_generated/dataModel";
-import { cleanAttachmentsForConvex } from "@/lib/utils";
 import {
   getChatKey,
   getSelectedPersonaIdFromStore,
@@ -182,7 +181,7 @@ export const createServerChatHandlers = (
       const sendPayload: Record<string, unknown> = {
         conversationId,
         content: params.content,
-        attachments: cleanAttachmentsForConvex(params.attachments),
+        attachments: params.attachments,
         model: modelOptions.model,
         provider: modelOptions.provider,
         reasoningConfig: params.reasoningConfig || modelOptions.reasoningConfig,

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -101,22 +101,23 @@ export function exportAsMarkdown(data: ExportData): string {
   return markdown;
 }
 
-export function downloadFile(
-  content: string,
-  filename: string,
-  mimeType: string
-) {
-  const blob = new Blob([content], { type: mimeType });
+function triggerBlobDownload(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
-
   const link = document.createElement("a");
   link.href = url;
   link.download = filename;
   document.body.appendChild(link);
   link.click();
-
   document.body.removeChild(link);
   URL.revokeObjectURL(url);
+}
+
+export function downloadFile(
+  content: string,
+  filename: string,
+  mimeType: string
+) {
+  triggerBlobDownload(new Blob([content], { type: mimeType }), filename);
 }
 
 export async function downloadFromUrl(
@@ -124,23 +125,10 @@ export async function downloadFromUrl(
   filename: string
 ): Promise<void> {
   const response = await fetch(downloadUrl);
-
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
   }
-
-  const blob = await response.blob();
-  const blobUrl = window.URL.createObjectURL(blob);
-
-  const link = document.createElement("a");
-  link.href = blobUrl;
-  link.download = filename;
-
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-
-  window.URL.revokeObjectURL(blobUrl);
+  triggerBlobDownload(await response.blob(), filename);
 }
 
 export function generateFilename(title: string, format: "json" | "md"): string {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -29,7 +29,6 @@
 
 export { ROUTES } from "./routes";
 export {
-  cleanAttachmentsForConvex,
   cn,
   formatDate,
   formatFileSize,
@@ -44,6 +43,7 @@ export { validateApiKey } from "./validation";
 // =============================================================================
 
 export {
+  base64ToUint8Array,
   convertImageToWebP,
   FILE_EXTENSION_TO_LANGUAGE,
   generateThumbnail,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,5 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
-import type { Attachment } from "@/types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -96,16 +95,4 @@ export function formatFileSize(bytes: number): string {
   );
   const value = bytes / 1024 ** i;
   return `${value < 10 && i > 0 ? value.toFixed(1) : Math.round(value)} ${units[i]}`;
-}
-
-export function cleanAttachmentsForConvex(attachments?: Attachment[]) {
-  if (!attachments) {
-    return undefined;
-  }
-
-  return attachments.map(attachment => {
-    // The Convex schema now includes all fields from the Attachment type
-    // This function is kept for potential future field filtering
-    return attachment;
-  });
 }

--- a/src/stores/chat-input-store.ts
+++ b/src/stores/chat-input-store.ts
@@ -214,19 +214,6 @@ export function getChatKey(conversationId?: string | null): ConversationKey {
   return conversationId ?? GLOBAL_CHAT_INPUT_KEY;
 }
 
-export function makeChatInputKey(
-  conversationId?: string,
-  usePreserved?: boolean
-): ConversationKey {
-  // Only preserve when explicitly requested for new conversations without messages
-  if (usePreserved) {
-    return conversationId ?? GLOBAL_CHAT_INPUT_KEY;
-  }
-  // When not preserving, still return a stable key to allow optional usage,
-  // but callers generally should not write to the store in this case.
-  return conversationId ?? GLOBAL_CHAT_INPUT_KEY;
-}
-
 export function getSelectedPersonaIdFromStore(key: ConversationKey) {
   return chatInputStoreApi.getState().selectedByKey[key] ?? null;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -140,17 +140,6 @@ export type ImageGenerationResult = {
   };
 };
 
-export type GeneratedImageAttachment = Attachment & {
-  type: "image";
-  isGenerated: true;
-  generationMetadata?: {
-    prompt: string;
-    model: string;
-    params: ImageGenerationParams;
-    replicateId: string;
-  };
-};
-
 // ============================================================================
 // CHAT & MESSAGING TYPES
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Dead code removed:** `makeChatInputKey`, `GeneratedImageAttachment` type, `cleanAttachmentsForConvex` no-op, `findStreamingMessage` (duplicate of `isConversationStreaming`), 4 unused `useFileUpload` return values, `validateMonthlyMessageLimit` wrapper functions
- **Extract `base64ToUint8Array`** utility to replace 4 duplicated base64→Uint8Array conversions across hooks
- **Extract `triggerBlobDownload`** to deduplicate blob download boilerplate in `export.ts`
- **Extract `scaleDimensions`** to deduplicate 3 identical dimension-scaling blocks in `file-utils.ts`
- **Extract `resolveObjectURLDeps`** to deduplicate thumbnail dependency setup in `file-utils.ts`
- **Replace `validateMonthlyMessageLimit` wrappers** with direct `validateFreeModelUsage` calls

15 files changed, **-224 net lines**.

## Test plan

- [x] `bun run check` passes (lint + types + build)
- [x] `bun run test` passes (1304 tests, 0 failures)
- [ ] Smoke test: file uploads, image conversion, blob downloads, chat send

🤖 Generated with [Claude Code](https://claude.com/claude-code)