### PR TITLE
feat: implement Exa Instant search mode for ultra-fast web search

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "date-fns": "^4.1.0",
         "dedent": "^1.7.1",
         "embla-carousel-react": "^8.6.0",
-        "exa-js": "^2.0.12",
+        "exa-js": "2.4.0",
         "framer-motion": "^12.24.12",
         "frimousse": "^0.3.0",
         "fuse.js": "^7.1.0",
@@ -776,7 +776,7 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
-    "exa-js": ["exa-js@2.0.12", "", { "dependencies": { "cross-fetch": "~4.1.0", "dotenv": "~16.4.7", "openai": "^5.0.1", "zod": "^3.22.0", "zod-to-json-schema": "^3.20.0" } }, "sha512-56ZYm8FLKAh3JXCptr0vlG8f39CZxCl4QcPW9QR4TSKS60PU12pEfuQdf+6xGWwQp+doTgXguCqqzxtvgDTDKw=="],
+    "exa-js": ["exa-js@2.4.0", "", { "dependencies": { "cross-fetch": "~4.1.0", "dotenv": "~16.4.7", "openai": "^5.0.1", "zod": "^3.22.0", "zod-to-json-schema": "^3.20.0" } }, "sha512-zOFClWWZnh9wyUN3xiBgbhuT8DsS62uZJY+P9toN4KgxyCRQma7aU89/7UCtrXNwq5kEFAACw4eualXcTKjiAQ=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 

--- a/convex/ai/exa.ts
+++ b/convex/ai/exa.ts
@@ -7,7 +7,12 @@ export const exaSearchArgs = v.object({
   query: v.string(),
   maxResults: v.optional(v.number()),
   searchType: v.optional(
-    v.union(v.literal("fast"), v.literal("auto"), v.literal("deep")),
+    v.union(
+      v.literal("instant"),
+      v.literal("fast"),
+      v.literal("auto"),
+      v.literal("deep"),
+    ),
   ),
   category: v.optional(
     v.union(
@@ -109,11 +114,12 @@ export async function searchWithExa(
     const exa = new Exa(apiKey);
 
     const searchMode =
-      args.searchType || (detectResearchQuery(args.query) ? "deep" : "fast");
+      args.searchType ||
+      (detectResearchQuery(args.query) ? "deep" : "instant");
 
     const searchOptions: Record<string, unknown> = {
       numResults: args.maxResults || WEB_SEARCH_MAX_RESULTS,
-      mode: searchMode,
+      type: searchMode,
       useAutoprompt: true,
       category: args.category,
       startPublishedDate: args.startPublishedDate,
@@ -304,7 +310,7 @@ export async function findSimilarWithExa(
 export interface WebSearchArgs {
   query: string;
   searchType?: "search" | "answer" | "similar";
-  searchMode?: "fast" | "auto" | "deep";
+  searchMode?: "instant" | "fast" | "auto" | "deep";
   category?: string;
   maxResults?: number;
   excludeDomains?: string[];
@@ -357,7 +363,7 @@ export async function performWebSearch(
 
         const searchMode =
           args.searchMode ||
-          (detectResearchQuery(args.query) ? "deep" : "fast");
+          (detectResearchQuery(args.query) ? "deep" : "instant");
         const result = await searchWithExa(apiKey, {
           query: args.query,
           maxResults,
@@ -384,7 +390,7 @@ export async function performWebSearch(
       default: {
         const searchMode =
           args.searchMode ||
-          (detectResearchQuery(args.query) ? "deep" : "fast");
+          (detectResearchQuery(args.query) ? "deep" : "instant");
         const result = await searchWithExa(apiKey, {
           query: args.query,
           maxResults,

--- a/convex/ai/tools/web_search.ts
+++ b/convex/ai/tools/web_search.ts
@@ -39,11 +39,11 @@ function cleanSnippet(text: string): string {
 export const webSearchToolSchema = z.object({
   query: z.string().describe("The search query to find relevant information"),
   searchMode: z
-    .enum(["fast", "deep", "auto"])
+    .enum(["instant", "fast", "deep", "auto"])
     .optional()
-    .default("fast")
+    .default("instant")
     .describe(
-      "Search mode: 'fast' for quick results (~350ms), 'deep' for comprehensive research (~3.5s), 'auto' for balanced"
+      "Search mode: 'instant' for ultra-fast results (<200ms, default), 'fast' for quick results (~350ms), 'deep' for comprehensive research (~3.5s), 'auto' for balanced"
     ),
   searchType: z
     .enum(["search", "answer", "similar"])
@@ -110,7 +110,8 @@ Parameters:
   - 'answer': Direct factual questions (who is CEO of X, what is the price of Y)
   - 'similar': Find pages similar to a given URL
 - searchMode: Search speed/depth tradeoff
-  - 'fast': Default for most queries (~350ms)
+  - 'instant': Default for most queries (<200ms, ultra-fast)
+  - 'fast': Quick results (~350ms)
   - 'deep': For comprehensive research (~3.5s)
   - 'auto': Let the system decide
 - category: Optional filter to narrow results by type
@@ -139,7 +140,7 @@ Example: For "latest AI news", use searchType='search' with category='news'.`,
           citations: result.citations,
           context: buildContextSummary(result),
           searchQuery: query,
-          searchMode: searchMode || "fast",
+          searchMode: searchMode || "instant",
           searchType: searchType || "search",
           category,
         };
@@ -149,7 +150,7 @@ Example: For "latest AI news", use searchType='search' with category='news'.`,
           citations: [],
           context: "",
           searchQuery: query,
-          searchMode: searchMode || "fast",
+          searchMode: searchMode || "instant",
           searchType: searchType || "search",
           error:
             error instanceof Error ? error.message : "Unknown error occurred",

--- a/convex/ai/url_processing.ts
+++ b/convex/ai/url_processing.ts
@@ -296,7 +296,7 @@ export async function fetchUrlContents(
           // Fallback: try to search for the URL content
           const searchOptions: Record<string, unknown> = {
             numResults: 1,
-            mode: "fast",
+            type: "instant",
             text: args.includeText !== false ? {
               maxCharacters: args.maxCharacters || 8000,
               includeHtmlTags: false,

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -238,7 +238,12 @@ export const messageMetadataSchema = v.object({
   searchFeature: v.optional(v.string()),
   searchCategory: v.optional(v.string()),
   searchMode: v.optional(
-    v.union(v.literal("fast"), v.literal("auto"), v.literal("deep")),
+    v.union(
+      v.literal("instant"),
+      v.literal("fast"),
+      v.literal("auto"),
+      v.literal("deep"),
+    ),
   ),
 });
 

--- a/convex/types.ts
+++ b/convex/types.ts
@@ -223,7 +223,7 @@ export type ProviderStreamOptions =
 // ============================================================================
 
 export type ExaFeatureType = "search" | "answer" | "similar";
-export type SearchMode = "fast" | "auto" | "deep";
+export type SearchMode = "instant" | "fast" | "auto" | "deep";
 
 export interface SearchDecision {
   shouldSearch: boolean;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "date-fns": "^4.1.0",
     "dedent": "^1.7.1",
     "embla-carousel-react": "^8.6.0",
-    "exa-js": "^2.0.12",
+    "exa-js": "2.4.0",
     "framer-motion": "^12.24.12",
     "frimousse": "^0.3.0",
     "fuse.js": "^7.1.0",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -222,7 +222,7 @@ export type ChatMessage = {
     searchQuery?: string;
     searchFeature?: string;
     searchCategory?: string;
-    searchMode?: "fast" | "auto" | "deep";
+    searchMode?: "instant" | "fast" | "auto" | "deep";
     status?: "pending" | "error";
   };
   imageGeneration?: {


### PR DESCRIPTION
Upgrade exa-js to v2.4.0 and add "instant" as the new default search
mode (<200ms), replacing "fast" (~350ms) for non-research queries.

https://claude.ai/code/session_01WmYEtUA5Hkm3Aykx8xLdZZ