### PR TITLE
refactor: Consolidate duplicated model picker item logic

### DIFF
--- a/src/components/chat/input/pickers/model-picker/model-item-tooltip.tsx
+++ b/src/components/chat/input/pickers/model-picker/model-item-tooltip.tsx
@@ -1,0 +1,63 @@
+import { MONTHLY_MESSAGE_LIMIT } from "@shared/constants";
+import type { ReactNode } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/**
+ * Wraps a model item with a tooltip explaining why it's disabled.
+ * Used by both desktop (ModelItem) and mobile (DrawerModelItem) variants.
+ */
+export function ModelItemTooltip({
+  isPollyDisabled,
+  isUnavailable,
+  triggerClassName,
+  children,
+}: {
+  isPollyDisabled?: boolean;
+  isUnavailable?: boolean;
+  triggerClassName?: string;
+  children: ReactNode;
+}) {
+  if (isPollyDisabled) {
+    return (
+      <Tooltip>
+        <TooltipTrigger className={triggerClassName}>{children}</TooltipTrigger>
+        <TooltipContent>
+          <div>
+            <div className="font-semibold text-foreground">
+              Monthly Limit Reached
+            </div>
+            <div className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              You've used all {MONTHLY_MESSAGE_LIMIT} free messages this month.
+              Switch to BYOK models for unlimited usage.
+            </div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  if (isUnavailable) {
+    return (
+      <Tooltip>
+        <TooltipTrigger className={triggerClassName}>{children}</TooltipTrigger>
+        <TooltipContent>
+          <div>
+            <div className="font-semibold text-foreground">
+              Model No Longer Available
+            </div>
+            <div className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              This model has been disabled or deprecated by its provider. Please
+              remove it from Settings or select a different model.
+            </div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return children;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -58,6 +58,7 @@ export { useConversationModelOverride } from "./use-conversation-model-override"
 export { useEnabledImageModels } from "./use-enabled-image-models";
 export { useLastGeneratedImageSeed } from "./use-last-generated-image-seed";
 export { useModelCatalog, useModelTitle } from "./use-model-catalog";
+export { useModelItemData } from "./use-model-item-data";
 export { useReplicateApiKey } from "./use-replicate-api-key";
 export { useReplicateSchema } from "./use-replicate-schema";
 export { useSelectedModel } from "./use-selected-model";

--- a/src/hooks/use-model-item-data.ts
+++ b/src/hooks/use-model-item-data.ts
@@ -1,0 +1,79 @@
+import { api } from "@convex/_generated/api";
+import { useQuery } from "convex/react";
+import { useCallback, useMemo } from "react";
+import { formatContextLength } from "@/lib/format-context";
+import { getModelCapabilities } from "@/lib/model-capabilities";
+import { useUserDataContext } from "@/providers/user-data-context";
+import type { HydratedModel } from "@/types";
+
+/**
+ * Shared data computation for model picker items (desktop + mobile).
+ *
+ * Encapsulates: unavailability check, capabilities, disabled state,
+ * context-length display, and the guarded select handler.
+ */
+export function useModelItemData(
+  model: HydratedModel,
+  onSelect: (value: string) => void,
+  hasReachedPollyLimit?: boolean
+) {
+  const { user } = useUserDataContext();
+  const unavailableModels = useQuery(
+    api.userModels.getUnavailableModelIds,
+    user?._id ? {} : "skip"
+  );
+
+  const isUnavailable = useMemo(() => {
+    if (!unavailableModels || model.free) {
+      return false;
+    }
+    return unavailableModels.some(
+      u => u.modelId === model.modelId && u.provider === model.provider
+    );
+  }, [unavailableModels, model]);
+
+  const capabilities = useMemo(
+    () =>
+      getModelCapabilities({
+        modelId: model.modelId,
+        provider: model.provider,
+        name: model.name,
+        contextLength: model.contextLength,
+        supportsReasoning: model.supportsReasoning,
+        supportsImages: model.supportsImages,
+        supportsTools: model.supportsTools,
+        supportsFiles: model.supportsFiles,
+        inputModalities: model.inputModalities,
+      }),
+    [model]
+  );
+
+  const handleSelect = useCallback(() => {
+    if (isUnavailable) {
+      return;
+    }
+    if (model.free && hasReachedPollyLimit) {
+      return;
+    }
+    onSelect(model.modelId);
+  }, [
+    model.modelId,
+    model.free,
+    hasReachedPollyLimit,
+    onSelect,
+    isUnavailable,
+  ]);
+
+  const isPollyDisabled = model.free && hasReachedPollyLimit;
+  const isDisabled = isUnavailable || isPollyDisabled;
+  const contextDisplay = formatContextLength(model.contextLength);
+
+  return {
+    isUnavailable,
+    capabilities,
+    handleSelect,
+    isPollyDisabled,
+    isDisabled,
+    contextDisplay,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract `useModelItemData` hook to deduplicate shared business logic between desktop (`ModelItem`) and mobile (`DrawerModelItem`) model picker items — unavailability query, capabilities, select handler, disabled state, context display
- Extract `ModelItemTooltip` component to deduplicate the disabled-state tooltip wrappers (monthly limit / unavailable model)
- Both model item components now import the shared hook and tooltip, keeping only their variant-specific rendering (CommandItem + icon badges vs DrawerItem + text labels)

## Test plan
- [x] `bun run check` passes (lint + types + build)
- [x] All 1307 tests pass
- [ ] Manual: Verify desktop model picker renders correctly with capabilities as icon badges
- [ ] Manual: Verify mobile model picker renders correctly with capabilities as text labels
- [ ] Manual: Verify disabled states (monthly limit, unavailable model) show correct tooltips on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)