### PR TITLE
refactor: Replace inline auth patterns with shared utilities

### DIFF
--- a/convex/backgroundJobs.ts
+++ b/convex/backgroundJobs.ts
@@ -8,6 +8,7 @@ import {
   mutation,
   query,
 } from "./_generated/server";
+import { getAuthenticatedUser } from "./lib/shared_utils";
 
 // Export conversation type definition
 export type ExportAttachment = {
@@ -365,10 +366,7 @@ export const create = mutation({
     includeAttachments: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-    if (!userId) {
-      throw new ConvexError("User not authenticated");
-    }
+    const userId = await getAuthenticatedUser(ctx);
 
     return handleCreateBackgroundJob(ctx, args, userId);
   },
@@ -514,10 +512,7 @@ export const deleteJob = mutation({
     jobId: v.string(),
   },
   handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-    if (!userId) {
-      throw new ConvexError("User not authenticated");
-    }
+    const userId = await getAuthenticatedUser(ctx);
 
     const job = await ctx.db
       .query("backgroundJobs")

--- a/convex/conversations.test.ts
+++ b/convex/conversations.test.ts
@@ -1022,7 +1022,7 @@ describe("conversations.stopGeneration", () => {
       stopGenerationHandler(ctx as MutationCtx, {
         conversationId,
       })
-    ).rejects.toThrow("Not authenticated");
+    ).rejects.toThrow("User not authenticated");
   });
 
   test("throws error when conversation not found", async () => {

--- a/convex/conversations.ts
+++ b/convex/conversations.ts
@@ -60,6 +60,8 @@ import {
 import {
   createDefaultConversationFields,
   createDefaultMessageFields,
+  getAuthenticatedUser,
+  getAuthenticatedUserWithData,
   getAuthenticatedUserWithDataForAction,
   hasConversationAccess,
   setConversationStreaming,
@@ -1447,17 +1449,7 @@ export const createEmpty = mutation({
   },
   returns: v.id("conversations"),
   handler: async (ctx, args) => {
-    // Get authenticated user ID (getAuthUserId returns Id<"users"> directly)
-    const userId = await getAuthUserId(ctx);
-    if (!userId) {
-      throw new Error("Not authenticated");
-    }
-
-    // Get user data for conversation count update
-    const user = await ctx.db.get("users", userId);
-    if (!user) {
-      throw new Error("User not found");
-    }
+    const { userId, user } = await getAuthenticatedUserWithData(ctx);
 
     // Create empty conversation with clientId for optimistic lookup
     const conversationId = await ctx.db.insert("conversations", {
@@ -2541,10 +2533,7 @@ export const stopGenerationHandler = async (
     reasoning?: string;
   }
 ) => {
-  const userId = await getAuthUserId(ctx);
-  if (!userId) {
-    throw new Error("Not authenticated");
-  }
+  const userId = await getAuthenticatedUser(ctx);
 
   const conversation = await ctx.db.get("conversations", args.conversationId);
   if (!conversation) {

--- a/convex/fileStorage.test.ts
+++ b/convex/fileStorage.test.ts
@@ -377,7 +377,7 @@ describe("fileStorage: getFileMetadata", () => {
 
     await expect(
       getFileMetadataHandler(ctx as QueryCtx, { storageId })
-    ).rejects.toThrow("Not authenticated");
+    ).rejects.toThrow("User not authenticated");
   });
 });
 
@@ -428,7 +428,7 @@ describe("fileStorage: getFileUrl", () => {
 
     await expect(
       getFileUrlHandler(ctx as QueryCtx, { storageId })
-    ).rejects.toThrow("Not authenticated");
+    ).rejects.toThrow("User not authenticated");
   });
 });
 
@@ -481,7 +481,7 @@ describe("fileStorage: deleteFile", () => {
 
     await expect(
       deleteFileHandler(ctx as MutationCtx, { storageId })
-    ).rejects.toThrow("Not authenticated");
+    ).rejects.toThrow("User not authenticated");
   });
 
   test("throws error when user does not own file", async () => {
@@ -950,7 +950,7 @@ describe("fileStorage: deleteMultipleFiles", () => {
 
     await expect(
       deleteMultipleFilesHandler(ctx as MutationCtx, { storageIds })
-    ).rejects.toThrow("Not authenticated");
+    ).rejects.toThrow("User not authenticated");
   });
 
   test("deletes files from storage", async () => {
@@ -1256,7 +1256,7 @@ describe("fileStorage: getUserFileStats", () => {
     });
 
     await expect(getUserFileStatsHandler(ctx as QueryCtx)).rejects.toThrow(
-      "Not authenticated"
+      "User not authenticated"
     );
   });
 

--- a/convex/imageModels.ts
+++ b/convex/imageModels.ts
@@ -10,7 +10,7 @@ import {
   query,
 } from "./_generated/server";
 import { imageModelDefinitionSchema } from "./lib/schemas";
-import { sanitizeSchema } from "./lib/shared_utils";
+import { getAuthenticatedUser, sanitizeSchema } from "./lib/shared_utils";
 
 // Helper function to determine if a model supports aspect_ratio parameter
 function determineAspectRatioSupport(
@@ -505,11 +505,7 @@ export const toggleImageModel = mutation({
     supportsNegativePrompt: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-
-    if (!userId) {
-      throw new Error("Authentication required");
-    }
+    const userId = await getAuthenticatedUser(ctx);
 
     // Check if model already exists
     const existingModel = await ctx.db
@@ -579,11 +575,7 @@ export const setSelectedImageModel = mutation({
     provider: v.string(),
   },
   handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-
-    if (!userId) {
-      throw new Error("Authentication required");
-    }
+    const userId = await getAuthenticatedUser(ctx);
 
     // Clear previous selection
     const selectedModels = await ctx.db

--- a/convex/stop_generation.test.ts
+++ b/convex/stop_generation.test.ts
@@ -60,7 +60,7 @@ describe("stopGeneration", () => {
       stopGenerationHandler(ctx as MutationCtx, {
         conversationId: "conv-123" as Id<"conversations">,
       })
-    ).rejects.toThrow("Not authenticated");
+    ).rejects.toThrow("User not authenticated");
   });
 
   test("throws if conversation not found", async () => {


### PR DESCRIPTION
## Summary

- Replaces ~30 inline auth-check-and-throw patterns with shared utility calls (`getAuthenticatedUser`, `getAuthenticatedUserWithData`, `validateConversationAccess`) from `convex/lib/shared_utils.ts`
- Updates 10 source files and 3 test files, net -162 lines
- Error message consistency: inline `new Error()` replaced with `ConvexError()` from the shared utilities (better client-side error serialization)

### Files changed
- `convex/conversations.ts` — 2 auth patterns replaced
- `convex/messages.ts` — 2 auth + 7 conversation access patterns replaced
- `convex/backgroundJobs.ts` — 2 auth patterns replaced
- `convex/fileStorage.ts` — 7 auth + 2 conversation access patterns replaced
- `convex/imageModels.ts` — 2 auth patterns replaced
- `convex/users.ts` — 3 auth patterns replaced
- `convex/userSettings.ts`, `convex/personas.ts`, `convex/apiKeys.ts`, `convex/sharedConversations.ts` — local `handleGetAuthenticatedUser` copies removed (extending PR #129)
- 3 test files updated for error message changes (`"Not authenticated"` → `"User not authenticated"`)

### Not changed (by design)
- Graceful-return patterns (queries returning null for unauthenticated users)
- Action-context patterns (`ActionCtx` — shared utilities only accept `MutationCtx | QueryCtx`)

## Test plan
- [x] `bun run check` passes (lint + types + build)
- [x] `bun run test` passes
- [ ] Manual: verify auth-gated mutations still reject unauthenticated requests
- [ ] Manual: verify conversation access checks still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)