### PR TITLE
feat: Show persona badge in message actions row

### DIFF
--- a/convex/ai/replicate.test.ts
+++ b/convex/ai/replicate.test.ts
@@ -35,8 +35,8 @@ function stubFetch(
         headers: { "content-type": contentType },
       }),
     ),
+  );
   globalThis.fetch = stub as unknown as typeof globalThis.fetch;
-  globalThis.fetch = stub as unknown as unknown as typeof globalThis.fetch;
   return { stub, restore: () => { globalThis.fetch = original; } };
 }
 

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -814,6 +814,10 @@ export const messageSchema = v.object({
   toolCalls: v.optional(v.array(toolCallSchema)), // Tool calls made during reasoning
   error: v.optional(v.string()), // Error message for failed text-to-text requests
   ttsAudioCache: v.optional(v.array(ttsAudioCacheEntrySchema)),
+  // Persona snapshot — frozen at message creation time so changing the conversation persona
+  // doesn't retroactively update existing messages.
+  personaName: v.optional(v.string()),
+  personaIcon: v.optional(v.string()),
   createdAt: v.number(),
   completedAt: v.optional(v.number()),
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -271,10 +271,26 @@ export async function createHandler(
     })
   );
 
+  // For assistant messages, snapshot the active persona so it's frozen at creation time
+  let personaName: string | undefined;
+  let personaIcon: string | undefined;
+  if (args.role === "assistant") {
+    const conversation = await ctx.db.get("conversations", args.conversationId);
+    if (conversation?.personaId) {
+      const persona = await ctx.db.get("personas", conversation.personaId);
+      if (persona) {
+        personaName = persona.name;
+        personaIcon = persona.icon ?? undefined;
+      }
+    }
+  }
+
   const messageId = await ctx.db.insert("messages", {
     ...args,
     attachments: attachmentsForStorage,
     userId,
+    personaName,
+    personaIcon,
     isMainBranch: args.isMainBranch ?? true,
     createdAt: Date.now(),
   });

--- a/src/components/chat/chat-header.tsx
+++ b/src/components/chat/chat-header.tsx
@@ -8,7 +8,6 @@ import {
   FloppyDiskIcon,
   GitBranchIcon,
   GitCommitIcon,
-  NotePencilIcon,
   PencilSimpleIcon,
   PushPinIcon,
   ShareNetworkIcon,
@@ -18,7 +17,6 @@ import {
 import { useMutation, useQuery } from "convex/react";
 import { memo, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
 import {
@@ -183,7 +181,6 @@ const ChatHeaderComponent = ({
   onSavePrivateChat,
   canSavePrivateChat,
   privateMessages,
-  privatePersonaId,
 }: ChatHeaderProps) => {
   const { user } = useUserDataContext();
   const { isSidebarVisible, setSidebarVisible } = useUI();
@@ -225,18 +222,6 @@ const ChatHeaderComponent = ({
     api.conversations.getForExport,
     conversationId && shouldLoadExportData ? { id: conversationId } : "skip"
   );
-
-  const personaQueryArg = (() => {
-    if (conversation?.personaId) {
-      return { id: conversation.personaId };
-    }
-    if (privatePersonaId) {
-      return { id: privatePersonaId };
-    }
-    return "skip";
-  })();
-
-  const persona = useQuery(api.personas.get, personaQueryArg);
 
   const patchConversation = useMutation(api.conversations.patch);
   const { deleteConversation: performDelete } = useDeleteConversation({
@@ -427,12 +412,6 @@ const ChatHeaderComponent = ({
           </Button>
         )}
         <div className="flex min-w-0 flex-1 items-center gap-1">
-          {persona && (
-            <Badge size="sm">
-              <span>{persona.icon}</span>
-              <span>{persona.name}</span>
-            </Badge>
-          )}
           {/* Branch selector */}
           {conversationId && Array.isArray(branches) && branches.length > 1 && (
             <DropdownMenu>

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -4,6 +4,7 @@ import type { Attachment, ChatMessage as ChatMessageType } from "@/types";
 import { AssistantBubble } from "./message/assistant-bubble";
 import type { ImageRetryParams } from "./message/image-actions";
 import { UserBubble } from "./message/user-bubble";
+import type { PersonaInfo } from "./virtualized-chat-messages";
 
 type ChatMessageProps = {
   message: ChatMessageType;
@@ -40,6 +41,13 @@ const ChatMessageComponent = ({
   onPreviewAttachment,
 }: ChatMessageProps) => {
   const isUser = message.role === "user";
+
+  // Only show persona when the message has its own snapshot — avoids retroactive
+  // persona changes when the conversation-level persona is switched.
+  const messagePersona: PersonaInfo = message.personaName
+    ? { name: message.personaName, icon: message.personaIcon ?? "" }
+    : null;
+
   const [isCopied, setIsCopied] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -125,6 +133,7 @@ const ChatMessageComponent = ({
         <AssistantBubble
           conversationId={conversationId}
           message={message}
+          persona={messagePersona}
           isStreaming={isStreaming}
           isCopied={isCopied}
           isRetrying={isRetrying}
@@ -196,6 +205,7 @@ export const ChatMessage = memo(
       prevProps.message.id === nextProps.message.id &&
       prevProps.message.content === nextProps.message.content &&
       prevProps.message.status === nextProps.message.status &&
+      prevProps.message.personaName === nextProps.message.personaName &&
       prevProps.isStreaming === nextProps.isStreaming
     );
   }

--- a/src/components/chat/input/index.tsx
+++ b/src/components/chat/input/index.tsx
@@ -85,6 +85,7 @@ const ChatInputInner = ({
   userMessageContents,
   autoFocus = false,
   isLikelyImageConversation = false,
+  conversationPersonaId,
   ref,
 }: ChatInputProps & { ref?: React.Ref<ChatInputRef> }) => {
   // Unified state management
@@ -458,6 +459,7 @@ const ChatInputInner = ({
             hasReplicateApiKey={hasReplicateApiKey}
             isPrivateMode={isPrivateMode}
             selectedImageModel={selectedImageModel}
+            conversationPersonaId={conversationPersonaId}
           />
         </div>
       </div>

--- a/src/components/chat/input/persona-selector.tsx
+++ b/src/components/chat/input/persona-selector.tsx
@@ -13,15 +13,12 @@ interface PersonaSelectorProps {
 
 export function PersonaSelector({
   conversationId,
-  hasExistingMessages,
+  hasExistingMessages = false,
   selectedPersonaId = null,
   onPersonaSelect,
   disabled = false,
 }: PersonaSelectorProps) {
-  const { showPersonaSelector } = useChatInputControls(
-    conversationId,
-    hasExistingMessages
-  );
+  const { showPersonaSelector } = useChatInputControls(conversationId);
 
   if (!showPersonaSelector) {
     return null;
@@ -33,6 +30,7 @@ export function PersonaSelector({
       selectedPersonaId={selectedPersonaId}
       onPersonaSelect={onPersonaSelect}
       disabled={disabled}
+      hasExistingMessages={hasExistingMessages}
     />
   );
 }

--- a/src/components/chat/input/pickers/persona-picker.tsx
+++ b/src/components/chat/input/pickers/persona-picker.tsx
@@ -25,6 +25,7 @@ type PersonaPickerProps = {
   onPersonaSelect?: (personaId: Id<"personas"> | null) => void;
   tooltip?: string | React.ReactNode;
   disabled?: boolean;
+  hasExistingMessages?: boolean;
 };
 
 function PersonaPickerComponent({
@@ -34,6 +35,7 @@ function PersonaPickerComponent({
   onPersonaSelect,
   tooltip,
   disabled = false,
+  hasExistingMessages = false,
 }: PersonaPickerProps) {
   const { user } = useUserDataContext();
   const isDesktop = useMediaQuery("(min-width: 640px)");
@@ -108,12 +110,14 @@ function PersonaPickerComponent({
             personas={availablePersonas}
             currentPersona={currentPersona}
             onPersonaSelect={onPersonaSelect}
+            hasExistingMessages={hasExistingMessages}
           />
         ) : (
           <PersonaListMobile
             personas={availablePersonas}
             currentPersona={currentPersona}
             onPersonaSelect={onPersonaSelect}
+            hasExistingMessages={hasExistingMessages}
           />
         )}
       </ResponsivePicker>
@@ -210,12 +214,14 @@ type PersonaListProps = {
     isBuiltIn: boolean;
   } | null;
   onPersonaSelect?: (personaId: Id<"personas"> | null) => void;
+  hasExistingMessages?: boolean;
 };
 
 const PersonaListDesktop = ({
   personas,
   currentPersona,
   onPersonaSelect,
+  hasExistingMessages = false,
 }: PersonaListProps) => {
   // Separate built-in and user-defined personas
   const builtInPersonas = personas.filter(persona => persona.isBuiltIn);
@@ -331,6 +337,11 @@ const PersonaListDesktop = ({
           </CommandGroup>
         )}
       </CommandList>
+      {hasExistingMessages && (
+        <p className="border-t border-border/40 px-3 py-2 text-xs text-muted-foreground">
+          New persona will apply to future messages.
+        </p>
+      )}
     </Command>
   );
 };
@@ -339,6 +350,7 @@ const PersonaListMobile = ({
   personas,
   currentPersona,
   onPersonaSelect,
+  hasExistingMessages = false,
 }: PersonaListProps) => {
   // Separate built-in and user-defined personas
   const builtInPersonas = personas.filter(persona => persona.isBuiltIn);
@@ -396,6 +408,12 @@ const PersonaListMobile = ({
             />
           ))}
         </div>
+      )}
+
+      {hasExistingMessages && (
+        <p className="px-2 text-xs text-muted-foreground">
+          New persona will apply to future messages.
+        </p>
       )}
     </div>
   );

--- a/src/components/chat/message/message-actions.tsx
+++ b/src/components/chat/message/message-actions.tsx
@@ -126,6 +126,7 @@ type MessageActionsProps = {
     aspectRatio?: string;
   };
   onRetryImageGeneration?: (params: ImageRetryParams) => void;
+  persona?: { name: string; icon: string } | null;
 };
 
 export const MessageActions = memo(
@@ -155,6 +156,7 @@ export const MessageActions = memo(
     isImageGenerationMessage,
     imageGenerationParams,
     onRetryImageGeneration,
+    persona,
   }: MessageActionsProps & {
     metadata?: Doc<"messages">["metadata"];
   }) => {
@@ -646,6 +648,14 @@ export const MessageActions = memo(
             isExpanded={citationsExpanded}
             onToggle={onToggleCitations}
           />
+        )}
+
+        {/* Persona badge */}
+        {!isUser && persona && (
+          <ActionButton size="label" className="pointer-events-none">
+            <span className="text-xs leading-none">{persona.icon || "🤖"}</span>
+            <span className="hidden sm:inline">{persona.name}</span>
+          </ActionButton>
         )}
 
         {/* Model badge */}

--- a/src/components/chat/virtualized-chat-messages.tsx
+++ b/src/components/chat/virtualized-chat-messages.tsx
@@ -14,6 +14,8 @@ import { ContextMessage } from "./context-message";
 import type { ImageRetryParams } from "./message/image-actions";
 import { ZenModeDialog } from "./message/zen-mode-dialog";
 
+export type PersonaInfo = { icon: string; name: string } | null;
+
 type VirtualizedChatMessagesProps = {
   messages: ChatMessageType[];
   isStreaming?: boolean;

--- a/src/hooks/chat-ui/use-chat-input-state.ts
+++ b/src/hooks/chat-ui/use-chat-input-state.ts
@@ -131,22 +131,11 @@ export function useChatInputState(conversationId?: ConversationId) {
  * Hook for managing chat input UI controls visibility
  * Determines which pickers should be shown based on context
  */
-export function useChatInputControls(
-  conversationId?: ConversationId,
-  hasExistingMessages?: boolean
-) {
-  const { isPrivateMode, personasEnabled, user } =
-    useChatInputState(conversationId);
-
-  // Show persona selector only when starting a new conversation
-  const isNewConversation = isPrivateMode && !hasExistingMessages;
-  const isNewRegularConversation = !(isPrivateMode || conversationId);
-  const shouldShowPersonaSelector =
-    isNewConversation || isNewRegularConversation;
+export function useChatInputControls(conversationId?: ConversationId) {
+  const { personasEnabled, user } = useChatInputState(conversationId);
 
   const canShowPersonaSelector = user && personasEnabled;
-  const showPersonaSelector =
-    canShowPersonaSelector && shouldShowPersonaSelector;
+  const showPersonaSelector = Boolean(canShowPersonaSelector);
 
   return {
     showPersonaSelector,

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -46,6 +46,8 @@ export function mapServerMessageToChatMessage(
     citations: msg.citations,
     toolCalls: msg.toolCalls as ChatMessage["toolCalls"],
     error: msg.error,
+    personaName: msg.personaName,
+    personaIcon: msg.personaIcon,
     metadata: msg.metadata,
     imageGeneration: msg.imageGeneration
       ? {

--- a/src/lib/chat/message-utils.ts
+++ b/src/lib/chat/message-utils.ts
@@ -46,6 +46,8 @@ export function convertServerMessage(msg: Doc<"messages">): ChatMessage {
     reasoningParts: msg.reasoningParts as ChatMessage["reasoningParts"],
     toolCalls: msg.toolCalls as ChatMessage["toolCalls"],
     error: msg.error,
+    personaName: msg.personaName,
+    personaIcon: msg.personaIcon,
     metadata: isMessageMetadata(msg.metadata)
       ? (msg.metadata as ChatMessage["metadata"])
       : undefined,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,6 +210,9 @@ export type ChatMessage = {
   reasoningParts?: ReasoningPart[]; // Interleaved reasoning segments
   toolCalls?: ToolCall[]; // Tool calls made during reasoning
   error?: string; // Error message for failed text-to-text requests
+  // Persona snapshot — frozen at message creation time
+  personaName?: string;
+  personaIcon?: string;
   metadata?: {
     tokenCount?: number;
     finishReason?: string;


### PR DESCRIPTION
## Summary
- Snapshot persona identity (name + icon) on assistant messages at creation time in the backend
- Display persona as a subtle badge in the message actions row, next to the model badge
- Remove the old per-message persona header (emoji circle + bold name above every message)
- Prevent retroactive persona changes when the conversation-level persona is switched mid-conversation

## Changes
- **Backend**: Add `personaName`/`personaIcon` optional fields to message schema; snapshot active persona in all message creation paths (`createHandler`, `createConversationHandler`, `createWithUserId`)
- **Frontend**: Render persona badge via `ActionButton size="label"` in `MessageActions`; fix `mapServerMessageToChatMessage` to pass persona fields through; remove conversation-level persona prop chain from `UnifiedChatView` → `VirtualizedChatMessages` → `ChatMessage`

## Test plan
- [ ] Select a persona, send a message — persona badge appears next to model badge
- [ ] No persona selected — no persona badge, only model badge
- [ ] Change persona mid-conversation — old messages keep their original persona badge
- [ ] New conversation from home page — first assistant message shows persona badge
- [ ] Mobile: persona badge shows emoji only, model badge shows icon only
- [ ] Reasoning/tool calls render unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)