### PR TITLE
refactor: Simplify action button ecosystem

### DIFF
--- a/src/components/chat/citation-avatar-stack.tsx
+++ b/src/components/chat/citation-avatar-stack.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { WebSearchCitation } from "@/types";
-import { actionButtonStyles } from "./message/action-button";
+import { ActionButton } from "./message/action-button";
 
 type CitationAvatarStackProps = {
   citations: WebSearchCitation[];
@@ -43,41 +43,37 @@ export function CitationAvatarStack({
 
   return (
     <Tooltip>
-      <TooltipTrigger>
-        <button
-          type="button"
-          onClick={onToggle}
-          className={cn(
-            actionButtonStyles.base,
-            actionButtonStyles.default,
-            "w-auto h-7 px-1 gap-1.5",
-            isExpanded && "bg-muted",
-            className
-          )}
-          aria-label={`${citations.length} source${citations.length === 1 ? "" : "s"}`}
-        >
-          <div className="flex items-center -space-x-2">
-            {visibleCitations.map((citation, index) => (
-              <Avatar
-                key={citation.url || `citation-${index}`}
-                className="h-5 w-5 border-2 border-muted"
-              >
-                {citation.favicon ? (
-                  <AvatarImage
-                    src={citation.favicon}
-                    alt={getDomain(citation.url)}
-                  />
-                ) : null}
-                <AvatarFallback className="text-[8px] bg-muted text-muted-foreground">
-                  {getInitials(citation.url)}
-                </AvatarFallback>
-              </Avatar>
-            ))}
-          </div>
-          <span className="text-xs font-medium text-muted-foreground">
-            {citations.length} source{citations.length === 1 ? "" : "s"}
-          </span>
-        </button>
+      <TooltipTrigger
+        render={
+          <ActionButton
+            size="label"
+            className={cn(isExpanded && "bg-muted", className)}
+          />
+        }
+        onClick={onToggle}
+        aria-label={`${citations.length} source${citations.length === 1 ? "" : "s"}`}
+      >
+        <div className="flex items-center -space-x-1.5">
+          {visibleCitations.map((citation, index) => (
+            <Avatar
+              key={citation.url || `citation-${index}`}
+              className="h-4 w-4 border border-muted"
+            >
+              {citation.favicon ? (
+                <AvatarImage
+                  src={citation.favicon}
+                  alt={getDomain(citation.url)}
+                />
+              ) : null}
+              <AvatarFallback className="text-[7px] bg-muted text-muted-foreground">
+                {getInitials(citation.url)}
+              </AvatarFallback>
+            </Avatar>
+          ))}
+        </div>
+        <span className="text-muted-foreground">
+          {citations.length} source{citations.length === 1 ? "" : "s"}
+        </span>
       </TooltipTrigger>
       <TooltipContent>
         <p>

--- a/src/components/chat/message/action-button.tsx
+++ b/src/components/chat/message/action-button.tsx
@@ -97,6 +97,7 @@ export function ActionButton({
     return (
       <Tooltip>
         <TooltipTrigger
+          delayDuration={200}
           render={<button ref={ref} type="button" className={chipClassName} />}
           aria-label={props["aria-label"] || tooltip}
           disabled={props.disabled}

--- a/src/components/chat/message/action-button.tsx
+++ b/src/components/chat/message/action-button.tsx
@@ -16,95 +16,93 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib";
 
-export type ActionButtonVariant = "default" | "destructive";
+// ============================================================================
+// ActionButton — the ONE base element for all action bar items
+// ============================================================================
 
-export type ActionButtonProps = {
-  icon: React.ReactNode;
-  tooltip: string;
-  onClick: () => void;
-  disabled?: boolean;
-  title?: string;
-  className?: string;
-  ariaLabel?: string;
-  /** Button variant - affects hover/active colors */
+export type ActionButtonVariant = "default" | "destructive";
+export type ActionButtonSize = "icon" | "label";
+
+type ActionButtonProps = React.ComponentProps<"button"> & {
   variant?: ActionButtonVariant;
+  /** `icon` (default) = fixed square, `label` = auto-width with padding */
+  size?: ActionButtonSize;
+  /** When set, wraps the chip in a Tooltip with this text */
+  tooltip?: string;
+  ref?: React.Ref<HTMLButtonElement>;
 };
 
-// Base styles shared by all variants
-const baseStyles = [
+const chipBase = [
+  "appearance-none",
   "flex items-center justify-center",
-  "h-7 w-7 rounded-md",
+  "h-6 rounded-md",
   "border border-transparent",
+  "text-muted-foreground text-xs",
   "transition-all duration-200 ease-out",
-  "motion-safe:hover:scale-105",
   "disabled:pointer-events-none disabled:opacity-50",
 ].join(" ");
 
-// Default variant: subtle gray hover
-const defaultStyles = [
-  "text-muted-foreground",
-  "hover:bg-muted/50 hover:border-border/50 hover:text-foreground",
-  "active:bg-muted",
-].join(" ");
+const chipSizes: Record<ActionButtonSize, string> = {
+  icon: "w-6",
+  label: "w-auto px-1.5 gap-1",
+};
 
-// Destructive variant: red hover
-const destructiveStyles = [
-  "text-muted-foreground",
-  "hover:bg-destructive/10 hover:border-destructive/30 hover:text-destructive",
-  "active:bg-destructive/15",
-].join(" ");
-
-const variantStyles: Record<ActionButtonVariant, string> = {
-  default: defaultStyles,
-  destructive: destructiveStyles,
+const chipVariants: Record<ActionButtonVariant, string> = {
+  default: [
+    "hover:bg-muted/50 hover:border-border/50 hover:text-foreground",
+    "active:bg-muted",
+  ].join(" "),
+  destructive: [
+    "hover:bg-destructive/10 hover:border-destructive/30 hover:text-destructive",
+    "active:bg-destructive/15",
+  ].join(" "),
 };
 
 /**
- * Export style utilities for use with external trigger components
- * (e.g., ResponsivePicker triggers that can't use ActionButton directly)
+ * Returns the computed class string for an ActionButton.
+ * Use this when you need the className but can't render an `<ActionButton>` element
+ * (e.g. passing `triggerClassName` to `ResponsivePicker`).
  */
-export const actionButtonStyles = {
-  base: baseStyles,
-  default: defaultStyles,
-  destructive: destructiveStyles,
-  /** Combined base + default styles */
-  get defaultButton() {
-    return `${baseStyles} ${defaultStyles}`;
-  },
-  /** Combined base + destructive styles */
-  get destructiveButton() {
-    return `${baseStyles} ${destructiveStyles}`;
-  },
-};
+export function actionButtonClass(
+  opts: { variant?: ActionButtonVariant; size?: ActionButtonSize } = {}
+): string {
+  const { variant = "default", size = "icon" } = opts;
+  return `${chipBase} ${chipSizes[size]} ${chipVariants[variant]}`;
+}
 
 /**
- * Standard action button with tooltip, consistent sizing, and hover effects.
- * Use for icon-only action buttons in toolbars, message actions, etc.
+ * Base visual element for ALL action bar items.
+ * Use `size="icon"` (default) for square icon buttons,
+ * `size="label"` for text chips (gen stats, model badge, sources).
+ *
+ * When `tooltip` is set, the chip wraps itself in a `Tooltip`.
+ * When absent, renders a bare `<button>` (for composition via external `render` props).
  */
-export const ActionButton = memo(
-  ({
-    icon,
-    tooltip,
-    onClick,
-    disabled,
-    title,
-    className,
-    ariaLabel,
-    variant = "default",
-  }: ActionButtonProps) => {
+export function ActionButton({
+  className,
+  variant = "default",
+  size = "icon",
+  tooltip,
+  ref,
+  ...props
+}: ActionButtonProps) {
+  const chipClassName = cn(
+    chipBase,
+    chipSizes[size],
+    chipVariants[variant],
+    className
+  );
+
+  if (tooltip) {
     return (
       <Tooltip>
-        <TooltipTrigger delayDuration={200}>
-          <button
-            type="button"
-            className={cn(baseStyles, variantStyles[variant], className)}
-            disabled={disabled}
-            title={title}
-            aria-label={ariaLabel || tooltip}
-            onClick={onClick}
-          >
-            {icon}
-          </button>
+        <TooltipTrigger
+          render={<button ref={ref} type="button" className={chipClassName} />}
+          aria-label={props["aria-label"] || tooltip}
+          disabled={props.disabled}
+          onClick={props.onClick}
+        >
+          {props.children}
         </TooltipTrigger>
         <TooltipContent>
           <p>{tooltip}</p>
@@ -112,160 +110,122 @@ export const ActionButton = memo(
       </Tooltip>
     );
   }
-);
 
-ActionButton.displayName = "ActionButton";
+  return (
+    <button ref={ref} type="button" className={chipClassName} {...props} />
+  );
+}
 
-// ============================================================================
-// Icon wrapper for consistent sizing
-// ============================================================================
-
-type ActionIconProps = {
-  className?: string;
-};
+/** Icon size for mobile drawer items (size-4) */
+export const DRAWER_ICON_SIZE = "size-4";
 
 const iconClass = "size-3.5";
 
 // ============================================================================
-// Icon size constants for consistent sizing across components
+// Preset action buttons
 // ============================================================================
 
-/** Icon size for desktop action buttons (size-3.5) */
-export const ACTION_ICON_SIZE = "size-3.5";
-/** Icon size for mobile drawer items (size-4) */
-export const DRAWER_ICON_SIZE = "size-4";
-
-/**
- * Pre-styled icons for use with ActionButton.
- * All icons have consistent sizing (h-3.5 w-3.5) and aria-hidden.
- */
-export const ActionIcon = {
-  Copy: ({ className }: ActionIconProps = {}) => (
-    <CopyIcon className={cn(iconClass, className)} aria-hidden="true" />
-  ),
-  Check: ({ className }: ActionIconProps = {}) => (
-    <CheckIcon className={cn(iconClass, className)} aria-hidden="true" />
-  ),
-  Edit: ({ className }: ActionIconProps = {}) => (
-    <NotePencilIcon className={cn(iconClass, className)} aria-hidden="true" />
-  ),
-  Delete: ({ className }: ActionIconProps = {}) => (
-    <TrashIcon className={cn(iconClass, className)} aria-hidden="true" />
-  ),
-  Favorite: ({ className, filled }: ActionIconProps & { filled?: boolean }) => (
-    <HeartIcon
-      className={cn(iconClass, className)}
-      weight={filled ? "fill" : "regular"}
-      aria-hidden="true"
-    />
-  ),
-  Branch: ({ className }: ActionIconProps = {}) => (
-    <GitBranchIcon className={cn(iconClass, className)} aria-hidden="true" />
-  ),
-  Retry: ({ className }: ActionIconProps = {}) => (
-    <ArrowCounterClockwiseIcon
-      className={cn(iconClass, className)}
-      aria-hidden="true"
-    />
-  ),
-  ZenMode: ({ className }: ActionIconProps = {}) => (
-    <TextAaIcon className={cn(iconClass, className)} aria-hidden="true" />
-  ),
-};
-
-// ============================================================================
-// Preset action buttons for common use cases
-// ============================================================================
-
-type PresetActionButtonProps = Omit<
-  ActionButtonProps,
-  "icon" | "variant" | "tooltip"
-> & {
-  /** Override the default tooltip */
+type PresetActionButtonProps = {
+  onClick: () => void;
+  disabled?: boolean;
+  title?: string;
+  className?: string;
+  ariaLabel?: string;
   tooltip?: string;
-  /** For copy button: whether currently showing copied state */
   copied?: boolean;
-  /** For favorite button: whether currently favorited */
   favorited?: boolean;
 };
 
-/**
- * Pre-configured action buttons for common actions.
- * These combine the icon, variant, and sensible defaults.
- */
 export const ActionButtons = {
-  Copy: memo(({ copied, tooltip, ...props }: PresetActionButtonProps) => (
-    <ActionButton
-      icon={
-        copied ? (
-          <ActionIcon.Check className="text-primary animate-copy-success" />
-        ) : (
-          <ActionIcon.Copy />
-        )
-      }
-      tooltip={tooltip || (copied ? "Copied!" : "Copy")}
-      {...props}
-    />
-  )),
-
-  Delete: memo(({ tooltip, ...props }: PresetActionButtonProps) => (
-    <ActionButton
-      variant="destructive"
-      icon={<ActionIcon.Delete />}
-      tooltip={tooltip || "Delete"}
-      {...props}
-    />
-  )),
-
-  Edit: memo(({ tooltip, ...props }: PresetActionButtonProps) => (
-    <ActionButton
-      icon={<ActionIcon.Edit />}
-      tooltip={tooltip || "Edit"}
-      {...props}
-    />
-  )),
-
-  Favorite: memo(
-    ({ favorited, tooltip, ...props }: PresetActionButtonProps) => (
+  Copy: memo(
+    ({ copied, tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
       <ActionButton
-        icon={
-          <ActionIcon.Favorite
-            filled={favorited}
-            className={favorited ? "text-destructive" : undefined}
-          />
-        }
-        tooltip={tooltip || (favorited ? "Unfavorite" : "Favorite")}
+        tooltip={tooltip || (copied ? "Copied!" : "Copy")}
+        aria-label={ariaLabel || tooltip || (copied ? "Copied!" : "Copy")}
         {...props}
-      />
+      >
+        {copied ? (
+          <CheckIcon
+            className={cn(iconClass, "text-primary animate-copy-success")}
+            aria-hidden="true"
+          />
+        ) : (
+          <CopyIcon className={iconClass} aria-hidden="true" />
+        )}
+      </ActionButton>
     )
   ),
 
-  Branch: memo(({ tooltip, ...props }: PresetActionButtonProps) => (
+  Delete: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
     <ActionButton
-      icon={<ActionIcon.Branch />}
+      variant="destructive"
+      tooltip={tooltip || "Delete"}
+      aria-label={ariaLabel || tooltip || "Delete"}
+      {...props}
+    >
+      <TrashIcon className={iconClass} aria-hidden="true" />
+    </ActionButton>
+  )),
+
+  Edit: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
+    <ActionButton
+      tooltip={tooltip || "Edit"}
+      aria-label={ariaLabel || tooltip || "Edit"}
+      {...props}
+    >
+      <NotePencilIcon className={iconClass} aria-hidden="true" />
+    </ActionButton>
+  )),
+
+  Favorite: memo(
+    ({ favorited, tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
+      <ActionButton
+        tooltip={tooltip || (favorited ? "Unfavorite" : "Favorite")}
+        aria-label={
+          ariaLabel || tooltip || (favorited ? "Unfavorite" : "Favorite")
+        }
+        {...props}
+      >
+        <HeartIcon
+          className={cn(iconClass, favorited && "text-destructive")}
+          weight={favorited ? "fill" : "regular"}
+          aria-hidden="true"
+        />
+      </ActionButton>
+    )
+  ),
+
+  Branch: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
+    <ActionButton
       tooltip={tooltip || "Branch from here"}
+      aria-label={ariaLabel || tooltip || "Branch from here"}
       {...props}
-    />
+    >
+      <GitBranchIcon className={iconClass} aria-hidden="true" />
+    </ActionButton>
   )),
 
-  Retry: memo(({ tooltip, ...props }: PresetActionButtonProps) => (
+  Retry: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
     <ActionButton
-      icon={<ActionIcon.Retry />}
       tooltip={tooltip || "Retry"}
+      aria-label={ariaLabel || tooltip || "Retry"}
       {...props}
-    />
+    >
+      <ArrowCounterClockwiseIcon className={iconClass} aria-hidden="true" />
+    </ActionButton>
   )),
 
-  ZenMode: memo(({ tooltip, ...props }: PresetActionButtonProps) => (
+  ZenMode: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
     <ActionButton
-      icon={<ActionIcon.ZenMode />}
       tooltip={tooltip || "Zen mode"}
+      aria-label={ariaLabel || tooltip || "Zen mode"}
       {...props}
-    />
+    >
+      <TextAaIcon className={iconClass} aria-hidden="true" />
+    </ActionButton>
   )),
 };
 
-// Set display names for debugging
 ActionButtons.Copy.displayName = "ActionButtons.Copy";
 ActionButtons.Delete.displayName = "ActionButtons.Delete";
 ActionButtons.Edit.displayName = "ActionButtons.Edit";
@@ -286,10 +246,6 @@ type DrawerItemProps = {
   destructive?: boolean;
 };
 
-/**
- * Standard drawer item for mobile menus.
- * Provides consistent styling for full-width list items with icons.
- */
 export const DrawerItem = memo(function DrawerItem({
   icon,
   children,

--- a/src/components/chat/message/image-actions.test.tsx
+++ b/src/components/chat/message/image-actions.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import type React from "react";
+import React from "react";
 import { TestProviders } from "../../../../test/TestProviders";
 import { ImageActions } from "./image-actions";
 
@@ -27,7 +27,25 @@ mock.module("@/lib/export", () => ({
 // Mock tooltip components to avoid context requirements
 mock.module("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
-  TooltipTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    render,
+    onClick,
+    disabled,
+    delayDuration: _delayDuration, // eslint-disable-line @typescript-eslint/no-unused-vars
+    ...props
+  }: React.PropsWithChildren<{
+    render?: React.ReactElement;
+    onClick?: () => void;
+    disabled?: boolean;
+    delayDuration?: number;
+  }>) => {
+    // If render prop is provided, clone it with the onClick and disabled props
+    if (render) {
+      return React.cloneElement(render, { onClick, disabled, ...props });
+    }
+    return <>{children}</>;
+  },
   TooltipContent: () => null,
 }));
 

--- a/src/components/chat/message/image-actions.tsx
+++ b/src/components/chat/message/image-actions.tsx
@@ -14,7 +14,7 @@ import {
 import { downloadFromUrl } from "@/lib/export";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/providers/toast-context";
-import { actionButtonStyles } from "./action-button";
+import { ActionButton } from "./action-button";
 import {
   type AspectRatioValue,
   type ImageRetryParams,
@@ -142,24 +142,13 @@ export const ImageActions = ({
   if (minimal) {
     return (
       <div className={cn("flex items-center gap-1", className)}>
-        <Tooltip>
-          <TooltipTrigger>
-            <button
-              type="button"
-              onClick={handleCopyPrompt}
-              disabled={isCopying || !prompt}
-              className={cn(
-                actionButtonStyles.defaultButton,
-                (isCopying || !prompt) && "pointer-events-none opacity-50"
-              )}
-            >
-              <CopyIcon className="size-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>
-            {prompt ? "Copy prompt to clipboard" : "No prompt available"}
-          </TooltipContent>
-        </Tooltip>
+        <ActionButton
+          tooltip={prompt ? "Copy prompt to clipboard" : "No prompt available"}
+          onClick={handleCopyPrompt}
+          disabled={isCopying || !prompt}
+        >
+          <CopyIcon className="size-3.5" />
+        </ActionButton>
 
         {onRetry && (
           <ImageRetryPopover
@@ -180,20 +169,14 @@ export const ImageActions = ({
           <Tooltip>
             <TooltipTrigger>
               <DropdownMenuTrigger>
-                <button
-                  type="button"
+                <ActionButton
+                  size="label"
+                  className="h-7 gap-0.5"
                   disabled={isCopying || (!prompt && seed === undefined)}
-                  className={cn(
-                    actionButtonStyles.base,
-                    actionButtonStyles.default,
-                    "w-auto h-7 px-1.5 gap-0.5",
-                    (isCopying || (!prompt && seed === undefined)) &&
-                      "pointer-events-none opacity-50"
-                  )}
                 >
                   <CopyIcon className="size-3.5" />
                   <CaretDownIcon className="size-3" />
-                </button>
+                </ActionButton>
               </DropdownMenuTrigger>
             </TooltipTrigger>
             <TooltipContent>Copy generation details</TooltipContent>
@@ -218,42 +201,22 @@ export const ImageActions = ({
           </DropdownMenuContent>
         </DropdownMenu>
       ) : (
-        <Tooltip>
-          <TooltipTrigger>
-            <button
-              type="button"
-              onClick={handleCopyPrompt}
-              disabled={isCopying || !prompt}
-              className={cn(
-                actionButtonStyles.defaultButton,
-                (isCopying || !prompt) && "pointer-events-none opacity-50"
-              )}
-            >
-              <CopyIcon className="size-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>
-            {prompt ? "Copy prompt to clipboard" : "No prompt available"}
-          </TooltipContent>
-        </Tooltip>
+        <ActionButton
+          tooltip={prompt ? "Copy prompt to clipboard" : "No prompt available"}
+          onClick={handleCopyPrompt}
+          disabled={isCopying || !prompt}
+        >
+          <CopyIcon className="size-3.5" />
+        </ActionButton>
       )}
 
-      <Tooltip>
-        <TooltipTrigger delayDuration={200}>
-          <button
-            type="button"
-            onClick={handleDownloadImage}
-            disabled={isDownloading}
-            className={cn(
-              actionButtonStyles.defaultButton,
-              isDownloading && "pointer-events-none opacity-50"
-            )}
-          >
-            <DownloadIcon className="size-3.5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>Download image</TooltipContent>
-      </Tooltip>
+      <ActionButton
+        tooltip="Download image"
+        onClick={handleDownloadImage}
+        disabled={isDownloading}
+      >
+        <DownloadIcon className="size-3.5" />
+      </ActionButton>
 
       {onRetry && (
         <ImageRetryPopover

--- a/src/components/chat/message/image-generation-bubble.tsx
+++ b/src/components/chat/message/image-generation-bubble.tsx
@@ -4,15 +4,10 @@ import { TrashIcon } from "@phosphor-icons/react";
 import { useQuery } from "convex/react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useHoverLinger } from "@/hooks/use-hover-linger";
 import { cn } from "@/lib/utils";
 import type { Attachment, ChatMessage as ChatMessageType } from "@/types";
-import { actionButtonStyles } from "./action-button";
+import { ActionButton } from "./action-button";
 import { ImageActions, type ImageRetryParams } from "./image-actions";
 import { ImageCardStack } from "./image-card-stack";
 import { ImageGenerationSkeleton } from "./image-generation-skeleton";
@@ -552,22 +547,14 @@ export const ImageGenerationBubble = ({
             />
 
             {onDeleteMessage && (
-              <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    type="button"
-                    onClick={onDeleteMessage}
-                    disabled={isDeleting}
-                    className={cn(
-                      actionButtonStyles.destructiveButton,
-                      isDeleting && "pointer-events-none opacity-50"
-                    )}
-                  >
-                    <TrashIcon className="size-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Delete message</TooltipContent>
-              </Tooltip>
+              <ActionButton
+                variant="destructive"
+                tooltip="Delete message"
+                onClick={onDeleteMessage}
+                disabled={isDeleting}
+              >
+                <TrashIcon className="size-3.5" />
+              </ActionButton>
             )}
           </div>
 
@@ -602,22 +589,14 @@ export const ImageGenerationBubble = ({
             />
 
             {onDeleteMessage && (
-              <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    type="button"
-                    onClick={onDeleteMessage}
-                    disabled={isDeleting}
-                    className={cn(
-                      actionButtonStyles.destructiveButton,
-                      isDeleting && "pointer-events-none opacity-50"
-                    )}
-                  >
-                    <TrashIcon className="size-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Delete message</TooltipContent>
-              </Tooltip>
+              <ActionButton
+                variant="destructive"
+                tooltip="Delete message"
+                onClick={onDeleteMessage}
+                disabled={isDeleting}
+              >
+                <TrashIcon className="size-3.5" />
+              </ActionButton>
             )}
           </div>
 

--- a/src/components/chat/message/image-retry-popover.tsx
+++ b/src/components/chat/message/image-retry-popover.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowCounterClockwiseIcon,
   DeviceMobile,
   DeviceTabletCamera,
   FrameCorners,
@@ -19,11 +20,7 @@ import {
 import { ResponsivePicker } from "@/components/ui/responsive-picker";
 import { useEnabledImageModels, useMediaQuery } from "@/hooks";
 import { cn } from "@/lib";
-import {
-  ActionIcon,
-  actionButtonStyles,
-  DRAWER_ICON_SIZE,
-} from "./action-button";
+import { actionButtonClass, DRAWER_ICON_SIZE } from "./action-button";
 
 const ASPECT_RATIOS = [
   { value: "1:1", label: "Square", icon: Square },
@@ -99,7 +96,9 @@ export function ImageRetryPopover({
     r => r.value === selectedAspectRatio
   );
 
-  const triggerContent = <ActionIcon.Retry />;
+  const triggerContent = (
+    <ArrowCounterClockwiseIcon className="size-3.5" aria-hidden="true" />
+  );
 
   return (
     <ResponsivePicker
@@ -113,7 +112,7 @@ export function ImageRetryPopover({
       contentClassName={isDesktop ? "w-80 p-0" : "stack-lg"}
       align="start"
       ariaLabel="Retry image generation"
-      triggerClassName={cn(actionButtonStyles.defaultButton, className)}
+      triggerClassName={cn(actionButtonClass(), className)}
     >
       {isDesktop ? (
         <DesktopContent
@@ -244,7 +243,10 @@ function DesktopContent({
           Cancel
         </Button>
         <Button size="sm" onClick={onRetry} disabled={!selectedModel}>
-          <ActionIcon.Retry className="mr-1.5" />
+          <ArrowCounterClockwiseIcon
+            className="size-3.5 mr-1.5"
+            aria-hidden="true"
+          />
           Retry
         </Button>
       </PickerFooter>
@@ -357,7 +359,10 @@ function MobileContent({
           Cancel
         </Button>
         <Button className="flex-1" onClick={onRetry} disabled={!selectedModel}>
-          <ActionIcon.Retry className="mr-1.5 size-4" />
+          <ArrowCounterClockwiseIcon
+            className="size-4 mr-1.5"
+            aria-hidden="true"
+          />
           Retry
         </Button>
       </div>

--- a/src/components/chat/message/message-actions.tsx
+++ b/src/components/chat/message/message-actions.tsx
@@ -14,8 +14,6 @@ import type React from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ProviderIcon } from "@/components/models/provider-icons";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Drawer,
   DrawerBody,
@@ -46,7 +44,6 @@ import { CitationAvatarStack } from "../citation-avatar-stack";
 import {
   ActionButton,
   ActionButtons,
-  actionButtonStyles,
   DRAWER_ICON_SIZE,
   DrawerItem,
 } from "./action-button";
@@ -336,7 +333,7 @@ export const MessageActions = memo(
     }
 
     const containerClassName = cn(
-      "flex items-center gap-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100",
+      "flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100",
       "translate-y-0 sm:translate-y-1 sm:group-hover:translate-y-0",
       "transition-all duration-200 ease-out",
       "@media (prefers-reduced-motion: reduce) { transition-duration: 0ms; opacity: 100; transform: none }",
@@ -427,267 +424,238 @@ export const MessageActions = memo(
 
     return (
       <div className={containerClassName}>
-        <div className="flex items-center gap-1">
-          {/* Mobile: Overflow drawer */}
-          {hasOverflowActions && (
-            <div className="sm:hidden">
-              <Drawer
-                open={isOverflowDrawerOpen}
-                onOpenChange={setIsOverflowDrawerOpen}
-              >
-                <Tooltip>
-                  <TooltipTrigger>
-                    <DrawerTrigger>
-                      <button
-                        type="button"
-                        className={cn(
-                          actionButtonStyles.defaultButton,
-                          isEditing && "pointer-events-none opacity-50"
-                        )}
-                        disabled={isEditing}
-                        aria-label="More actions"
-                      >
-                        <DotsThreeIcon
-                          className="size-3.5"
-                          aria-hidden="true"
-                        />
-                      </button>
-                    </DrawerTrigger>
+        {/* Mobile: Overflow drawer */}
+        {hasOverflowActions && (
+          <div className="sm:hidden">
+            <Drawer
+              open={isOverflowDrawerOpen}
+              onOpenChange={setIsOverflowDrawerOpen}
+            >
+              <Tooltip>
+                <DrawerTrigger asChild>
+                  <TooltipTrigger
+                    render={<ActionButton />}
+                    disabled={isEditing}
+                    aria-label="More actions"
+                  >
+                    <DotsThreeIcon className="size-3.5" aria-hidden="true" />
                   </TooltipTrigger>
-                  <TooltipContent>
-                    <p>More actions</p>
-                  </TooltipContent>
-                </Tooltip>
+                </DrawerTrigger>
+                <TooltipContent>
+                  <p>More actions</p>
+                </TooltipContent>
+              </Tooltip>
 
-                <DrawerContent>
-                  <DrawerHeader>
-                    <DrawerTitle>More actions</DrawerTitle>
-                  </DrawerHeader>
-                  <DrawerBody>
-                    <div className="flex flex-col">
-                      {renderOverflowDrawerItems()}
-                    </div>
-                  </DrawerBody>
-                </DrawerContent>
-              </Drawer>
-            </div>
-          )}
-
-          {/* Desktop: Individual action buttons */}
-          <div className="hidden sm:flex sm:items-center sm:gap-1">
-            {onEditMessage && (
-              <ActionButtons.Edit
-                disabled={isEditing}
-                tooltip="Edit message"
-                ariaLabel="Edit this message"
-                onClick={onEditMessage}
-              />
-            )}
-
-            {!isPrivateMode && messageId && conversationId && (
-              <BranchActionButton
-                conversationId={conversationId}
-                messageId={messageId}
-                isEditing={isEditing}
-                onSuccess={newConversationId => {
-                  navigate(ROUTES.CHAT_CONVERSATION(newConversationId));
-                }}
-              />
-            )}
-
-            {!isPrivateMode &&
-              messageId &&
-              !messageId.startsWith("private-") && (
-                <ActionButtons.Favorite
-                  disabled={isEditing}
-                  favorited={isFavorited}
-                  ariaLabel={
-                    isFavorited ? "Remove from favorites" : "Add to favorites"
-                  }
-                  onClick={handleToggleFavorite}
-                />
-              )}
-
-            {!isUser && messageId && (
-              <ActionButton
-                disabled={isEditing}
-                tooltip={getTTSTooltip(ttsState)}
-                ariaLabel={getTTSTooltip(ttsState)}
-                icon={getTTSIconForButton(ttsState)}
-                onClick={handleTTS}
-              />
-            )}
-
-            {!isUser && onOpenZenMode && (
-              <ActionButtons.ZenMode
-                disabled={isEditing}
-                ariaLabel="Open Zen mode"
-                onClick={onOpenZenMode}
-              />
-            )}
+              <DrawerContent>
+                <DrawerHeader>
+                  <DrawerTitle>More actions</DrawerTitle>
+                </DrawerHeader>
+                <DrawerBody>
+                  <div className="flex flex-col">
+                    {renderOverflowDrawerItems()}
+                  </div>
+                </DrawerBody>
+              </DrawerContent>
+            </Drawer>
           </div>
+        )}
 
-          {/* Primary actions: Copy, Retry, Delete */}
-          <ActionButtons.Copy
-            disabled={isEditing}
-            copied={isCopied}
-            tooltip="Copy message"
-            ariaLabel={
-              isCopied
-                ? "Message copied to clipboard"
-                : "Copy message to clipboard"
-            }
-            onClick={copyToClipboard}
-          />
-
-          {/* Image generation messages use dedicated popover */}
-          {isImageGenerationMessage && onRetryImageGeneration && (
-            <ImageRetryPopover
-              currentModel={imageGenerationParams?.model}
-              currentAspectRatio={imageGenerationParams?.aspectRatio}
-              onRetry={onRetryImageGeneration}
+        {/* Desktop: Individual action buttons */}
+        <div className="hidden sm:flex sm:items-center sm:gap-1">
+          {onEditMessage && (
+            <ActionButtons.Edit
+              disabled={isEditing}
+              tooltip="Edit message"
+              ariaLabel="Edit this message"
+              onClick={onEditMessage}
             />
           )}
 
-          {/* Text messages use the regular retry dropdown */}
-          {!isImageGenerationMessage && onRetryMessage && (
-            <RetryDropdown
-              isUser={isUser}
-              isRetrying={isRetrying}
-              isStreaming={isStreaming}
-              isEditing={isEditing}
+          {!isPrivateMode && messageId && conversationId && (
+            <BranchActionButton
+              conversationId={conversationId}
               messageId={messageId}
-              onRetry={onRetryMessage}
-              onRefine={onRefineMessage}
-              onDropdownOpenChange={setIsDropdownOpen}
-              currentModel={model}
-              currentProvider={provider}
+              isEditing={isEditing}
+              onSuccess={newConversationId => {
+                navigate(ROUTES.CHAT_CONVERSATION(newConversationId));
+              }}
             />
           )}
 
-          {onDeleteMessage && (
-            <ActionButtons.Delete
-              disabled={isEditing || isDeleting || isStreaming}
-              title="Delete message"
-              ariaLabel="Delete this message permanently"
-              onClick={onDeleteMessage}
+          {!isPrivateMode && messageId && !messageId.startsWith("private-") && (
+            <ActionButtons.Favorite
+              disabled={isEditing}
+              favorited={isFavorited}
+              ariaLabel={
+                isFavorited ? "Remove from favorites" : "Add to favorites"
+              }
+              onClick={handleToggleFavorite}
             />
           )}
 
-          {/* Metadata Display */}
-          {showMetadata && tokenUsage && (
-            <Popover>
-              <PopoverTrigger>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 gap-1.5 px-2 text-overline font-medium text-primary sm:text-muted-foreground hover:text-foreground/80 hover:bg-muted/50"
-                >
-                  {/* Desktop: Show full text */}
-                  <span className="hidden sm:inline">
-                    {tokenUsage.totalTokens} tokens
-                  </span>
-                  {metadata?.tokensPerSecond && (
-                    <span className="hidden sm:inline">
-                      <span className="text-muted-foreground/30">&middot;</span>
-                      <span>{Math.round(metadata.tokensPerSecond)} t/s</span>
-                    </span>
-                  )}
-                  {/* Mobile: Show only icon */}
-                  <ChartBarIcon
-                    className="size-3.5 sm:hidden"
-                    aria-hidden="true"
-                  />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-64 p-3" align="start" side="top">
-                <div className="stack-md">
-                  <div className="flex items-center justify-between border-b pb-2">
-                    <span className="text-xs font-semibold">
-                      Generation Stats
-                    </span>
-                    <span className="text-overline text-muted-foreground font-mono">
-                      {metadata?.providerMessageId?.slice(0, 8)}
-                    </span>
-                  </div>
-
-                  <div className="grid gap-2 text-xs">
-                    <div className="flex justify-between items-center">
-                      <span className="text-muted-foreground">
-                        Input Tokens
-                      </span>
-                      <span className="font-mono">
-                        {tokenUsage.inputTokens.toLocaleString()}
-                      </span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-muted-foreground">
-                        Output Tokens
-                      </span>
-                      <span className="font-mono">
-                        {tokenUsage.outputTokens.toLocaleString()}
-                      </span>
-                    </div>
-                    <div className="flex justify-between items-center border-t pt-2 mt-1 font-medium">
-                      <span>Total Tokens</span>
-                      <span className="font-mono">
-                        {tokenUsage.totalTokens.toLocaleString()}
-                      </span>
-                    </div>
-                  </div>
-
-                  {(metadata?.timeToFirstTokenMs ||
-                    metadata?.tokensPerSecond) && (
-                    <div className="grid gap-2 text-xs border-t pt-2">
-                      {metadata.timeToFirstTokenMs && (
-                        <div className="flex justify-between items-center">
-                          <span className="text-muted-foreground">
-                            Time to First Token
-                          </span>
-                          <span className="font-mono">
-                            {metadata.timeToFirstTokenMs}ms
-                          </span>
-                        </div>
-                      )}
-                      {metadata.tokensPerSecond && (
-                        <div className="flex justify-between items-center">
-                          <span className="text-muted-foreground">
-                            Generation Speed
-                          </span>
-                          <span className="font-mono">
-                            {metadata.tokensPerSecond.toFixed(1)} t/s
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </PopoverContent>
-            </Popover>
+          {!isUser && messageId && (
+            <ActionButton
+              disabled={isEditing}
+              tooltip={getTTSTooltip(ttsState)}
+              aria-label={getTTSTooltip(ttsState)}
+              onClick={handleTTS}
+            >
+              {getTTSIconForButton(ttsState)}
+            </ActionButton>
           )}
 
-          {/* Citations avatar stack */}
-          {!isUser &&
-            citations &&
-            citations.length > 0 &&
-            onToggleCitations && (
-              <CitationAvatarStack
-                citations={citations}
-                isExpanded={citationsExpanded}
-                onToggle={onToggleCitations}
-              />
-            )}
+          {!isUser && onOpenZenMode && (
+            <ActionButtons.ZenMode
+              disabled={isEditing}
+              ariaLabel="Open Zen mode"
+              onClick={onOpenZenMode}
+            />
+          )}
         </div>
 
-        {!isUser && model && provider && (
-          <Badge variant="outline" size="sm" className="text-muted-foreground">
-            <div className="flex items-center gap-1.5">
-              {provider !== "replicate" && (
-                <ProviderIcon className="h-3 w-3" provider={provider} />
+        {/* Primary actions: Copy, Retry, Delete */}
+        <ActionButtons.Copy
+          disabled={isEditing}
+          copied={isCopied}
+          tooltip="Copy message"
+          ariaLabel={
+            isCopied
+              ? "Message copied to clipboard"
+              : "Copy message to clipboard"
+          }
+          onClick={copyToClipboard}
+        />
+
+        {/* Image generation messages use dedicated popover */}
+        {isImageGenerationMessage && onRetryImageGeneration && (
+          <ImageRetryPopover
+            currentModel={imageGenerationParams?.model}
+            currentAspectRatio={imageGenerationParams?.aspectRatio}
+            onRetry={onRetryImageGeneration}
+          />
+        )}
+
+        {/* Text messages use the regular retry dropdown */}
+        {!isImageGenerationMessage && onRetryMessage && (
+          <RetryDropdown
+            isUser={isUser}
+            isRetrying={isRetrying}
+            isStreaming={isStreaming}
+            isEditing={isEditing}
+            messageId={messageId}
+            onRetry={onRetryMessage}
+            onRefine={onRefineMessage}
+            onDropdownOpenChange={setIsDropdownOpen}
+            currentModel={model}
+            currentProvider={provider}
+          />
+        )}
+
+        {onDeleteMessage && (
+          <ActionButtons.Delete
+            disabled={isEditing || isDeleting || isStreaming}
+            title="Delete message"
+            ariaLabel="Delete this message permanently"
+            onClick={onDeleteMessage}
+          />
+        )}
+
+        {/* Metadata Display */}
+        {showMetadata && tokenUsage && (
+          <Popover>
+            <PopoverTrigger render={<ActionButton size="label" />}>
+              {/* Desktop: Show full text */}
+              <span className="hidden sm:inline">
+                {tokenUsage.totalTokens} tokens
+              </span>
+              {metadata?.tokensPerSecond && (
+                <span className="hidden sm:inline">
+                  <span className="text-muted-foreground/30">&middot;</span>
+                  <span>{Math.round(metadata.tokensPerSecond)} t/s</span>
+                </span>
               )}
-              <span className="hidden sm:inline">{modelTitle}</span>
-            </div>
-          </Badge>
+              {/* Mobile: Show only icon */}
+              <ChartBarIcon className="size-3.5 sm:hidden" aria-hidden="true" />
+            </PopoverTrigger>
+            <PopoverContent className="w-64 p-3" align="start" side="top">
+              <div className="stack-md">
+                <div className="flex items-center justify-between border-b pb-2">
+                  <span className="text-xs font-semibold">
+                    Generation Stats
+                  </span>
+                  <span className="text-overline text-muted-foreground font-mono">
+                    {metadata?.providerMessageId?.slice(0, 8)}
+                  </span>
+                </div>
+
+                <div className="grid gap-2 text-xs">
+                  <div className="flex justify-between items-center">
+                    <span className="text-muted-foreground">Input Tokens</span>
+                    <span className="font-mono">
+                      {tokenUsage.inputTokens.toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <span className="text-muted-foreground">Output Tokens</span>
+                    <span className="font-mono">
+                      {tokenUsage.outputTokens.toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center border-t pt-2 mt-1 font-medium">
+                    <span>Total Tokens</span>
+                    <span className="font-mono">
+                      {tokenUsage.totalTokens.toLocaleString()}
+                    </span>
+                  </div>
+                </div>
+
+                {(metadata?.timeToFirstTokenMs ||
+                  metadata?.tokensPerSecond) && (
+                  <div className="grid gap-2 text-xs border-t pt-2">
+                    {metadata.timeToFirstTokenMs && (
+                      <div className="flex justify-between items-center">
+                        <span className="text-muted-foreground">
+                          Time to First Token
+                        </span>
+                        <span className="font-mono">
+                          {metadata.timeToFirstTokenMs}ms
+                        </span>
+                      </div>
+                    )}
+                    {metadata.tokensPerSecond && (
+                      <div className="flex justify-between items-center">
+                        <span className="text-muted-foreground">
+                          Generation Speed
+                        </span>
+                        <span className="font-mono">
+                          {metadata.tokensPerSecond.toFixed(1)} t/s
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
+
+        {/* Citations avatar stack */}
+        {!isUser && citations && citations.length > 0 && onToggleCitations && (
+          <CitationAvatarStack
+            citations={citations}
+            isExpanded={citationsExpanded}
+            onToggle={onToggleCitations}
+          />
+        )}
+
+        {/* Model badge */}
+        {!isUser && model && provider && (
+          <ActionButton size="label" className="pointer-events-none">
+            {provider !== "replicate" && (
+              <ProviderIcon className="h-3 w-3" provider={provider} />
+            )}
+            <span className="hidden sm:inline">{modelTitle}</span>
+          </ActionButton>
         )}
       </div>
     );

--- a/src/components/chat/message/retry-model-menu.tsx
+++ b/src/components/chat/message/retry-model-menu.tsx
@@ -47,11 +47,7 @@ import { useSelectedModel } from "@/hooks/use-selected-model";
 import { getModelCapabilities } from "@/lib/model-capabilities";
 import { cn } from "@/lib/utils";
 import type { HydratedModel } from "@/types";
-import {
-  actionButtonStyles,
-  DRAWER_ICON_SIZE,
-  DrawerItem,
-} from "./action-button";
+import { ActionButton, DRAWER_ICON_SIZE, DrawerItem } from "./action-button";
 
 // Union type for models from getAvailableModels
 type AvailableModel = HydratedModel;
@@ -701,33 +697,31 @@ export const RetryDropdown = memo(
           <DropdownMenu open={open} onOpenChange={handleOpenChange}>
             <Tooltip>
               <TooltipTrigger>
-                <DropdownMenuTrigger>
-                  <button
-                    type="button"
-                    className={cn(
-                      actionButtonStyles.defaultButton,
-                      (isEditing || isRetrying || isStreaming) &&
-                        "pointer-events-none opacity-50"
-                    )}
-                    disabled={isEditing || isRetrying || isStreaming}
-                    title={
-                      isUser ? "Retry from this message" : "Retry this response"
-                    }
-                    aria-label={
-                      isUser
-                        ? "Retry conversation from this message"
-                        : "Regenerate this response"
-                    }
-                  >
-                    <ArrowCounterClockwiseIcon
-                      className={cn(
-                        "size-3.5",
-                        isRetrying && "motion-safe:animate-spin-reverse",
-                        "@media (prefers-reduced-motion: reduce) { animation: none }"
-                      )}
-                      aria-hidden="true"
+                <DropdownMenuTrigger
+                  render={
+                    <ActionButton
+                      disabled={isEditing || isRetrying || isStreaming}
+                      title={
+                        isUser
+                          ? "Retry from this message"
+                          : "Retry this response"
+                      }
+                      aria-label={
+                        isUser
+                          ? "Retry conversation from this message"
+                          : "Regenerate this response"
+                      }
                     />
-                  </button>
+                  }
+                >
+                  <ArrowCounterClockwiseIcon
+                    className={cn(
+                      "size-3.5",
+                      isRetrying && "motion-safe:animate-spin-reverse",
+                      "@media (prefers-reduced-motion: reduce) { animation: none }"
+                    )}
+                    aria-hidden="true"
+                  />
                 </DropdownMenuTrigger>
               </TooltipTrigger>
               <TooltipContent>
@@ -846,36 +840,34 @@ export const RetryDropdown = memo(
             onOpenChange={handleMobileSheetOpenChange}
           >
             <Tooltip>
-              <TooltipTrigger>
-                <DrawerTrigger>
-                  <button
-                    type="button"
-                    className={cn(
-                      actionButtonStyles.defaultButton,
-                      (isEditing || isRetrying || isStreaming) &&
-                        "pointer-events-none opacity-50"
-                    )}
-                    disabled={isEditing || isRetrying || isStreaming}
-                    title={
-                      isUser ? "Retry from this message" : "Retry this response"
-                    }
-                    aria-label={
-                      isUser
-                        ? "Retry conversation from this message"
-                        : "Regenerate this response"
-                    }
-                  >
-                    <ArrowCounterClockwiseIcon
-                      className={cn(
-                        "size-3.5",
-                        isRetrying && "motion-safe:animate-spin-reverse",
-                        "@media (prefers-reduced-motion: reduce) { animation: none }"
-                      )}
-                      aria-hidden="true"
+              <DrawerTrigger asChild>
+                <TooltipTrigger
+                  render={
+                    <ActionButton
+                      disabled={isEditing || isRetrying || isStreaming}
+                      title={
+                        isUser
+                          ? "Retry from this message"
+                          : "Retry this response"
+                      }
+                      aria-label={
+                        isUser
+                          ? "Retry conversation from this message"
+                          : "Regenerate this response"
+                      }
                     />
-                  </button>
-                </DrawerTrigger>
-              </TooltipTrigger>
+                  }
+                >
+                  <ArrowCounterClockwiseIcon
+                    className={cn(
+                      "size-3.5",
+                      isRetrying && "motion-safe:animate-spin-reverse",
+                      "@media (prefers-reduced-motion: reduce) { animation: none }"
+                    )}
+                    aria-hidden="true"
+                  />
+                </TooltipTrigger>
+              </DrawerTrigger>
               <TooltipContent>
                 <p>
                   {isUser ? "Retry from this message" : "Retry this response"}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,7 +12,6 @@ import { cn } from "@/lib/utils";
  * @variant outline - Secondary button with border, transparent background
  * @variant secondary - Low-emphasis button with subtle background
  * @variant ghost - Minimal button, visible only on hover
- * @variant action - Custom action button styles (uses .btn-action class)
  * @variant link - Text-only button styled as a link
  * @variant tropical - Gradient button for special CTAs
  * @variant primary - Alias for default
@@ -48,7 +47,6 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary-hover focus-visible:bg-secondary-hover",
         ghost:
           "hover:bg-muted hover:text-foreground focus-visible:bg-muted focus-visible:text-foreground",
-        action: "btn-action",
         link: "text-primary underline-offset-4 hover:underline focus-visible:underline",
         tropical:
           "bg-gradient-tropical text-white shadow-lg transition-all duration-200 ease-in-out hover:scale-105 hover:shadow-xl focus-visible:scale-105 focus-visible:shadow-xl",

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -18,7 +18,7 @@ import { cn } from "@/lib/utils";
 
 type ThemeToggleProps = {
   size?: "sm" | "default" | "lg" | "icon-sm";
-  variant?: "ghost" | "default" | "outline" | "secondary" | "action";
+  variant?: "ghost" | "default" | "outline" | "secondary";
   className?: string;
 };
 

--- a/src/pages/favorites-page.tsx
+++ b/src/pages/favorites-page.tsx
@@ -5,17 +5,12 @@ import { useMutation, usePaginatedQuery } from "convex/react";
 import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Virtuoso } from "react-virtuoso";
-import { actionButtonStyles } from "@/components/chat/message/action-button";
+import { ActionButton } from "@/components/chat/message/action-button";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StreamingMarkdown } from "@/components/ui/streaming-markdown";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { cn } from "@/lib";
 import { ROUTES } from "@/lib/routes";
 import { useToast } from "@/providers/toast-context";
@@ -205,50 +200,28 @@ export default function FavoritesPage() {
                 )}
               </div>
               <div className="flex items-center gap-1 ml-2">
-                <Tooltip>
-                  <TooltipTrigger>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        navigate(
-                          ROUTES.CHAT_CONVERSATION(item.conversation._id)
-                        )
-                      }
-                      className={actionButtonStyles.defaultButton}
-                    >
-                      <ArrowSquareOutIcon className="size-3.5" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>Open conversation</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <button
-                      type="button"
-                      onClick={() => handleCopy(item.message.content)}
-                      className={actionButtonStyles.defaultButton}
-                    >
-                      <CopyIcon className="size-3.5" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>Copy message</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <button
-                      type="button"
-                      onClick={() => handleUnfavorite(item.message._id)}
-                      className={cn(
-                        actionButtonStyles.destructiveButton,
-                        "text-destructive"
-                      )}
-                      title="Remove favorite"
-                    >
-                      <HeartIcon className="size-3.5" weight="fill" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>Remove favorite</TooltipContent>
-                </Tooltip>
+                <ActionButton
+                  tooltip="Open conversation"
+                  onClick={() =>
+                    navigate(ROUTES.CHAT_CONVERSATION(item.conversation._id))
+                  }
+                >
+                  <ArrowSquareOutIcon className="size-3.5" />
+                </ActionButton>
+                <ActionButton
+                  tooltip="Copy message"
+                  onClick={() => handleCopy(item.message.content)}
+                >
+                  <CopyIcon className="size-3.5" />
+                </ActionButton>
+                <ActionButton
+                  variant="destructive"
+                  tooltip="Remove favorite"
+                  className="text-destructive"
+                  onClick={() => handleUnfavorite(item.message._id)}
+                >
+                  <HeartIcon className="size-3.5" weight="fill" />
+                </ActionButton>
               </div>
             </div>
           </Card>


### PR DESCRIPTION
## Summary
- Collapsed `ActionButton` (tooltip wrapper) + `ActionChip` into a single `ActionButton` component with optional `tooltip` prop
- Deleted `ActionIcon.*` namespace, `actionButtonStyles` legacy export, and `ACTION_ICON_SIZE` constant
- Added `actionButtonClass()` utility for cases needing a computed class string (e.g. `triggerClassName`)
- Rewrote `ActionButtons.*` presets to call `ActionButton` directly
- Removed dead `action: "btn-action"` variant from `Button`
- Replaced manual `Tooltip > TooltipTrigger > button` patterns across 6 consumer files with `<ActionButton tooltip="...">`

**Net: -170 lines, 10 files touched**

## Test plan
- [ ] Message action bar: copy, edit, favorite, branch, TTS, zen mode, delete all render and tooltip correctly
- [ ] Retry dropdown trigger renders on desktop (dropdown) and mobile (drawer)
- [ ] Image actions: copy prompt, download, retry popover all functional
- [ ] Image generation bubble: delete buttons render with destructive variant
- [ ] Favorites page: open, copy, unfavorite buttons all work with tooltips
- [ ] Citation avatar stack still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)