### PR TITLE
fix: pass supportsReasoning to streamMessage so OpenRouter respects disabled reasoning

### DIFF
--- a/convex/conversations.ts
+++ b/convex/conversations.ts
@@ -291,6 +291,7 @@ export async function createConversationHandler(
       // Pass model capabilities from mutation context where auth is available
       supportsTools: fullModel.supportsTools ?? false,
       supportsFiles: fullModel.supportsFiles ?? false,
+      supportsReasoning: fullModel.supportsReasoning ?? false,
     });
   }
   return {
@@ -612,6 +613,7 @@ export const sendMessage = action({
       // Pass model capabilities from mutation context where auth is available
       supportsTools: fullModel.supportsTools ?? false,
       supportsFiles: fullModel.supportsFiles ?? false,
+      supportsReasoning: fullModel.supportsReasoning ?? false,
     });
 
     return { userMessageId, assistantMessageId };
@@ -1630,6 +1632,7 @@ export const startConversation = action({
       // Pass model capabilities from mutation context where auth is available
       supportsTools: fullModel.supportsTools ?? false,
       supportsFiles: fullModel.supportsFiles ?? false,
+      supportsReasoning: fullModel.supportsReasoning ?? false,
     });
 
     // 7. Schedule title generation
@@ -2289,6 +2292,7 @@ export const retryFromMessage = action({
           reasoningConfig: args.reasoningConfig,
           supportsTools: fullModel.supportsTools ?? false,
           supportsFiles: fullModel.supportsFiles ?? false,
+          supportsReasoning: fullModel.supportsReasoning ?? false,
         }
       );
 

--- a/convex/lib/conversation/streaming.ts
+++ b/convex/lib/conversation/streaming.ts
@@ -72,6 +72,7 @@ export const executeStreamingActionForRetry = async (
     // Model capabilities - passed from caller who has access to model info
     supportsTools?: boolean;
     supportsFiles?: boolean;
+    supportsReasoning?: boolean;
   }
 ): Promise<StreamingActionResult> => {
   const userId = await getAuthUserId(ctx);
@@ -113,6 +114,7 @@ export const executeStreamingActionForRetry = async (
     reasoningConfig: args.reasoningConfig,
     supportsTools: args.supportsTools ?? false,
     supportsFiles: args.supportsFiles ?? false,
+    supportsReasoning: args.supportsReasoning ?? false,
   });
 
   return {

--- a/convex/streaming_actions.ts
+++ b/convex/streaming_actions.ts
@@ -140,6 +140,7 @@ export const streamMessage = internalAction({
     // Model capabilities passed from mutation context (where auth is available)
     supportsTools: v.optional(v.boolean()),
     supportsFiles: v.optional(v.boolean()),
+    supportsReasoning: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const {
@@ -180,7 +181,12 @@ export const streamMessage = internalAction({
         ctx,
         provider as Parameters<typeof getProviderStreamOptions>[1],
         modelId,
-        reasoningConfig
+        reasoningConfig,
+        {
+          modelId,
+          provider,
+          supportsReasoning: args.supportsReasoning ?? false,
+        }
       );
 
       // 4. Strip attachments from older messages (keep only on last user message)

--- a/shared/reasoning-config.test.ts
+++ b/shared/reasoning-config.test.ts
@@ -484,6 +484,41 @@ describe("getProviderReasoningConfig", () => {
     });
   });
 
+  test("returns explicit disable for OpenRouter Kimi K2.5 via pattern detection when reasoning disabled", () => {
+    // Even without supportsReasoning from DB, pattern detection should recognize K2.5
+    const model: ModelWithCapabilities = {
+      modelId: "moonshotai/kimi-k2.5",
+      provider: "openrouter",
+      supportsReasoning: false,
+    };
+
+    const result = getProviderReasoningConfig(model, { enabled: false });
+    expect(result).toEqual({
+      extraBody: {
+        reasoning: {
+          enabled: false,
+        },
+      },
+    });
+  });
+
+  test("returns explicit disable for OpenRouter Kimi K2.5 via pattern detection when no config", () => {
+    const model: ModelWithCapabilities = {
+      modelId: "moonshotai/kimi-k2.5",
+      provider: "openrouter",
+      supportsReasoning: false,
+    };
+
+    const result = getProviderReasoningConfig(model);
+    expect(result).toEqual({
+      extraBody: {
+        reasoning: {
+          enabled: false,
+        },
+      },
+    });
+  });
+
   test("returns explicit disable for OpenRouter when no reasoning config", () => {
     const model: ModelWithCapabilities = {
       modelId: "grok-4",

--- a/shared/reasoning-model-detection.test.ts
+++ b/shared/reasoning-model-detection.test.ts
@@ -55,6 +55,13 @@ describe("hasMandatoryReasoning", () => {
     expect(hasMandatoryReasoning("moonshot", "kimi-k2")).toBe(false);
     expect(hasMandatoryReasoning("moonshot", "moonlight-16k-v2")).toBe(false);
   });
+
+  test("returns false for Kimi K2.5 (optional reasoning, not mandatory)", () => {
+    expect(hasMandatoryReasoning("openrouter", "moonshotai/kimi-k2.5")).toBe(
+      false
+    );
+    expect(hasMandatoryReasoning("moonshot", "kimi-k2.5")).toBe(false);
+  });
 });
 
 describe("hasOptionalReasoning", () => {
@@ -88,6 +95,13 @@ describe("hasOptionalReasoning", () => {
     expect(hasOptionalReasoning("openrouter", "gemini-2.5-flash")).toBe(true);
     expect(hasOptionalReasoning("openrouter", "claude-opus-4")).toBe(true);
   });
+
+  test("detects Kimi K2.5 as optional reasoning", () => {
+    expect(hasOptionalReasoning("openrouter", "moonshotai/kimi-k2.5")).toBe(
+      true
+    );
+    expect(hasOptionalReasoning("moonshot", "kimi-k2.5")).toBe(true);
+  });
 });
 
 describe("supportsReasoning", () => {
@@ -112,6 +126,10 @@ describe("supportsReasoning", () => {
 
   test("returns false for non-thinking Moonshot models", () => {
     expect(supportsReasoning("moonshot", "kimi-k2")).toBe(false);
+  });
+
+  test("returns true for Kimi K2.5 via OpenRouter", () => {
+    expect(supportsReasoning("openrouter", "moonshotai/kimi-k2.5")).toBe(true);
   });
 });
 
@@ -174,6 +192,12 @@ describe("getReasoningType", () => {
 
   test("returns none for non-thinking Moonshot models", () => {
     expect(getReasoningType("moonshot", "kimi-k2")).toBe("none");
+  });
+
+  test("returns optional for Kimi K2.5", () => {
+    expect(getReasoningType("openrouter", "moonshotai/kimi-k2.5")).toBe(
+      "optional"
+    );
   });
 });
 

--- a/shared/reasoning-model-detection.ts
+++ b/shared/reasoning-model-detection.ts
@@ -71,6 +71,9 @@ export const OPTIONAL_REASONING_PATTERNS = [
   "grok", // Grok supports effort levels per OpenRouter docs
   "grok-4", // Grok-4 with optional reasoning
 
+  // Moonshot/Kimi reasoning models (optional reasoning via OpenRouter)
+  "kimi-k2.5",
+
   // Additional reasoning-capable models available via OpenRouter
   "deepthink",
   "reflection",


### PR DESCRIPTION
The streamMessage internal action lacked auth context to look up model
capabilities, and Kimi K2.5 wasn't in any reasoning pattern list. This
meant the action couldn't detect the model supports reasoning, so it
never sent { reasoning: { enabled: false } } to OpenRouter — which then
auto-enabled reasoning regardless of user settings.

Pass supportsReasoning from callers (who have models.dev-hydrated
capabilities) to the streaming action, matching how supportsTools and
supportsFiles are already passed. Also add kimi-k2.5 to optional
reasoning patterns as a detection fallback.

https://claude.ai/code/session_01Jpb7RMn9dCNSd2swDSTLUY