### PR TITLE
fix: Respect reasoning toggle for optional-reasoning models

### DIFF
--- a/shared/reasoning-config.test.ts
+++ b/shared/reasoning-config.test.ts
@@ -5,6 +5,7 @@ import {
   getProviderBaseOptions,
   getProviderReasoningConfig,
   getProviderReasoningOptions,
+  getReasoningDisabledOptions,
   type ModelWithCapabilities,
   normalizeReasoningEffort,
   type ReasoningConfig,
@@ -356,6 +357,36 @@ describe("getProviderBaseOptions", () => {
   });
 });
 
+describe("getReasoningDisabledOptions", () => {
+  test("returns explicit disable for OpenRouter", () => {
+    expect(getReasoningDisabledOptions("openrouter")).toEqual({
+      extraBody: {
+        reasoning: {
+          enabled: false,
+        },
+      },
+    });
+  });
+
+  test("returns Google base options for Google", () => {
+    expect(getReasoningDisabledOptions("google")).toEqual({
+      providerOptions: {
+        google: {
+          structuredOutputs: false,
+        },
+      },
+    });
+  });
+
+  test("returns empty object for Anthropic", () => {
+    expect(getReasoningDisabledOptions("anthropic")).toEqual({});
+  });
+
+  test("returns empty object for OpenAI", () => {
+    expect(getReasoningDisabledOptions("openai")).toEqual({});
+  });
+});
+
 describe("getProviderReasoningConfig", () => {
   test("returns empty config for non-reasoning OpenAI model", () => {
     const model: ModelWithCapabilities = {
@@ -409,6 +440,62 @@ describe("getProviderReasoningConfig", () => {
       providerOptions: {
         google: {
           structuredOutputs: false,
+        },
+      },
+    });
+  });
+
+  test("returns empty config when reasoning disabled for Anthropic model", () => {
+    const model: ModelWithCapabilities = {
+      modelId: "claude-sonnet-4",
+      provider: "anthropic",
+      supportsReasoning: true,
+    };
+
+    const result = getProviderReasoningConfig(model, { enabled: false });
+    expect(result).toEqual({});
+  });
+
+  test("returns empty config when no reasoning config for Anthropic model", () => {
+    const model: ModelWithCapabilities = {
+      modelId: "claude-opus-4",
+      provider: "anthropic",
+      supportsReasoning: true,
+    };
+
+    const result = getProviderReasoningConfig(model);
+    expect(result).toEqual({});
+  });
+
+  test("returns explicit disable for OpenRouter when reasoning disabled", () => {
+    const model: ModelWithCapabilities = {
+      modelId: "kimi-k2.5",
+      provider: "openrouter",
+      supportsReasoning: true,
+    };
+
+    const result = getProviderReasoningConfig(model, { enabled: false });
+    expect(result).toEqual({
+      extraBody: {
+        reasoning: {
+          enabled: false,
+        },
+      },
+    });
+  });
+
+  test("returns explicit disable for OpenRouter when no reasoning config", () => {
+    const model: ModelWithCapabilities = {
+      modelId: "grok-4",
+      provider: "openrouter",
+      supportsReasoning: true,
+    };
+
+    const result = getProviderReasoningConfig(model);
+    expect(result).toEqual({
+      extraBody: {
+        reasoning: {
+          enabled: false,
         },
       },
     });

--- a/shared/reasoning-config.ts
+++ b/shared/reasoning-config.ts
@@ -126,9 +126,9 @@ export function getProviderReasoningConfig(
       reasoningConfig.maxTokens
     )
   ) {
-    // Return base provider options when reasoning not enabled
-    // (e.g., Google needs structuredOutputs: false even without reasoning)
-    return getProviderBaseOptions(provider);
+    // Return explicit disable options for providers that auto-enable reasoning
+    // (e.g., OpenRouter enables reasoning by default for capable models)
+    return getReasoningDisabledOptions(actualProvider);
   }
 
   // Delegate to provider-specific implementation when reasoning is explicitly enabled
@@ -307,6 +307,27 @@ export function getProviderReasoningOptions(
     default:
       return {};
   }
+}
+
+/**
+ * Get provider options for when a reasoning-capable model has reasoning disabled.
+ * Some providers (e.g., OpenRouter) auto-enable reasoning for capable models,
+ * so we need to explicitly disable it. Other providers only reason when
+ * explicitly asked, so base options suffice.
+ */
+export function getReasoningDisabledOptions(
+  provider: string
+): ProviderStreamOptions {
+  if (provider === "openrouter") {
+    return {
+      extraBody: {
+        reasoning: {
+          enabled: false,
+        },
+      },
+    };
+  }
+  return getProviderBaseOptions(provider);
 }
 
 /**

--- a/shared/reasoning-model-detection.test.ts
+++ b/shared/reasoning-model-detection.test.ts
@@ -196,13 +196,13 @@ describe("needsSpecialReasoningHandling", () => {
     expect(needsSpecialReasoningHandling("openai", "o3-mini")).toBe(true);
   });
 
-  test("returns true for Anthropic optional reasoning models", () => {
+  test("returns false for Anthropic optional reasoning models", () => {
     expect(needsSpecialReasoningHandling("anthropic", "claude-opus-4")).toBe(
-      true
+      false
     );
     expect(
       needsSpecialReasoningHandling("anthropic", "claude-3-7-sonnet")
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("returns false for standard models", () => {

--- a/shared/reasoning-model-detection.ts
+++ b/shared/reasoning-model-detection.ts
@@ -371,12 +371,6 @@ export function needsSpecialReasoningHandling(
     return true;
   }
 
-  // Anthropic models with optional reasoning need special handling
-  // to enable default reasoning config when no explicit config is provided
-  if (provider === "anthropic" && hasOptionalReasoning(provider, modelId)) {
-    return true;
-  }
-
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Removed incorrect `needsSpecialHandling` flag for Anthropic optional-reasoning models (Claude Opus 4, Sonnet 4, Sonnet 3.7) that caused reasoning to always be enabled regardless of the toggle setting
- Added explicit `reasoning: { enabled: false }` for OpenRouter when reasoning is toggled off, since OpenRouter auto-enables reasoning for capable models (e.g., Kimi K2.5) when no config is sent
- Added `getReasoningDisabledOptions()` to distinguish between "model doesn't support reasoning" (base options) and "model supports reasoning but user disabled it" (explicit disable for providers that need it)

## Test plan
- [x] All 82 reasoning tests pass (6 new tests added)
- [x] TypeScript compiles cleanly
- [x] Biome lint passes
- [ ] Manual: Toggle reasoning OFF for Claude Sonnet 4 → verify no thinking in response
- [ ] Manual: Toggle reasoning OFF for Kimi K2.5 on OpenRouter → verify no reasoning tokens
- [ ] Manual: Toggle reasoning ON for same models → verify reasoning works normally
- [ ] Manual: Mandatory reasoning models (o3, Gemini 2.5 Pro) still always reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)