### PR TITLE
feat: Fix import/export round-trip and add markdown import

### DIFF
--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -20,6 +20,7 @@ import {
   ShareNetworkIcon,
   SunIcon,
   TrashIcon,
+  UploadIcon,
   UsersIcon,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery } from "convex/react";
@@ -46,6 +47,7 @@ import { ControlledShareConversationDialog } from "@/components/ui/share-convers
 import { Spinner } from "@/components/ui/spinner";
 import { TextInputDialog } from "@/components/ui/text-input-dialog";
 import { useArchiveConversation } from "@/hooks/use-archive-conversation";
+import { useConversationImport } from "@/hooks/use-conversation-import";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useDeleteConversation } from "@/hooks/use-delete-conversation";
 import { useModelCatalog } from "@/hooks/use-model-catalog";
@@ -226,6 +228,7 @@ export function CommandPalette({
     });
 
   const managedToast = useToast();
+  const conversationImport = useConversationImport();
 
   const allModels: ModelType[] = useMemo(() => {
     const combined: AvailableModel[] = [
@@ -529,6 +532,12 @@ export function CommandPalette({
     handleClose();
   }, [toggleTheme, handleClose]);
 
+  const handleImportConversations = useCallback(() => {
+    handleClose();
+    // Trigger file picker after palette closes
+    setTimeout(() => conversationImport.triggerFileInput(), 200);
+  }, [handleClose, conversationImport]);
+
   const handlePrivateMode = useCallback(() => {
     navigate("/private");
     handleClose();
@@ -678,7 +687,7 @@ export function CommandPalette({
       },
     ];
 
-    // Browse actions require authentication
+    // Browse and import actions require authentication
     if (isAuthenticated) {
       actions.push(
         {
@@ -700,6 +709,13 @@ export function CommandPalette({
           handler: () =>
             navigateToMenu("model-categories", undefined, "All Models"),
           disabled: !online,
+        },
+        {
+          id: "import-conversations",
+          label: "Import Conversations",
+          icon: UploadIcon,
+          handler: handleImportConversations,
+          disabled: !online,
         }
       );
     }
@@ -717,6 +733,7 @@ export function CommandPalette({
     theme,
     handleNewConversation,
     handlePrivateMode,
+    handleImportConversations,
     handleToggleTheme,
     navigateToMenu,
     online,
@@ -1337,6 +1354,26 @@ export function CommandPalette({
         cancelText="Cancel"
         variant="destructive"
         onConfirm={confirmDeleteConversation}
+      />
+
+      {/* Import file input + confirmation dialog */}
+      <input
+        ref={conversationImport.fileInputRef}
+        type="file"
+        accept=".json,.md,.markdown"
+        onChange={conversationImport.handleFileChange}
+        className="hidden"
+      />
+      <ConfirmationDialog
+        open={conversationImport.confirmDialog.state.isOpen}
+        onOpenChange={conversationImport.confirmDialog.handleOpenChange}
+        title={conversationImport.confirmDialog.state.title}
+        description={conversationImport.confirmDialog.state.description}
+        confirmText={conversationImport.confirmDialog.state.confirmText}
+        cancelText={conversationImport.confirmDialog.state.cancelText}
+        variant={conversationImport.confirmDialog.state.variant}
+        onConfirm={conversationImport.confirmDialog.handleConfirm}
+        onCancel={conversationImport.confirmDialog.handleCancel}
       />
 
       {/* Rename Dialog */}

--- a/src/components/settings/chat-history-tab/import-export-actions.tsx
+++ b/src/components/settings/chat-history-tab/import-export-actions.tsx
@@ -1,171 +1,25 @@
 import { UploadIcon } from "@phosphor-icons/react";
-import { api } from "convex/_generated/api";
-import { useMutation } from "convex/react";
-import { useCallback, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
 import { Spinner } from "@/components/ui/spinner";
-import { useBackgroundJobs } from "@/hooks/use-background-jobs";
-import { useConfirmationDialog } from "@/hooks/use-dialog-management";
-import { detectAndParseImportData } from "@/lib/import-parsers";
-import { useToast } from "@/providers/toast-context";
+import { useConversationImport } from "@/hooks/use-conversation-import";
 
 export function ImportExportActions() {
-  const [isValidating, setIsValidating] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const confirmDialog = useConfirmationDialog();
-  const backgroundJobs = useBackgroundJobs();
-  const managedToast = useToast();
-
-  const validateImportData = useMutation(
-    api.conversationImport.validateImportData
-  );
-
-  const handleImport = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      if (!file) {
-        return;
-      }
-
-      // Check file size (warn if > 10MB)
-      if (file.size > 10 * 1024 * 1024) {
-        managedToast.error(
-          "Large file detected. Import may take longer than usual."
-        );
-      }
-
-      if (!file.name.endsWith(".json")) {
-        managedToast.error("Please select a JSON file");
-        return;
-      }
-
-      const reader = new FileReader();
-
-      reader.onerror = () => {
-        managedToast.error("Failed to read the file");
-        setIsValidating(false);
-      };
-
-      reader.onload = async e => {
-        try {
-          setIsValidating(true);
-          const content = e.target?.result as string;
-
-          if (!content || content.trim() === "") {
-            managedToast.error("The selected file is empty");
-            setIsValidating(false);
-            return;
-          }
-
-          const importResult = detectAndParseImportData(content);
-
-          if (importResult.errors.length > 0) {
-            managedToast.error(`Import failed: ${importResult.errors[0]}`);
-            setIsValidating(false);
-            return;
-          }
-
-          if (importResult.conversations.length === 0) {
-            console.warn("No conversations found in import result");
-            managedToast.error("No valid conversations found in the file");
-            setIsValidating(false);
-            return;
-          }
-
-          // Validate a sample of conversations for better error reporting
-          try {
-            const validationResult = await validateImportData({
-              sampleConversations: importResult.conversations,
-              maxSampleSize: 20,
-            });
-
-            if (!validationResult.isValid) {
-              managedToast.error(
-                `Validation failed: ${validationResult.errors[0]}`
-              );
-              setIsValidating(false);
-              return;
-            }
-
-            if (validationResult.warnings.length > 0) {
-              console.warn("Validation warnings:", validationResult.warnings);
-              managedToast.error(
-                `${validationResult.warnings.length} warnings found in data`
-              );
-            }
-          } catch (validationError) {
-            console.warn(
-              "Validation failed, proceeding anyway:",
-              validationError
-            );
-          }
-
-          setIsValidating(false);
-
-          const sourceInfo =
-            importResult.source !== "Unknown"
-              ? ` from ${importResult.source}`
-              : "";
-
-          const conversationCount = importResult.conversations.length;
-
-          // Always use background jobs for consistency and proper tracking
-          confirmDialog.confirm(
-            {
-              title: "Import Conversations",
-              description: `This will import ${conversationCount} conversation(s)${sourceInfo} in the background. You'll be notified when it's complete. Continue?`,
-              confirmText: "Import",
-              cancelText: "Cancel",
-              variant: "default",
-            },
-            async () => {
-              try {
-                await backgroundJobs.startImport(importResult.conversations);
-                managedToast.success(
-                  `Started importing ${conversationCount} conversations${sourceInfo}`
-                );
-              } catch (_error) {
-                managedToast.error("Failed to start import");
-              }
-            }
-          );
-        } catch (error) {
-          managedToast.error("Failed to read or parse the file", {
-            description:
-              error instanceof Error ? error.message : "Unknown parsing error",
-          });
-          setIsValidating(false);
-        }
-      };
-
-      reader.readAsText(file);
-
-      // Clear the file input
-      if (fileInputRef.current) {
-        fileInputRef.current.value = "";
-      }
-    },
-    [
-      confirmDialog,
-      backgroundJobs,
-      validateImportData,
-      managedToast.success,
-      managedToast.error,
-    ]
-  );
-
-  const triggerFileInput = useCallback(() => {
-    fileInputRef.current?.click();
-  }, []);
+  const {
+    fileInputRef,
+    confirmDialog,
+    isValidating,
+    triggerFileInput,
+    handleFileChange,
+  } = useConversationImport();
 
   return (
     <div className="stack-lg">
       <div className="flex flex-col gap-3">
         <h3 className="text-lg font-semibold">Import Conversations</h3>
         <p className="text-sm text-muted-foreground">
-          Import conversations from a JSON file. Supported formats include
-          exports from Polly and other AI chat applications.
+          Import conversations from a JSON or Markdown file. Supported formats
+          include exports from Polly.
         </p>
 
         <Button
@@ -182,7 +36,7 @@ export function ImportExportActions() {
           ) : (
             <>
               <UploadIcon className="mr-2 size-4" />
-              Import JSON
+              Import
             </>
           )}
         </Button>
@@ -197,8 +51,8 @@ export function ImportExportActions() {
       <input
         ref={fileInputRef}
         type="file"
-        accept=".json"
-        onChange={handleImport}
+        accept=".json,.md,.markdown"
+        onChange={handleFileChange}
         className="hidden"
       />
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -68,6 +68,7 @@ export { useSelectedModel } from "./use-selected-model";
 // =============================================================================
 
 export { useArchiveConversation } from "./use-archive-conversation";
+export { useConversationImport } from "./use-conversation-import";
 export { useDeleteConversation } from "./use-delete-conversation";
 export { usePaginatedConversations } from "./use-paginated-conversations";
 

--- a/src/hooks/use-conversation-import.ts
+++ b/src/hooks/use-conversation-import.ts
@@ -1,0 +1,176 @@
+import { api } from "convex/_generated/api";
+import { useMutation } from "convex/react";
+import { useCallback, useRef, useState } from "react";
+import { useBackgroundJobs } from "@/hooks/use-background-jobs";
+import { useConfirmationDialog } from "@/hooks/use-dialog-management";
+import { detectAndParseImportData } from "@/lib/import-parsers";
+import { useToast } from "@/providers/toast-context";
+
+type ConversationImportState = {
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  confirmDialog: ReturnType<typeof useConfirmationDialog>;
+  isValidating: boolean;
+  triggerFileInput: () => void;
+  handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function useConversationImport(): ConversationImportState {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isValidating, setIsValidating] = useState(false);
+  const confirmDialog = useConfirmationDialog();
+  const backgroundJobs = useBackgroundJobs();
+  const managedToast = useToast();
+
+  const validateImportData = useMutation(
+    api.conversationImport.validateImportData
+  );
+
+  const triggerFileInput = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) {
+        return;
+      }
+
+      // Check file size (warn if > 10MB)
+      if (file.size > 10 * 1024 * 1024) {
+        managedToast.error(
+          "Large file detected. Import may take longer than usual."
+        );
+      }
+
+      const isJson = file.name.endsWith(".json");
+      const isMarkdown =
+        file.name.endsWith(".md") || file.name.endsWith(".markdown");
+
+      if (!(isJson || isMarkdown)) {
+        managedToast.error("Please select a JSON or Markdown file");
+        return;
+      }
+
+      const reader = new FileReader();
+
+      reader.onerror = () => {
+        managedToast.error("Failed to read the file");
+        setIsValidating(false);
+      };
+
+      reader.onload = async e => {
+        try {
+          setIsValidating(true);
+          const content = e.target?.result as string;
+
+          if (!content || content.trim() === "") {
+            managedToast.error("The selected file is empty");
+            setIsValidating(false);
+            return;
+          }
+
+          const importResult = detectAndParseImportData(content);
+
+          if (importResult.errors.length > 0) {
+            managedToast.error(`Import failed: ${importResult.errors[0]}`);
+            setIsValidating(false);
+            return;
+          }
+
+          if (importResult.conversations.length === 0) {
+            console.warn("No conversations found in import result");
+            managedToast.error("No valid conversations found in the file");
+            setIsValidating(false);
+            return;
+          }
+
+          // Validate a sample of conversations for better error reporting
+          try {
+            const validationResult = await validateImportData({
+              sampleConversations: importResult.conversations,
+              maxSampleSize: 20,
+            });
+
+            if (!validationResult.isValid) {
+              managedToast.error(
+                `Validation failed: ${validationResult.errors[0]}`
+              );
+              setIsValidating(false);
+              return;
+            }
+
+            if (validationResult.warnings.length > 0) {
+              console.warn("Validation warnings:", validationResult.warnings);
+              managedToast.error(
+                `${validationResult.warnings.length} warnings found in data`
+              );
+            }
+          } catch (validationError) {
+            console.warn(
+              "Validation failed, proceeding anyway:",
+              validationError
+            );
+          }
+
+          setIsValidating(false);
+
+          const sourceInfo =
+            importResult.source !== "Unknown"
+              ? ` from ${importResult.source}`
+              : "";
+
+          const conversationCount = importResult.conversations.length;
+
+          confirmDialog.confirm(
+            {
+              title: "Import Conversations",
+              description: `This will import ${conversationCount} conversation(s)${sourceInfo} in the background. You'll be notified when it's complete. Continue?`,
+              confirmText: "Import",
+              cancelText: "Cancel",
+              variant: "default",
+            },
+            async () => {
+              try {
+                await backgroundJobs.startImport(importResult.conversations);
+                managedToast.success(
+                  `Started importing ${conversationCount} conversations${sourceInfo}`
+                );
+              } catch (_error) {
+                managedToast.error("Failed to start import");
+              }
+            }
+          );
+        } catch (error) {
+          managedToast.error("Failed to read or parse the file", {
+            description:
+              error instanceof Error ? error.message : "Unknown parsing error",
+          });
+          setIsValidating(false);
+        }
+      };
+
+      reader.readAsText(file);
+
+      // Clear the file input
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    },
+    [
+      confirmDialog,
+      backgroundJobs,
+      validateImportData,
+      managedToast.success,
+      managedToast.error,
+    ]
+  );
+
+  return {
+    fileInputRef,
+    confirmDialog,
+    isValidating,
+    triggerFileInput,
+    handleFileChange,
+  };
+}

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -8,25 +8,30 @@ export function exportAsJSON(data: ExportData): string {
 
   return JSON.stringify(
     {
-      conversation: {
-        title: data.conversation.title,
-        createdAt: new Date(data.conversation.createdAt).toISOString(),
-        updatedAt: new Date(data.conversation.updatedAt).toISOString(),
-      },
-      messages: data.messages.map(message => ({
-        role: message.role,
-        content: stripCitations(message.content),
-        reasoning: message.reasoning
-          ? stripCitations(message.reasoning)
-          : undefined,
-        model: message.model,
-        provider: message.provider,
-        useWebSearch: message.useWebSearch,
-        attachments: message.attachments,
-        citations: message.citations,
-        createdAt: new Date(message.createdAt).toISOString(),
-        metadata: message.metadata,
-      })),
+      source: "Polly",
+      version: "1.0.0",
+      exportedAt: Date.now(),
+      conversations: [
+        {
+          title: data.conversation.title,
+          createdAt: data.conversation.createdAt,
+          updatedAt: data.conversation.updatedAt,
+          messages: data.messages.map(message => ({
+            role: message.role,
+            content: stripCitations(message.content),
+            reasoning: message.reasoning
+              ? stripCitations(message.reasoning)
+              : undefined,
+            model: message.model,
+            provider: message.provider,
+            useWebSearch: message.useWebSearch,
+            attachments: message.attachments,
+            citations: message.citations,
+            createdAt: message.createdAt,
+            metadata: message.metadata,
+          })),
+        },
+      ],
     },
     null,
     2

--- a/src/lib/import-parsers.ts
+++ b/src/lib/import-parsers.ts
@@ -26,14 +26,41 @@ export interface ImportResult {
   errors: string[];
 }
 
-// Simplified detection - focus on Polly format only
-export function detectAndParseImportData(jsonContent: string): ImportResult {
-  try {
-    const data = JSON.parse(jsonContent);
+/**
+ * Parse a timestamp that may be a number (epoch ms) or an ISO string.
+ * Returns a numeric timestamp or undefined.
+ */
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
 
-    // Check if it has the basic polly structure (even if corrupted)
+export function detectAndParseImportData(content: string): ImportResult {
+  // Check if content looks like markdown (starts with #)
+  const trimmed = content.trim();
+  if (trimmed.startsWith("#")) {
+    return parseMarkdownImport(trimmed);
+  }
+
+  try {
+    const data = JSON.parse(content);
+
+    // Standard Polly format: { conversations: [...] }
     if (hasPollyStructure(data)) {
       return parsePollyFormat(data);
+    }
+
+    // Legacy single-conversation format: { conversation: {...}, messages: [...] }
+    if (hasLegacySingleConversationStructure(data)) {
+      return parseLegacySingleConversation(data);
     }
 
     return {
@@ -56,13 +83,30 @@ function hasPollyStructure(data: unknown): boolean {
   return typeof data === "object" && data !== null && "conversations" in data;
 }
 
-// Note: This function is available for future format validation if needed
-// Currently not used, but kept for potential format checking enhancements
-function _isPollyFormat(data: unknown): boolean {
+function hasLegacySingleConversationStructure(data: unknown): boolean {
   return (
-    hasPollyStructure(data) &&
-    Array.isArray((data as Record<string, unknown>).conversations)
+    typeof data === "object" &&
+    data !== null &&
+    "conversation" in data &&
+    "messages" in data
   );
+}
+
+function parseMessage(msgData: Record<string, unknown>) {
+  return {
+    role: ["user", "assistant", "system"].includes(msgData.role as string)
+      ? (msgData.role as "user" | "assistant" | "system")
+      : "user",
+    content: msgData.content === null ? "null" : String(msgData.content || ""),
+    createdAt: parseTimestamp(msgData.createdAt),
+    model: typeof msgData.model === "string" ? msgData.model : undefined,
+    provider:
+      typeof msgData.provider === "string" ? msgData.provider : undefined,
+    reasoning:
+      typeof msgData.reasoning === "string" ? msgData.reasoning : undefined,
+    attachments:
+      msgData.attachments as ParsedConversation["messages"][0]["attachments"],
+  };
 }
 
 function parsePollyFormat(data: Record<string, unknown>): ImportResult {
@@ -75,46 +119,11 @@ function parsePollyFormat(data: Record<string, unknown>): ImportResult {
       const convData = conv as Record<string, unknown>;
       return {
         title: String(convData.title || "Untitled Conversation"),
-        messages: ((convData.messages as unknown[]) || []).map(
-          (msg: unknown) => {
-            const msgData = msg as Record<string, unknown>;
-            return {
-              role: ["user", "assistant", "system"].includes(
-                msgData.role as string
-              )
-                ? (msgData.role as "user" | "assistant" | "system")
-                : "user",
-              content:
-                msgData.content === null
-                  ? "null"
-                  : String(msgData.content || ""),
-              createdAt:
-                typeof msgData.createdAt === "number"
-                  ? msgData.createdAt
-                  : undefined,
-              model:
-                typeof msgData.model === "string" ? msgData.model : undefined,
-              provider:
-                typeof msgData.provider === "string"
-                  ? msgData.provider
-                  : undefined,
-              reasoning:
-                typeof msgData.reasoning === "string"
-                  ? msgData.reasoning
-                  : undefined,
-              attachments:
-                msgData.attachments as ParsedConversation["messages"][0]["attachments"],
-            };
-          }
+        messages: ((convData.messages as unknown[]) || []).map((msg: unknown) =>
+          parseMessage(msg as Record<string, unknown>)
         ),
-        createdAt:
-          typeof convData.createdAt === "number"
-            ? convData.createdAt
-            : undefined,
-        updatedAt:
-          typeof convData.updatedAt === "number"
-            ? convData.updatedAt
-            : undefined,
+        createdAt: parseTimestamp(convData.createdAt),
+        updatedAt: parseTimestamp(convData.updatedAt),
         isArchived: Boolean(convData.isArchived),
         isPinned: Boolean(convData.isPinned),
       };
@@ -132,6 +141,238 @@ function parsePollyFormat(data: Record<string, unknown>): ImportResult {
       source: "polly",
       count: 0,
       errors: ["Failed to parse Polly format"],
+    };
+  }
+}
+
+function parseLegacySingleConversation(
+  data: Record<string, unknown>
+): ImportResult {
+  try {
+    const convData = data.conversation as Record<string, unknown>;
+    const messages = data.messages as unknown[];
+
+    if (!Array.isArray(messages)) {
+      throw new Error("messages is not an array");
+    }
+
+    const parsed: ParsedConversation = {
+      title: String(convData?.title || "Untitled Conversation"),
+      messages: messages.map((msg: unknown) =>
+        parseMessage(msg as Record<string, unknown>)
+      ),
+      createdAt: parseTimestamp(convData?.createdAt),
+      updatedAt: parseTimestamp(convData?.updatedAt),
+    };
+
+    return {
+      conversations: [parsed],
+      source: "polly",
+      count: 1,
+      errors: [],
+    };
+  } catch {
+    return {
+      conversations: [],
+      source: "polly",
+      count: 0,
+      errors: ["Failed to parse legacy Polly format"],
+    };
+  }
+}
+
+/**
+ * Parse a markdown file exported by Polly's `exportAsMarkdown()`.
+ *
+ * Expected structure:
+ * ```
+ * # Title
+ * **Created:** <date>
+ * **Updated:** <date>
+ * ---
+ * ## 👤 User
+ * *<timestamp>*
+ * ...content...
+ * ---
+ * ## 🤖 Assistant
+ * *<timestamp>*
+ * **Model:** model-name (provider)
+ * ### Reasoning
+ * ...reasoning text...
+ * ...content...
+ * ---
+ * ```
+ */
+function parseMarkdownImport(content: string): ImportResult {
+  try {
+    const lines = content.split("\n");
+
+    // Parse title from first heading
+    const titleMatch = lines[0]?.match(/^#\s+(.+)$/);
+    if (!titleMatch) {
+      return {
+        conversations: [],
+        source: "polly",
+        count: 0,
+        errors: ["Could not find conversation title in markdown"],
+      };
+    }
+    const title = (titleMatch[1] ?? "").trim();
+
+    // Parse Created/Updated dates
+    let createdAt: number | undefined;
+    let updatedAt: number | undefined;
+
+    for (const line of lines.slice(1, 6)) {
+      const createdMatch = line.match(/^\*\*Created:\*\*\s*(.+)$/);
+      if (createdMatch) {
+        createdAt = parseTimestamp(createdMatch[1]?.trim());
+      }
+      const updatedMatch = line.match(/^\*\*Updated:\*\*\s*(.+)$/);
+      if (updatedMatch) {
+        updatedAt = parseTimestamp(updatedMatch[1]?.trim());
+      }
+    }
+
+    // Split into message sections by ## headings
+    const messages: ParsedConversation["messages"] = [];
+    const sectionRegex = /^##\s+(👤|🤖)\s+(User|Assistant)\s*$/;
+
+    let currentRole: "user" | "assistant" | null = null;
+    let currentTimestamp: number | undefined;
+    let currentModel: string | undefined;
+    let currentProvider: string | undefined;
+    let currentReasoning: string[] = [];
+    let currentContent: string[] = [];
+    let inReasoning = false;
+
+    const flushMessage = () => {
+      if (currentRole) {
+        const contentText = currentContent.join("\n").trim();
+        if (contentText) {
+          messages.push({
+            role: currentRole,
+            content: contentText,
+            createdAt: currentTimestamp,
+            model: currentModel,
+            provider: currentProvider,
+            reasoning:
+              currentReasoning.length > 0
+                ? currentReasoning.join("\n").trim()
+                : undefined,
+          });
+        }
+      }
+      currentRole = null;
+      currentTimestamp = undefined;
+      currentModel = undefined;
+      currentProvider = undefined;
+      currentReasoning = [];
+      currentContent = [];
+      inReasoning = false;
+    };
+
+    for (const line of lines) {
+      const sectionMatch = line.match(sectionRegex);
+      if (sectionMatch) {
+        flushMessage();
+        currentRole = sectionMatch[2] === "User" ? "user" : "assistant";
+        continue;
+      }
+
+      if (currentRole === null) {
+        continue;
+      }
+
+      // Parse timestamp line: *<timestamp>*
+      if (!currentTimestamp) {
+        const timestampMatch = line.match(/^\*(.+)\*$/);
+        if (timestampMatch) {
+          currentTimestamp = parseTimestamp(timestampMatch[1]?.trim());
+          continue;
+        }
+      }
+
+      // Parse model line: **Model:** model-name (provider)
+      const modelMatch = line.match(
+        /^\*\*Model:\*\*\s*(.+?)(?:\s*\(([^)]+)\))?\s*$/
+      );
+      if (modelMatch) {
+        currentModel = modelMatch[1]?.trim();
+        if (modelMatch[2]) {
+          currentProvider = modelMatch[2].trim();
+        }
+        continue;
+      }
+
+      // Detect reasoning section
+      if (line.match(/^###\s+Reasoning\s*$/)) {
+        inReasoning = true;
+        continue;
+      }
+
+      // Section separator - skip if it's the trailing ---
+      if (line === "---") {
+        continue;
+      }
+
+      // Skip attachment and citation blocks for content
+      if (
+        line.match(/^\*\*Attachments:\*\*/) ||
+        line.match(/^\*\*Sources:\*\*/)
+      ) {
+        // Skip attachment/source lines until next blank line or section
+        continue;
+      }
+
+      if (inReasoning) {
+        // Reasoning ends when we hit the main content (non-empty line after a blank)
+        // Since the markdown format puts reasoning before content with a blank line between,
+        // we detect the transition: once we see content after reasoning, switch
+        if (line === "") {
+          // Check if we already have reasoning content - blank line might be the separator
+          if (currentReasoning.length > 0) {
+            inReasoning = false;
+          }
+          continue;
+        }
+        currentReasoning.push(line);
+      } else {
+        currentContent.push(line);
+      }
+    }
+
+    // Flush last message
+    flushMessage();
+
+    if (messages.length === 0) {
+      return {
+        conversations: [],
+        source: "polly",
+        count: 0,
+        errors: ["No messages found in markdown file"],
+      };
+    }
+
+    return {
+      conversations: [
+        {
+          title,
+          messages,
+          createdAt,
+          updatedAt,
+        },
+      ],
+      source: "polly",
+      count: 1,
+      errors: [],
+    };
+  } catch {
+    return {
+      conversations: [],
+      source: "polly",
+      count: 0,
+      errors: ["Failed to parse markdown format"],
     };
   }
 }

--- a/src/lib/import-parsers.ts
+++ b/src/lib/import-parsers.ts
@@ -271,6 +271,7 @@ function parseMarkdownImport(content: string): ImportResult {
       currentReasoning = [];
       currentContent = [];
       inReasoning = false;
+      inAttachmentsOrSources = false;
     };
 
     for (const line of lines) {

--- a/src/lib/import-parsers.ts
+++ b/src/lib/import-parsers.ts
@@ -326,20 +326,17 @@ function parseMarkdownImport(content: string): ImportResult {
       }
 
       if (inReasoning) {
-        // Reasoning ends when we hit the main content (non-empty line after a blank)
-        // Since the markdown format puts reasoning before content with a blank line between,
-        // we detect the transition: once we see content after reasoning, switch
         if (line === "") {
-          // Check if we already have reasoning content - blank line might be the separator
+          // Blank lines within reasoning are preserved
           if (currentReasoning.length > 0) {
-            inReasoning = false;
+            currentReasoning.push(line);
           }
           continue;
         }
+        // Check if this looks like content (e.g., starts new paragraph after reasoning)
+        // For now, keep accumulating reasoning until we hit metadata or separator
         currentReasoning.push(line);
       } else {
-        currentContent.push(line);
-      }
     }
 
     // Flush last message

--- a/src/lib/import-parsers.ts
+++ b/src/lib/import-parsers.ts
@@ -245,6 +245,7 @@ function parseMarkdownImport(content: string): ImportResult {
     let currentReasoning: string[] = [];
     let currentContent: string[] = [];
     let inReasoning = false;
+    let inAttachmentsOrSources = false;
 
     const flushMessage = () => {
       if (currentRole) {
@@ -346,6 +347,8 @@ function parseMarkdownImport(content: string): ImportResult {
         // For now, keep accumulating reasoning until we hit metadata or separator
         currentReasoning.push(line);
       } else {
+        currentContent.push(line);
+      }
     }
 
     // Flush last message

--- a/src/lib/import-parsers.ts
+++ b/src/lib/import-parsers.ts
@@ -321,8 +321,17 @@ function parseMarkdownImport(content: string): ImportResult {
         line.match(/^\*\*Attachments:\*\*/) ||
         line.match(/^\*\*Sources:\*\*/)
       ) {
-        // Skip attachment/source lines until next blank line or section
+        inAttachmentsOrSources = true;
         continue;
+      }
+
+      // Skip content within attachments/sources blocks (list items, citations)
+      if (inAttachmentsOrSources) {
+        if (line === "" || line.match(/^###/) || line.match(/^##/)) {
+          inAttachmentsOrSources = false;
+        } else {
+          continue;
+        }
       }
 
       if (inReasoning) {


### PR DESCRIPTION
## Summary
- **Fix JSON export format**: `exportAsJSON()` now produces the standard `{ source, version, conversations: [...] }` structure with numeric timestamps, making single-conversation exports importable
- **Add legacy format support**: Import parser handles old `{ conversation, messages }` shape and ISO date strings gracefully
- **Add markdown import**: New parser for `.md` files exported by Polly, extracting titles, timestamps, model info, reasoning blocks, and message content
- **Extract reusable import hook**: New `useConversationImport` hook shared by settings page and command palette
- **Add command palette import action**: "Import Conversations" action available from the command palette for authenticated users

## Test plan
- [ ] Export a conversation as JSON → import the file → verify conversation appears
- [ ] Export as Markdown → import the `.md` file → verify conversation appears
- [ ] Import a legacy-format JSON (old `{ conversation, messages }` shape) → verify it works
- [ ] Test command palette: search "import" → see the action → trigger file picker
- [ ] Test settings page import still works with both JSON and Markdown files
- [ ] Verify `bun run check` passes (lint + types + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)