### PR TITLE
chore: Replace local auth helpers with shared getAuthenticatedUser

### DIFF
--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -10,6 +10,7 @@ import {
   type QueryCtx,
   query,
 } from "./_generated/server";
+import { getAuthenticatedUser } from "./lib/shared_utils";
 
 // Provider type definition
 type ProviderType =
@@ -21,17 +22,6 @@ type ProviderType =
   | "moonshot"
   | "replicate"
   | "elevenlabs";
-
-// Shared handler for user authentication
-async function handleGetAuthenticatedUser(
-  ctx: MutationCtx | QueryCtx
-): Promise<Id<"users">> {
-  const userId = await getAuthUserId(ctx);
-  if (!userId) {
-    throw new Error("User not authenticated");
-  }
-  return userId;
-}
 
 // Shared handler for getting user API key record
 async function handleGetUserApiKey(
@@ -178,7 +168,7 @@ export const storeApiKey = mutation({
     rawKey: v.string(),
   },
   handler: async (ctx, args) => {
-    const userId = await handleGetAuthenticatedUser(ctx);
+    const userId = await getAuthenticatedUser(ctx);
 
     if (!validateApiKeyFormat(args.provider, args.rawKey)) {
       throw new Error(`Invalid API key format for ${args.provider}`);
@@ -216,7 +206,7 @@ export const storeClientEncryptedApiKey = mutation({
     partialKey: v.string(), // For display purposes
   },
   handler: async (ctx, args) => {
-    const userId = await handleGetAuthenticatedUser(ctx);
+    const userId = await getAuthenticatedUser(ctx);
 
     await handleUpsertApiKey(ctx, userId, args.provider, {
       clientEncryptedKey: args.encryptedKey,
@@ -267,7 +257,7 @@ export const removeApiKey = mutation({
     ),
   },
   handler: async (ctx, args) => {
-    const userId = await handleGetAuthenticatedUser(ctx);
+    const userId = await getAuthenticatedUser(ctx);
     const existing = await handleGetUserApiKey(ctx, userId, args.provider);
 
     if (existing) {
@@ -290,7 +280,7 @@ export const validateApiKey = mutation({
     ),
   },
   handler: async (ctx, args) => {
-    const userId = await handleGetAuthenticatedUser(ctx);
+    const userId = await getAuthenticatedUser(ctx);
     const apiKeyRecord = await handleGetUserApiKey(ctx, userId, args.provider);
 
     if (!apiKeyRecord) {

--- a/convex/personas.ts
+++ b/convex/personas.ts
@@ -16,17 +16,7 @@ import {
   validatePaginationOpts,
 } from "./lib/pagination";
 import { personaImportSchema } from "./lib/schemas";
-
-// Shared handler for user authentication and validation
-async function handleGetAuthenticatedUser(
-  ctx: MutationCtx | QueryCtx
-): Promise<Id<"users">> {
-  const userId = await getAuthUserId(ctx);
-  if (!userId) {
-    throw new Error("User not authenticated");
-  }
-  return userId;
-}
+import { getAuthenticatedUser } from "./lib/shared_utils";
 
 // Shared handler for persona ownership validation
 async function handleValidatePersonaOwnership(
@@ -124,7 +114,7 @@ export async function createHandler(
     advancedSamplingEnabled?: boolean;
   }
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
 
   const now = Date.now();
 
@@ -167,7 +157,7 @@ export async function updateHandler(
     advancedSamplingEnabled?: boolean;
   }
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
   await handleValidatePersonaOwnership(ctx, args.id, userId);
 
   await ctx.db.patch("personas", args.id, {
@@ -199,7 +189,7 @@ export async function removeHandler(
   ctx: MutationCtx,
   args: { id: Id<"personas"> }
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
   await handleValidatePersonaOwnership(ctx, args.id, userId);
 
   await ctx.db.delete("personas", args.id);
@@ -209,7 +199,7 @@ export async function togglePersonaHandler(
   ctx: MutationCtx,
   args: { id: Id<"personas">; isActive: boolean }
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
   await handleValidatePersonaOwnership(ctx, args.id, userId);
 
   await ctx.db.patch("personas", args.id, {
@@ -243,7 +233,7 @@ export async function importPersonasHandler(
     }>;
   }
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
 
   const now = Date.now();
   const createdPersonas = [];
@@ -597,7 +587,7 @@ export async function toggleBuiltInPersonaHandler(
   ctx: MutationCtx,
   args: { personaId: Id<"personas">; isDisabled: boolean }
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
 
   // Verify this is a built-in persona
   const persona = await ctx.db.get("personas", args.personaId);

--- a/convex/sharedConversations.ts
+++ b/convex/sharedConversations.ts
@@ -1,4 +1,3 @@
-import { getAuthUserId } from "@convex-dev/auth/server";
 import { paginationOptsValidator } from "convex/server";
 import { ConvexError, v } from "convex/values";
 import { api } from "./_generated/api";
@@ -10,17 +9,7 @@ import {
   query,
 } from "./_generated/server";
 import { paginationOptsSchema, validatePaginationOpts } from "./lib/pagination";
-
-// Shared handler for user authentication
-async function handleGetAuthenticatedUser(
-  ctx: MutationCtx | QueryCtx
-): Promise<Id<"users">> {
-  const userId = await getAuthUserId(ctx);
-  if (!userId) {
-    throw new ConvexError("User not authenticated");
-  }
-  return userId;
-}
+import { getAuthenticatedUser } from "./lib/shared_utils";
 
 // Shared handler for conversation ownership validation
 async function handleValidateConversationOwnership(
@@ -68,7 +57,7 @@ export const shareConversation = mutation({
     conversationId: v.id("conversations"),
   },
   handler: async (ctx, args) => {
-    const userId = await handleGetAuthenticatedUser(ctx);
+    const userId = await getAuthenticatedUser(ctx);
     const conversation = await handleValidateConversationOwnership(
       ctx,
       args.conversationId,
@@ -112,7 +101,7 @@ export const updateSharedConversation = mutation({
     conversationId: v.id("conversations"),
   },
   handler: async (ctx, args) => {
-    const userId = await handleGetAuthenticatedUser(ctx);
+    const userId = await getAuthenticatedUser(ctx);
     const conversation = await handleValidateConversationOwnership(
       ctx,
       args.conversationId,
@@ -150,7 +139,7 @@ export const unshareConversation = mutation({
     conversationId: v.id("conversations"),
   },
   handler: async (ctx, args) => {
-    const userId = await handleGetAuthenticatedUser(ctx);
+    const userId = await getAuthenticatedUser(ctx);
     await handleValidateConversationOwnership(ctx, args.conversationId, userId);
 
     // Find and delete the shared conversation record
@@ -276,7 +265,7 @@ export const listUserSharedConversations = query({
     paginationOpts: paginationOptsSchema,
   },
   handler: async (ctx, args) => {
-    const userId = await handleGetAuthenticatedUser(ctx);
+    const userId = await getAuthenticatedUser(ctx);
 
     const query = ctx.db
       .query("sharedConversations")
@@ -300,7 +289,7 @@ export const listUserSharedConversationsPaginated = query({
     sortDirection: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
   },
   handler: async (ctx, args) => {
-    const userId = await handleGetAuthenticatedUser(ctx);
+    const userId = await getAuthenticatedUser(ctx);
     const sortField = args.sortField ?? "sharedAt";
     const sortDirection = args.sortDirection ?? "desc";
 

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -8,17 +8,7 @@ import {
   query,
 } from "./_generated/server";
 import { userSettingsUpdateSchema } from "./lib/schemas";
-
-// Shared handler for user authentication
-async function handleGetAuthenticatedUser(
-  ctx: MutationCtx | QueryCtx
-): Promise<Id<"users">> {
-  const userId = await getAuthUserId(ctx);
-  if (!userId) {
-    throw new Error("User not authenticated");
-  }
-  return userId;
-}
+import { getAuthenticatedUser } from "./lib/shared_utils";
 
 // Shared handler for getting user settings
 async function handleGetUserSettings(
@@ -123,7 +113,7 @@ export async function updateUserSettingsHandler(
   ctx: MutationCtx,
   args: UpdateUserSettingsArgs
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
 
   const existingSettings = await handleGetUserSettings(ctx, userId);
 
@@ -227,7 +217,7 @@ export async function updateUserSettingsForImportHandler(
   ctx: MutationCtx,
   args: { settings: Partial<Doc<"userSettings">> }
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
   await handleUpsertUserSettings(ctx, userId, args.settings);
   return { success: true };
 }
@@ -243,7 +233,7 @@ export async function togglePersonasEnabledHandler(
   ctx: MutationCtx,
   args: { enabled: boolean }
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
   await handleUpsertUserSettings(ctx, userId, {
     personasEnabled: args.enabled,
   });
@@ -261,7 +251,7 @@ export async function updateArchiveSettingsHandler(
   ctx: MutationCtx,
   args: { autoArchiveEnabled: boolean; autoArchiveDays: number }
 ) {
-  const userId = await handleGetAuthenticatedUser(ctx);
+  const userId = await getAuthenticatedUser(ctx);
 
   // Validate autoArchiveDays range (1-365 days)
   if (args.autoArchiveDays < 1 || args.autoArchiveDays > 365) {


### PR DESCRIPTION
## Summary
- Remove 4 identical `handleGetAuthenticatedUser` functions from `apiKeys.ts`, `personas.ts`, `userSettings.ts`, `sharedConversations.ts`
- Replace with import of `getAuthenticatedUser` from `convex/lib/shared_utils.ts` which already existed

## Test plan
- [x] `bun run check` passes (lint + types + build)
- [x] No behavioral change — same function signature, same error handling (now uses `ConvexError` consistently instead of mixed `Error`/`ConvexError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)