### PR TITLE
fix: Eliminate layout shift on attachments and remove message animations

### DIFF
--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -170,6 +170,9 @@ export const attachmentSchema = v.object({
   textFileId: v.optional(v.id("_storage")), // Reference to stored text file
   extractedText: v.optional(v.string()), // Cached text extraction for PDFs (deprecated in favor of textFileId)
   extractionError: v.optional(v.string()), // Error message if extraction failed
+  // Media dimensions for layout shift prevention
+  width: v.optional(v.float64()),
+  height: v.optional(v.float64()),
   // Generated image metadata
   generatedImage: v.optional(
     v.object({

--- a/src/components/chat/input/attachment-display.tsx
+++ b/src/components/chat/input/attachment-display.tsx
@@ -96,7 +96,6 @@ function AttachmentDisplayInner({
     <>
       <AttachmentStrip
         attachments={attachments as Attachment[]}
-        variant="assistant"
         className="mt-0 mb-2 flex-nowrap overflow-x-auto"
         onPreviewFile={setPreviewFile}
         onRemove={onRemoveAttachment}

--- a/src/components/chat/message/assistant-bubble.tsx
+++ b/src/components/chat/message/assistant-bubble.tsx
@@ -218,7 +218,6 @@ const TextMessageBubble = ({
         attachments={message.attachments?.filter(
           att => !att.generatedImage?.isGenerated
         )}
-        variant="assistant"
         onPreviewFile={onPreviewFile}
       />
 

--- a/src/components/chat/message/attachment-strip.test.tsx
+++ b/src/components/chat/message/attachment-strip.test.tsx
@@ -4,12 +4,6 @@ import React from "react";
 import type { Attachment } from "@/types";
 import { AttachmentStrip } from "./attachment-strip";
 
-type FileDisplayProps = {
-  attachment: Attachment;
-  className?: string;
-  onClick?: () => void;
-};
-
 type ImageThumbnailProps = {
   attachment: Attachment;
   className?: string;
@@ -17,16 +11,6 @@ type ImageThumbnailProps = {
 
 // Mock the child components
 mock.module("@/components/files/file-display", () => ({
-  FileDisplay: ({ attachment, onClick }: FileDisplayProps) => (
-    // biome-ignore lint/a11y/useKeyWithClickEvents: Test mock component
-    <div
-      data-testid="file-display"
-      data-attachment-name={attachment.name}
-      onClick={onClick}
-    >
-      File: {attachment.name}
-    </div>
-  ),
   ImageThumbnail: ({ attachment, className }: ImageThumbnailProps) => (
     <div
       data-testid="image-thumbnail"
@@ -67,176 +51,32 @@ describe("AttachmentStrip", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  test("renders user variant with FileDisplay for non-image files", () => {
+  test("renders thumbnails for all attachment types", () => {
     const attachments = [
-      createMockAttachment({ name: "file1.pdf", type: "pdf" }),
-      createMockAttachment({ name: "file2.docx", type: "text" }),
-    ];
-
-    render(
-      <AttachmentStrip
-        attachments={attachments}
-        variant="user"
-        onPreviewFile={mockOnPreviewFile}
-      />
-    );
-
-    const fileDisplays = screen.getAllByTestId("file-display");
-    expect(fileDisplays).toHaveLength(2);
-    const firstDisplay = fileDisplays[0];
-    const secondDisplay = fileDisplays[1];
-    expect(firstDisplay?.getAttribute("data-attachment-name")).toBe(
-      "file1.pdf"
-    );
-    expect(secondDisplay?.getAttribute("data-attachment-name")).toBe(
-      "file2.docx"
-    );
-  });
-
-  test("renders user variant with thumbnail buttons for images", () => {
-    const attachments = [
-      createMockAttachment({ name: "photo1.jpg", type: "image" }),
-      createMockAttachment({ name: "photo2.png", type: "image" }),
-    ];
-
-    render(
-      <AttachmentStrip
-        attachments={attachments}
-        variant="user"
-        onPreviewFile={mockOnPreviewFile}
-      />
-    );
-
-    // Images should render as buttons containing thumbnails
-    const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(2);
-
-    const thumbnails = screen.getAllByTestId("image-thumbnail");
-    expect(thumbnails).toHaveLength(2);
-    expect(thumbnails[0]?.getAttribute("data-attachment-name")).toBe(
-      "photo1.jpg"
-    );
-    expect(thumbnails[1]?.getAttribute("data-attachment-name")).toBe(
-      "photo2.png"
-    );
-  });
-
-  test("user variant groups images above files", () => {
-    const attachments = [
+      createMockAttachment({ name: "photo.jpg", type: "image" }),
       createMockAttachment({ name: "doc.pdf", type: "pdf" }),
-      createMockAttachment({ name: "photo1.jpg", type: "image" }),
-      createMockAttachment({ name: "code.ts", type: "text" }),
-      createMockAttachment({ name: "photo2.png", type: "image" }),
     ];
 
-    const { container } = render(
+    render(
       <AttachmentStrip
         attachments={attachments}
-        variant="user"
         onPreviewFile={mockOnPreviewFile}
       />
     );
 
-    // Images should render as thumbnails
     const thumbnails = screen.getAllByTestId("image-thumbnail");
     expect(thumbnails).toHaveLength(2);
-
-    // Files should render as FileDisplay
-    const fileDisplays = screen.getAllByTestId("file-display");
-    expect(fileDisplays).toHaveLength(2);
-
-    // Images row should appear before files row in DOM
-    const rows = container.querySelectorAll(".flex.flex-wrap");
-    expect(rows).toHaveLength(2);
-
-    // First row should contain images (buttons)
-    expect(rows[0]?.querySelectorAll("button")).toHaveLength(2);
-
-    // Second row should contain files (file-display divs)
-    expect(
-      rows[1]?.querySelectorAll('[data-testid="file-display"]')
-    ).toHaveLength(2);
-  });
-
-  test("calls onPreviewFile when image thumbnail is clicked in user variant", () => {
-    const imageAttachment = createMockAttachment({
-      name: "photo.jpg",
-      type: "image",
-    });
-
-    render(
-      <AttachmentStrip
-        attachments={[imageAttachment]}
-        variant="user"
-        onPreviewFile={mockOnPreviewFile}
-      />
-    );
-
-    const button = screen.getByRole("button");
-    fireEvent.click(button);
-
-    expect(mockOnPreviewFile).toHaveBeenCalledWith(imageAttachment);
-    expect(mockOnPreviewFile).toHaveBeenCalledTimes(1);
-  });
-
-  test("renders assistant variant with custom buttons and thumbnails", () => {
-    const attachments = [
-      createMockAttachment({ name: "image.jpg", type: "image" }),
-      createMockAttachment({ name: "document.pdf", type: "pdf" }),
-    ];
-
-    render(
-      <AttachmentStrip
-        attachments={attachments}
-        variant="assistant"
-        onPreviewFile={mockOnPreviewFile}
-      />
-    );
 
     const buttons = screen.getAllByRole("button");
     expect(buttons).toHaveLength(2);
-
-    // Check for image thumbnails
-    const thumbnails = screen.getAllByTestId("image-thumbnail");
-    expect(thumbnails).toHaveLength(2);
   });
 
-  test("defaults to user variant", () => {
-    const attachments = [createMockAttachment()];
-
-    render(<AttachmentStrip attachments={attachments} />);
-
-    expect(screen.getByTestId("file-display")).toBeTruthy();
-    expect(screen.queryByRole("button")).toBeNull();
-  });
-
-  test("calls onPreviewFile when file display is clicked in user variant", () => {
-    const attachment = createMockAttachment({ name: "test.pdf" });
-    const attachments = [attachment];
-
-    render(
-      <AttachmentStrip
-        attachments={attachments}
-        variant="user"
-        onPreviewFile={mockOnPreviewFile}
-      />
-    );
-
-    const fileDisplay = screen.getByTestId("file-display");
-    fireEvent.click(fileDisplay);
-
-    expect(mockOnPreviewFile).toHaveBeenCalledWith(attachment);
-    expect(mockOnPreviewFile).toHaveBeenCalledTimes(1);
-  });
-
-  test("calls onPreviewFile when button is clicked in assistant variant", () => {
+  test("calls onPreviewFile when button is clicked", () => {
     const attachment = createMockAttachment({ name: "test.pdf", type: "text" });
-    const attachments = [attachment];
 
     render(
       <AttachmentStrip
-        attachments={attachments}
-        variant="assistant"
+        attachments={[attachment]}
         onPreviewFile={mockOnPreviewFile}
       />
     );
@@ -248,33 +88,29 @@ describe("AttachmentStrip", () => {
     expect(mockOnPreviewFile).toHaveBeenCalledTimes(1);
   });
 
-  test("does not render filename for image attachments in assistant variant", () => {
+  test("does not render filename for image attachments", () => {
     const attachment = createMockAttachment({
       name: "photo.jpg",
       type: "image",
     });
-    const attachments = [attachment];
 
-    render(<AttachmentStrip attachments={attachments} variant="assistant" />);
+    render(<AttachmentStrip attachments={[attachment]} />);
 
-    // Should not contain the filename text in the rendered output
     expect(screen.queryByText("photo.jpg")).toBeNull();
   });
 
-  test("renders truncated filename for non-image attachments in assistant variant", () => {
+  test("renders truncated filename for non-image attachments", () => {
     const attachment = createMockAttachment({
       name: "very-long-filename-that-should-be-truncated.pdf",
       type: "text",
     });
-    const attachments = [attachment];
 
-    render(<AttachmentStrip attachments={attachments} variant="assistant" />);
+    render(<AttachmentStrip attachments={[attachment]} />);
 
-    // Should show truncated version
     expect(screen.getByText("very-long....pdf")).toBeTruthy();
   });
 
-  test("applies different CSS classes for image vs file attachments in assistant variant", () => {
+  test("applies different CSS classes for image vs file attachments", () => {
     const imageAttachment = createMockAttachment({
       name: "photo.jpg",
       type: "image",
@@ -283,9 +119,8 @@ describe("AttachmentStrip", () => {
       name: "doc.pdf",
       type: "text",
     });
-    const attachments = [imageAttachment, fileAttachment];
 
-    render(<AttachmentStrip attachments={attachments} variant="assistant" />);
+    render(<AttachmentStrip attachments={[imageAttachment, fileAttachment]} />);
 
     const buttons = screen.getAllByRole("button");
     const firstButton = buttons[0];
@@ -300,24 +135,17 @@ describe("AttachmentStrip", () => {
   test("applies custom className", () => {
     const attachments = [createMockAttachment()];
 
-    render(
-      <AttachmentStrip
-        attachments={attachments}
-        variant="user"
-        className="custom-class"
-      />
+    const { container } = render(
+      <AttachmentStrip attachments={attachments} className="custom-class" />
     );
 
-    // FileDisplay is inside inner row div, which is inside outer container
-    const innerRow = screen.getByTestId("file-display").parentElement;
-    const outerContainer = innerRow?.parentElement;
-    expect(outerContainer?.className).toContain("custom-class");
+    expect(container.firstElementChild?.className).toContain("custom-class");
   });
 
   test("applies focus styles for accessibility", () => {
     const attachments = [createMockAttachment({ type: "text" })];
 
-    render(<AttachmentStrip attachments={attachments} variant="assistant" />);
+    render(<AttachmentStrip attachments={attachments} />);
 
     const button = screen.getByRole("button");
     expect(button.className).toContain("focus-visible:outline-none");
@@ -331,11 +159,9 @@ describe("AttachmentStrip", () => {
       name: "very-long-filename-with-multiple-extensions.tar.gz",
       type: "text",
     });
-    const attachments = [attachment];
 
-    render(<AttachmentStrip attachments={attachments} variant="assistant" />);
+    render(<AttachmentStrip attachments={[attachment]} />);
 
-    // Should preserve the last extension part
     expect(screen.getByText("very-long-....gz")).toBeTruthy();
   });
 
@@ -344,21 +170,17 @@ describe("AttachmentStrip", () => {
       name: "very-long-filename-without-extension",
       type: "text",
     });
-    const attachments = [attachment];
 
-    render(<AttachmentStrip attachments={attachments} variant="assistant" />);
+    render(<AttachmentStrip attachments={[attachment]} />);
 
-    // Should still truncate but without extension
     expect(screen.getByText("very-long-fil...")).toBeTruthy();
   });
 
   test("handles attachments with missing names gracefully", () => {
     const attachment = createMockAttachment({ name: "" });
-    const attachments = [attachment];
 
-    render(<AttachmentStrip attachments={attachments} variant="assistant" />);
+    render(<AttachmentStrip attachments={[attachment]} />);
 
-    // Should still render without crashing
     expect(screen.getByRole("button")).toBeTruthy();
   });
 
@@ -367,30 +189,14 @@ describe("AttachmentStrip", () => {
     const attachments2 = [createMockAttachment({ name: "file1.pdf" })]; // Same content
     const attachments3 = [createMockAttachment({ name: "file2.pdf" })]; // Different content
 
-    const { rerender } = render(
-      <AttachmentStrip attachments={attachments1} variant="user" />
-    );
+    const { rerender } = render(<AttachmentStrip attachments={attachments1} />);
 
     // Should not re-render with identical props
-    rerender(<AttachmentStrip attachments={attachments2} variant="user" />);
+    rerender(<AttachmentStrip attachments={attachments2} />);
 
     // Should re-render with different attachments
-    rerender(<AttachmentStrip attachments={attachments3} variant="user" />);
+    rerender(<AttachmentStrip attachments={attachments3} />);
 
-    expect(screen.getByText("File: file2.pdf")).toBeTruthy();
-  });
-
-  test("memoization detects variant changes", () => {
-    const attachments = [createMockAttachment()];
-
-    const { rerender } = render(
-      <AttachmentStrip attachments={attachments} variant="user" />
-    );
-
-    // Should re-render when variant changes
-    rerender(<AttachmentStrip attachments={attachments} variant="assistant" />);
-
-    expect(screen.getByRole("button")).toBeTruthy();
-    expect(screen.queryByTestId("file-display")).toBeNull();
+    expect(screen.getByText("Thumbnail: file2.pdf")).toBeTruthy();
   });
 });

--- a/src/components/chat/message/attachment-strip.tsx
+++ b/src/components/chat/message/attachment-strip.tsx
@@ -1,13 +1,12 @@
 import { XIcon } from "@phosphor-icons/react";
 import { memo, useCallback } from "react";
-import { FileDisplay, ImageThumbnail } from "@/components/files/file-display";
+import { ImageThumbnail } from "@/components/files/file-display";
 import { truncateMiddle } from "@/lib";
 import { cn } from "@/lib/utils";
 import type { Attachment } from "@/types";
 
 type AttachmentStripProps = {
   attachments?: Attachment[];
-  variant?: "user" | "assistant";
   onPreviewFile?: (attachment: Attachment) => void;
   onRemove?: (index: number) => void;
   className?: string;
@@ -17,7 +16,6 @@ type AttachmentStripProps = {
 
 const AttachmentStripComponent = ({
   attachments,
-  variant = "user",
   onPreviewFile,
   onRemove,
   className,
@@ -36,56 +34,11 @@ const AttachmentStripComponent = ({
     return null;
   }
 
-  if (variant === "user") {
-    const images = attachments.filter(att => att.type === "image");
-    const files = attachments.filter(att => att.type !== "image");
-
-    return (
-      <div className={cn("mt-2 stack-sm", className)}>
-        {/* Images - horizontal thumbnails */}
-        {images.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {images.map((attachment, index) => (
-              <button
-                key={attachment.name || attachment.url || `image-${index}`}
-                type="button"
-                className={cn(
-                  "relative h-12 w-12 cursor-pointer overflow-hidden rounded-lg",
-                  "ring-1 ring-border/30 hover:ring-primary/50",
-                  "transition-all duration-200 hover:shadow-md",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                )}
-                onClick={() => handleFileClick(attachment)}
-              >
-                <ImageThumbnail attachment={attachment} className="h-12 w-12" />
-              </button>
-            ))}
-          </div>
-        )}
-
-        {/* Files - compact pills */}
-        {files.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {files.map((attachment, index) => (
-              <FileDisplay
-                key={attachment.name || attachment.url || `file-${index}`}
-                attachment={attachment}
-                onClick={() => handleFileClick(attachment)}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // Assistant attachments - compact style with thumbnails
   return (
     <div className={cn("mt-2 flex flex-wrap gap-2", className)}>
       {attachments.map((attachment, index) => {
         const isVisual =
-          attachment.type === "image" ||
-          (attachment.type === "video" && !!attachment.thumbnail);
+          attachment.type === "image" || attachment.type === "video";
         return (
           <div
             key={attachment.name || attachment.url || `attachment-${index}`}
@@ -165,7 +118,7 @@ const AttachmentStripComponent = ({
 };
 
 export const AttachmentStrip = memo(AttachmentStripComponent, (prev, next) => {
-  if (prev.variant !== next.variant || prev.className !== next.className) {
+  if (prev.className !== next.className) {
     return false;
   }
   if (prev.onPreviewFile !== next.onPreviewFile) {

--- a/src/components/chat/message/user-bubble.tsx
+++ b/src/components/chat/message/user-bubble.tsx
@@ -162,7 +162,6 @@ export const UserBubble = memo(
                   attachments={message.attachments?.filter(
                     att => !att.generatedImage?.isGenerated
                   )}
-                  variant="user"
                   onPreviewFile={onPreviewFile}
                   className="mt-2"
                 />
@@ -192,7 +191,6 @@ export const UserBubble = memo(
                   attachments={message.attachments?.filter(
                     att => !att.generatedImage?.isGenerated
                   )}
-                  variant="user"
                   onPreviewFile={onPreviewFile}
                 />
               </div>

--- a/src/components/chat/virtualized-chat-messages.tsx
+++ b/src/components/chat/virtualized-chat-messages.tsx
@@ -59,7 +59,6 @@ export interface VirtualizedChatMessagesRef {
 interface MessageItemProps {
   messageId: string;
   isStreaming: boolean;
-  animate: boolean;
   conversationId?: string;
   onPreviewAttachment?: (attachment: import("@/types").Attachment) => void;
   onEditMessage?: (messageId: string, newContent: string) => void;
@@ -102,7 +101,6 @@ const MessageItem = memo(
   ({
     messageId,
     isStreaming,
-    animate,
     conversationId,
     onPreviewAttachment,
     onEditMessage,
@@ -123,7 +121,7 @@ const MessageItem = memo(
       <div className="px-4 sm:px-8 overflow-visible">
         <div
           id={message.id}
-          className={`mx-auto w-full max-w-3xl pb-3 sm:pb-4 overflow-visible${animate ? " animate-message-in" : ""}`}
+          className="mx-auto w-full max-w-3xl pb-3 sm:pb-4 overflow-visible"
         >
           {message.role === "context" ? (
             <ContextMessage message={message} />
@@ -159,10 +157,6 @@ const MessageItem = memo(
     }
 
     if (prevProps.isStreaming !== nextProps.isStreaming) {
-      return false;
-    }
-
-    if (prevProps.animate !== nextProps.animate) {
       return false;
     }
 
@@ -246,12 +240,6 @@ export const VirtualizedChatMessages = memo(
     const hasScrolledForCurrentAssistant = useRef(false);
     const lastAssistantMessageId = useRef<string | null>(null);
     const hasInitialScrolled = useRef(false);
-
-    // Track initial message IDs so we only animate newly added messages
-    const initialMessageIdsRef = useRef<Set<string> | null>(null);
-    if (initialMessageIdsRef.current === null) {
-      initialMessageIdsRef.current = new Set(messages.map(m => m.id));
-    }
 
     // Create a memoized message selector for efficient lookups
     const messagesMap = useMemo(() => {
@@ -625,13 +613,10 @@ export const VirtualizedChatMessages = memo(
           !message.metadata?.finishReason &&
           !message.metadata?.stopped;
 
-        const isNewMessage = !initialMessageIdsRef.current?.has(message.id);
-
         return (
           <MessageItem
             messageId={message.id}
             isStreaming={!!isMessageStreaming}
-            animate={isNewMessage}
             conversationId={conversationId}
             onPreviewAttachment={onPreviewAttachment}
             onEditMessage={onEditMessage}

--- a/src/components/layouts/shared-chat-layout.tsx
+++ b/src/components/layouts/shared-chat-layout.tsx
@@ -83,7 +83,7 @@ export const SharedChatLayout = ({ children }: SharedChatLayoutProps) => {
 
       <main
         className={cn(
-          "min-w-0 flex-1 overflow-hidden flex flex-col transition-all duration-300 ease-out",
+          "min-w-0 flex-1 overflow-hidden flex flex-col transition-[margin,padding,border-radius,box-shadow] duration-300 ease-out",
           // Base styles
           "bg-background",
           // Private mode specific styles: use margins to create the "shrunk" card effect

--- a/src/globals.css
+++ b/src/globals.css
@@ -1184,22 +1184,6 @@ pre {
   animation: fade-in-up 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-/* Message entrance animation - subtle slide up + fade */
-@keyframes message-in {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.animate-message-in {
-  animation: message-in 0.25s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
 /* Copy success bounce - plays on the check icon */
 @keyframes copy-success {
   0% {
@@ -1251,7 +1235,6 @@ pre {
 
 /* Respect reduced motion preferences */
 @media (prefers-reduced-motion: reduce) {
-  .animate-message-in,
   .animate-copy-success,
   .animate-page-enter,
   .animate-list-item-in {

--- a/src/hooks/use-convex-file-upload.ts
+++ b/src/hooks/use-convex-file-upload.ts
@@ -84,7 +84,10 @@ export function useConvexFileUpload() {
         // Generate thumbnail for images
         if (attachmentType === "image") {
           try {
-            attachment.thumbnail = await generateThumbnail(file);
+            const imageResult = await generateThumbnail(file);
+            attachment.thumbnail = imageResult.thumbnail;
+            attachment.width = imageResult.width;
+            attachment.height = imageResult.height;
           } catch (error) {
             console.warn("Failed to generate thumbnail:", error);
           }
@@ -93,7 +96,10 @@ export function useConvexFileUpload() {
         // Generate thumbnail for videos
         if (attachmentType === "video") {
           try {
-            attachment.thumbnail = await generateVideoThumbnail(file);
+            const videoResult = await generateVideoThumbnail(file);
+            attachment.thumbnail = videoResult.thumbnail;
+            attachment.width = videoResult.width;
+            attachment.height = videoResult.height;
           } catch (error) {
             console.warn("Failed to generate video thumbnail:", error);
           }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -267,6 +267,9 @@ export type Attachment = {
     wordCount: number;
     contentLength: number;
   };
+  // Media dimensions for layout shift prevention
+  width?: number;
+  height?: number;
   // Generated image metadata
   generatedImage?: {
     isGenerated: boolean;


### PR DESCRIPTION
## Summary

- **Attachment dimension tracking**: Store `width`/`height` in Attachment schema and type, returned from image/video processing utilities and persisted during upload
- **Skeleton loading states**: Replace spinners with properly-sized skeleton placeholders using CSS `aspect-ratio` for images, videos, and file pills — eliminates layout shift when content loads
- **Unified attachment strip**: Remove user/assistant variant split — both use the same compact thumbnail rendering with consistent video play icon fallback
- **Remove message entrance animation**: Strip `animate-message-in` entirely (CSS, refs, prop) so conversation switches are instant with no slide-up flicker

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run fix` — no issues
- [x] `bun run test` — 1322 pass, 0 fail
- [ ] Switch between conversations rapidly — no message animations, no layout transitions
- [ ] Upload an image, send message — skeleton with correct aspect ratio, no shift when loaded
- [ ] Upload a video — thumbnail with play icon in both input and message
- [ ] View old messages with images (no stored dimensions) — fallback 4:3 skeleton
- [ ] Video without thumbnail shows muted placeholder with play icon, not a skeleton

🤖 Generated with [Claude Code](https://claude.com/claude-code)