### PR TITLE
feat: Add image generation as AI SDK tool for text models

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as ai_server_utils from "../ai/server_utils.js";
 import type * as ai_streaming_core from "../ai/streaming_core.js";
 import type * as ai_text_generation from "../ai/text_generation.js";
 import type * as ai_tools_conversation_search from "../ai/tools/conversation_search.js";
+import type * as ai_tools_image_generation from "../ai/tools/image_generation.js";
 import type * as ai_tools_index from "../ai/tools/index.js";
 import type * as ai_tools_web_search from "../ai/tools/web_search.js";
 import type * as ai_url_processing from "../ai/url_processing.js";
@@ -110,6 +111,7 @@ declare const fullApi: ApiFromModules<{
   "ai/streaming_core": typeof ai_streaming_core;
   "ai/text_generation": typeof ai_text_generation;
   "ai/tools/conversation_search": typeof ai_tools_conversation_search;
+  "ai/tools/image_generation": typeof ai_tools_image_generation;
   "ai/tools/index": typeof ai_tools_index;
   "ai/tools/web_search": typeof ai_tools_web_search;
   "ai/url_processing": typeof ai_url_processing;

--- a/convex/ai/tools/image_generation.ts
+++ b/convex/ai/tools/image_generation.ts
@@ -1,0 +1,296 @@
+import { tool } from "ai";
+import { z } from "zod/v3";
+import Replicate from "replicate";
+import type { ActionCtx } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { internal } from "../../_generated/api";
+
+/**
+ * Image model info passed from mutation context (where auth is available).
+ */
+export type ImageModelInfo = {
+  modelId: string;
+  name: string;
+  description?: string;
+  supportedAspectRatios?: string[];
+  modelVersion?: string;
+};
+
+/**
+ * Image generation tool schema for AI SDK tool calling.
+ */
+export const imageGenerationToolSchema = z.object({
+  prompt: z
+    .string()
+    .describe(
+      "A detailed prompt describing the image to generate. Be specific about style, composition, lighting, and subject matter."
+    ),
+  model: z
+    .string()
+    .describe(
+      "The model ID to use for generation. Must be one of the available models listed in the tool description."
+    ),
+  aspectRatio: z
+    .enum(["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"])
+    .optional()
+    .default("1:1")
+    .describe("Aspect ratio for the generated image. Defaults to 1:1 (square)."),
+});
+
+export type ImageGenerationToolParams = z.infer<
+  typeof imageGenerationToolSchema
+>;
+
+/**
+ * Result returned from the image generation tool.
+ */
+export interface ImageGenerationToolResult {
+  success: boolean;
+  imageCount?: number;
+  model?: string;
+  prompt?: string;
+  error?: string;
+}
+
+/**
+ * Tool name constant for reference.
+ */
+export const IMAGE_GENERATION_TOOL_NAME = "generateImage" as const;
+
+/**
+ * Creates the image generation tool for AI SDK streamText.
+ * Uses the same closure pattern as createConversationSearchTool.
+ */
+export function createImageGenerationTool(
+  ctx: ActionCtx,
+  messageId: Id<"messages">,
+  replicateApiKey: string,
+  availableModels: ImageModelInfo[]
+) {
+  // Build dynamic description listing available models
+  const modelListStr = availableModels
+    .map((m) => {
+      const desc = m.description ? ` — ${m.description}` : "";
+      return `- "${m.modelId}" (${m.name})${desc}`;
+    })
+    .join("\n");
+
+  return tool({
+    description: `Generate an image using AI image generation models. Use this tool when the user asks you to create, generate, draw, or make an image.
+
+Available models:
+${modelListStr}
+
+Choose the model that best fits the user's request. If the user doesn't specify a model, pick the most appropriate one.
+
+Tips for good prompts:
+- Be specific and descriptive about what you want to see
+- Include style, lighting, composition, and mood details
+- Mention the medium (photograph, oil painting, digital art, etc.)`,
+    inputSchema: imageGenerationToolSchema,
+    execute: async ({
+      prompt,
+      model,
+      aspectRatio,
+    }): Promise<ImageGenerationToolResult> => {
+      // Validate the requested model is in the available list
+      const validModel = availableModels.find((m) => m.modelId === model);
+      if (!validModel) {
+        const validIds = availableModels.map((m) => m.modelId).join(", ");
+        return {
+          success: false,
+          error: `Model "${model}" is not available. Available models: ${validIds}`,
+        };
+      }
+
+      try {
+        const replicate = new Replicate({ auth: replicateApiKey });
+
+        // Resolve the model version — use stored version or fetch latest
+        let version = validModel.modelVersion;
+        if (!version) {
+          const [owner, name] = model.split("/");
+          if (!owner || !name) {
+            return {
+              success: false,
+              model,
+              prompt,
+              error: `Invalid model format: ${model}. Expected 'owner/name'.`,
+            };
+          }
+          const modelData = await replicate.models.get(owner, name);
+          version = modelData.latest_version?.id;
+          if (!version) {
+            return {
+              success: false,
+              model,
+              prompt,
+              error: `No version available for model: ${model}`,
+            };
+          }
+        }
+
+        // Create prediction with explicit version and wait for completion
+        const input: Record<string, unknown> = { prompt };
+
+        // Only include aspect_ratio if the model declares supported ratios
+        if (validModel.supportedAspectRatios && validModel.supportedAspectRatios.length > 0) {
+          input.aspect_ratio = aspectRatio || "1:1";
+        }
+
+        const prediction = await replicate.predictions.create({
+          version,
+          input,
+        });
+
+        // Wait for the prediction to complete
+        const completedPrediction = await replicate.wait(prediction);
+
+        if (
+          completedPrediction.status !== "succeeded" ||
+          !completedPrediction.output
+        ) {
+          return {
+            success: false,
+            model,
+            prompt,
+            error:
+              typeof completedPrediction.error === "string"
+                ? completedPrediction.error
+                : `Prediction ${completedPrediction.status}`,
+          };
+        }
+
+        // Handle various Replicate output types
+        const imageUrls = extractImageUrls(completedPrediction.output);
+
+        if (imageUrls.length === 0) {
+          return {
+            success: false,
+            model,
+            prompt,
+            error: "No images were returned from the model.",
+          };
+        }
+
+        // Download and store each image in Convex file storage
+        const attachments = [];
+        for (let i = 0; i < imageUrls.length; i++) {
+          const imageUrl = imageUrls[i];
+          if (!imageUrl) {
+            continue;
+          }
+          try {
+            const response = await fetch(imageUrl);
+            if (!response.ok) {
+              console.error(
+                `[image_generation] Failed to download image ${i}:`,
+                response.status
+              );
+              continue;
+            }
+
+            const imageBuffer = await response.arrayBuffer();
+            const contentType =
+              response.headers.get("content-type") || "image/jpeg";
+            const imageBlob = new globalThis.Blob([imageBuffer], {
+              type: contentType,
+            });
+
+            const storageId = await ctx.storage.store(imageBlob);
+
+            const baseName = model.replace(/[^a-zA-Z0-9]/g, "_");
+            let ext = ".jpg";
+            if (contentType.includes("png")) {
+              ext = ".png";
+            } else if (contentType.includes("webp")) {
+              ext = ".webp";
+            }
+            const fileName =
+              imageUrls.length > 1
+                ? `${baseName}_${i + 1}${ext}`
+                : `${baseName}${ext}`;
+
+            attachments.push({
+              type: "image" as const,
+              url: imageUrl,
+              name: fileName,
+              size: imageBuffer.byteLength,
+              storageId: storageId as Id<"_storage">,
+              mimeType: contentType,
+              generatedImage: {
+                isGenerated: true,
+                source: "replicate",
+                model,
+                prompt,
+              },
+            });
+          } catch (imgError) {
+            console.error(
+              `[image_generation] Failed to store image ${i}:`,
+              imgError
+            );
+          }
+        }
+
+        if (attachments.length > 0) {
+          // Attach images to the assistant message
+          await ctx.runMutation(internal.messages.addAttachments, {
+            messageId,
+            attachments,
+          });
+        }
+
+        return {
+          success: true,
+          imageCount: attachments.length,
+          model,
+          prompt,
+        };
+      } catch (error) {
+        console.error("[image_generation] Error:", error);
+        return {
+          success: false,
+          model,
+          prompt,
+          error:
+            error instanceof Error ? error.message : "Image generation failed",
+        };
+      }
+    },
+  });
+}
+
+/**
+ * Extract image URLs from various Replicate output formats.
+ * Handles: string URL, array of strings, ReadableStream (returns empty — not supported).
+ */
+function extractImageUrls(output: unknown): string[] {
+  if (typeof output === "string") {
+    return [output];
+  }
+
+  if (Array.isArray(output)) {
+    return output
+      .filter((item): item is string => typeof item === "string")
+      .filter((url) => url.startsWith("http"));
+  }
+
+  // Some newer models return an object with an `output` or `url` field
+  if (output && typeof output === "object") {
+    const obj = output as Record<string, unknown>;
+    if (typeof obj.url === "string") {
+      return [obj.url];
+    }
+    if (typeof obj.output === "string") {
+      return [obj.output];
+    }
+    if (Array.isArray(obj.output)) {
+      return (obj.output as unknown[])
+        .filter((item): item is string => typeof item === "string")
+        .filter((url) => url.startsWith("http"));
+    }
+  }
+
+  return [];
+}

--- a/convex/ai/tools/index.ts
+++ b/convex/ai/tools/index.ts
@@ -20,3 +20,12 @@ export {
   type ConversationSearchToolParams,
   type ConversationSearchToolResult,
 } from "./conversation_search";
+
+export {
+  createImageGenerationTool,
+  imageGenerationToolSchema,
+  IMAGE_GENERATION_TOOL_NAME,
+  type ImageModelInfo,
+  type ImageGenerationToolParams,
+  type ImageGenerationToolResult,
+} from "./image_generation";

--- a/convex/imageModels.ts
+++ b/convex/imageModels.ts
@@ -272,6 +272,20 @@ export const getUserImageModels = query({
 });
 
 /**
+ * Internal query to get user image models without auth context.
+ * Used by streaming actions which run outside auth context.
+ */
+export const getUserImageModelsInternal = internalQuery({
+  args: { userId: v.id("users") },
+  handler: (ctx, args) => {
+    return ctx.db
+      .query("userImageModels")
+      .withIndex("by_user", q => q.eq("userId", args.userId))
+      .collect();
+  },
+});
+
+/**
  * Get all active built-in image models.
  */
 export const getBuiltInImageModels = query({

--- a/convex/lib/conversation/context_building.ts
+++ b/convex/lib/conversation/context_building.ts
@@ -330,8 +330,8 @@ export const buildContextMessages = async (
     // Build system messages
     const systemMessages = [];
 
-    // Add baseline instructions with persona (webSearchEnabled: false for retry contexts)
-    const baselineInstructions = getBaselineInstructions("default", "UTC", { webSearchEnabled: false });
+    // Add baseline instructions with persona
+    const baselineInstructions = getBaselineInstructions("default", "UTC");
     const mergedInstructions = mergeSystemPrompts(
       baselineInstructions,
       personaPrompt,

--- a/convex/lib/conversation/streaming.ts
+++ b/convex/lib/conversation/streaming.ts
@@ -73,6 +73,15 @@ export const executeStreamingActionForRetry = async (
     supportsTools?: boolean;
     supportsFiles?: boolean;
     supportsReasoning?: boolean;
+    // Image generation tool support
+    imageModels?: Array<{
+      modelId: string;
+      name: string;
+      description?: string;
+      supportedAspectRatios?: string[];
+      modelVersion?: string;
+    }>;
+    userId?: string;
   }
 ): Promise<StreamingActionResult> => {
   const userId = await getAuthUserId(ctx);
@@ -115,6 +124,8 @@ export const executeStreamingActionForRetry = async (
     supportsTools: args.supportsTools ?? false,
     supportsFiles: args.supportsFiles ?? false,
     supportsReasoning: args.supportsReasoning ?? false,
+    imageModels: args.imageModels,
+    userId: args.userId as Id<"users"> | undefined,
   });
 
   return {

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -766,6 +766,8 @@ export const toolCallSchema = v.object({
     v.object({
       query: v.optional(v.string()),
       mode: v.optional(v.string()),
+      prompt: v.optional(v.string()),
+      imageModel: v.optional(v.string()),
     })
   ),
   error: v.optional(v.string()),

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -572,6 +572,10 @@ export const internalUpdate = internalMutation({
     // Web search citations
     citations: v.optional(v.array(webCitationSchema)),
     metadata: v.optional(extendedMessageMetadataSchema),
+    // Streaming state that must be clearable on retry
+    toolCalls: v.optional(v.array(toolCallSchema)),
+    attachments: v.optional(v.array(attachmentSchema)),
+    reasoningParts: v.optional(v.array(reasoningPartSchema)),
     // Allow simple appends for streaming-like updates
     appendContent: v.optional(v.string()),
     appendReasoning: v.optional(v.string()),

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -22,6 +22,13 @@ export const BATCH_SIZE = 20; // Batch size for import processing
 export const WEB_SEARCH_MAX_RESULTS = 12; // Default max Exa search results - matches Exa demo default
 
 // Image Generation Defaults
+/**
+ * Marker inserted into assistant message content at the point where
+ * an image-generation tool call occurs. The frontend splits on this
+ * to render: text-before → generated image → text-after.
+ */
+export const IMAGE_GEN_MARKER = "\n\n<!-- generated-image -->\n\n";
+
 export const IMAGE_GENERATION_DEFAULTS = {
   MODEL: "black-forest-labs/flux-dev",
   ASPECT_RATIO: "1:1" as const,

--- a/shared/system-prompts.ts
+++ b/shared/system-prompts.ts
@@ -51,7 +51,25 @@ CITATIONS:
 `;
 
 /**
- * Build baseline instructions with dynamic values
+ * Image generation instructions - appended when image generation tool is available
+ */
+export const IMAGE_GENERATION_INSTRUCTIONS = dedent`
+IMAGE GENERATION:
+- You can generate images using the generateImage tool when the user asks you to create, draw, make, or generate an image.
+- Only call generateImage ONCE per response. Do not generate multiple images unless the user explicitly asks for variations.
+- Write a brief introduction before calling the tool, then call generateImage.
+- The generated image is displayed directly to the user. After the tool completes, do NOT describe the image, restate what it shows, or output the tool result. Just continue the conversation naturally — the user can already see it.
+- Write detailed, descriptive prompts that specify style, composition, lighting, mood, and subject matter.
+- If generation fails, inform the user and suggest they try again or adjust their request.
+`;
+
+/**
+ * Build baseline instructions with dynamic values.
+ *
+ * Note: Tool-specific instructions (citations, image generation) are injected
+ * in streaming_core.ts where tool availability is actually determined, rather
+ * than being passed as options here.
+ *
  * @param modelName - The AI model name to display
  * @param timezone - Timezone for datetime (defaults to UTC)
  * @param options.webSearchEnabled - Include citation instructions when true

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -200,6 +200,20 @@ export const ChatMessage = memo(
       return false;
     }
 
+    // Re-render when tool calls change (e.g., generateImage running → completed)
+    const prevToolCalls = prevProps.message.toolCalls;
+    const nextToolCalls = nextProps.message.toolCalls;
+    if ((prevToolCalls?.length ?? 0) !== (nextToolCalls?.length ?? 0)) {
+      return false;
+    }
+    if (prevToolCalls && nextToolCalls) {
+      for (let i = 0; i < prevToolCalls.length; i++) {
+        if (prevToolCalls[i]?.status !== nextToolCalls[i]?.status) {
+          return false;
+        }
+      }
+    }
+
     // Default memo comparison for other props
     return (
       prevProps.message.id === nextProps.message.id &&

--- a/src/components/chat/message/assistant-loading-state.tsx
+++ b/src/components/chat/message/assistant-loading-state.tsx
@@ -10,6 +10,8 @@ type AssistantLoadingStateProps = {
   reasoningParts?: ReasoningPart[];
   thinkingDurationMs?: number;
   toolCalls?: ToolCall[];
+  /** Suppress the text skeleton when another loading indicator is visible (e.g. image gen). */
+  suppressSkeleton?: boolean;
 };
 
 /**
@@ -24,12 +26,13 @@ export function AssistantLoadingState({
   reasoningParts,
   thinkingDurationMs,
   toolCalls,
+  suppressSkeleton,
 }: AssistantLoadingStateProps) {
   const hasActivity =
     (reasoningParts?.length ?? 0) > 0 ||
     Boolean(reasoning?.trim()) ||
     (toolCalls?.length ?? 0) > 0;
-  const showSkeleton = phase === "loading" && !hasActivity;
+  const showSkeleton = phase === "loading" && !hasActivity && !suppressSkeleton;
 
   // Reasoning is only "active" before content starts streaming.
   // Once the phase transitions to streaming/complete, reasoning is done.

--- a/src/components/chat/message/tool-generated-images.tsx
+++ b/src/components/chat/message/tool-generated-images.tsx
@@ -1,0 +1,141 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useQuery } from "convex/react";
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { Attachment, ToolCall } from "@/types";
+import { ImageGenerationSkeleton } from "./image-generation-skeleton";
+
+type ToolGeneratedImagesProps = {
+  toolCalls?: ToolCall[];
+  attachments?: Attachment[];
+  /** When true the message is still streaming — show skeletons for running tools. */
+  isActive?: boolean;
+  onPreviewFile?: (attachment: Attachment) => void;
+};
+
+/**
+ * Renders tool-generated images inline in a text message bubble.
+ * Placed between the activity stream and text content so images
+ * interleave naturally: activity → images → text.
+ *
+ * Skeletons only appear while the message is actively streaming
+ * (`isActive`) and no images have arrived yet.
+ */
+export function ToolGeneratedImages({
+  toolCalls,
+  attachments,
+  isActive = false,
+  onPreviewFile,
+}: ToolGeneratedImagesProps) {
+  const generatedImages = useMemo(
+    () =>
+      attachments?.filter(
+        att => att.type === "image" && att.generatedImage?.isGenerated
+      ) ?? [],
+    [attachments]
+  );
+
+  // Only show skeletons when actively streaming, a tool is running,
+  // AND no images have arrived yet (prevents overlap when attachment
+  // mutation commits before tool-result status update).
+  const showSkeleton = useMemo(() => {
+    if (!isActive || generatedImages.length > 0) {
+      return false;
+    }
+    return (
+      toolCalls?.some(
+        tc => tc.name === "generateImage" && tc.status === "running"
+      ) ?? false
+    );
+  }, [toolCalls, isActive, generatedImages.length]);
+
+  if (!showSkeleton && generatedImages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-3">
+      {/* Skeleton while generating (before any images arrive) */}
+      {showSkeleton && (
+        <div className="max-w-sm sm:max-w-md">
+          <ImageGenerationSkeleton aspectRatio="1:1" />
+        </div>
+      )}
+
+      {/* Completed generated images */}
+      {generatedImages.length > 0 && (
+        <div
+          className={cn(
+            "overflow-visible",
+            generatedImages.length === 1
+              ? "flex flex-col items-start"
+              : "grid gap-4",
+            generatedImages.length === 2 && "grid-cols-1 sm:grid-cols-2",
+            generatedImages.length >= 3 && "grid-cols-1 sm:grid-cols-2"
+          )}
+        >
+          {generatedImages.map((attachment, index) => (
+            <GeneratedImageCard
+              key={attachment.storageId || attachment.url || `gen-img-${index}`}
+              attachment={attachment}
+              onPreviewFile={onPreviewFile}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Single tool-generated image card with Convex storage URL resolution.
+ * Uses a simple img tag — no skeleton overlay to avoid reserving extra space.
+ */
+function GeneratedImageCard({
+  attachment,
+  onPreviewFile,
+}: {
+  attachment: Attachment;
+  onPreviewFile?: (attachment: Attachment) => void;
+}) {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const storageUrl = useQuery(
+    api.fileStorage.getFileUrl,
+    attachment.storageId
+      ? { storageId: attachment.storageId as Id<"_storage"> }
+      : "skip"
+  );
+
+  const imageUrl = storageUrl || attachment.url;
+
+  if (!imageUrl) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "max-w-sm sm:max-w-md rounded-lg overflow-hidden transition-all duration-300 ease-out",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-zoom-in",
+        isLoaded
+          ? "opacity-100 translate-y-0 shadow-lg hover:shadow-xl"
+          : "opacity-0 translate-y-1"
+      )}
+      onClick={() => onPreviewFile?.(attachment)}
+      aria-label="View full size image"
+    >
+      <img
+        src={imageUrl}
+        alt={attachment.generatedImage?.prompt || attachment.name}
+        className="w-full rounded-lg"
+        loading="lazy"
+        decoding="async"
+        onLoad={() => setIsLoaded(true)}
+        onError={() => setIsLoaded(true)}
+      />
+    </button>
+  );
+}

--- a/src/components/chat/unified-chat-view/index.tsx
+++ b/src/components/chat/unified-chat-view/index.tsx
@@ -39,30 +39,6 @@ const ConversationZeroState = () => {
   );
 };
 
-function checkIfLikelyImageConversation(messages: ChatMessage[]): boolean {
-  if (!messages || messages.length === 0) {
-    return false;
-  }
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const m = messages[i];
-    if (!m) {
-      continue;
-    }
-    if (m.role === "assistant") {
-      if (m.imageGeneration) {
-        return true;
-      }
-      const hasGeneratedImage = (m.attachments || []).some(
-        att => att.type === "image" && att.generatedImage?.isGenerated
-      );
-      if (hasGeneratedImage) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 type UnifiedChatViewProps = {
   conversationId?: ConversationId;
   messages: ChatMessage[];
@@ -571,9 +547,6 @@ export const UnifiedChatView = memo(
                       isLoading={isLoading || !hasApiKeys}
                       isStreaming={isStreaming}
                       isArchived={isArchived}
-                      isLikelyImageConversation={checkIfLikelyImageConversation(
-                        messages
-                      )}
                       onSendMessage={
                         hasApiKeys && !isArchived
                           ? handleSendMessage

--- a/src/pages/chat-conversation-page.tsx
+++ b/src/pages/chat-conversation-page.tsx
@@ -453,13 +453,9 @@ export default function ConversationRoute() {
       if (!latestWithContext) {
         return "text";
       }
-      if (
-        latestWithContext.imageGeneration ||
-        latestWithContext.provider === "replicate" ||
-        (latestWithContext.attachments ?? []).some(
-          att => att.type === "image" && att.generatedImage?.isGenerated
-        )
-      ) {
+      // Only switch to image mode for direct Replicate image generation,
+      // not when a text model calls the generateImage tool.
+      if (latestWithContext.provider === "replicate") {
         return "image";
       }
       return "text";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -176,6 +176,8 @@ export type ToolCall = {
   args?: {
     query?: string;
     mode?: string;
+    prompt?: string;
+    imageModel?: string;
   };
   error?: string;
 };


### PR DESCRIPTION
## Summary
- Adds `generateImage` as an AI SDK tool so text models (Claude, GPT, etc.) can generate images inline via Replicate without requiring the user to switch to image mode
- New `image_generation.ts` tool calls Replicate API, stores results in Convex file storage, and attaches them to the assistant message
- Frontend splits content on `IMAGE_GEN_MARKER` to render text → image → text inline, with skeleton loading states
- Removes the `isLikelyImageConversation` auto-switch heuristic — image generation is now a tool call, not a mode

## Key changes
- **Backend**: `streaming_core.ts` orchestrates both `webSearch` and `generateImage` tools, injects tool-specific system prompt instructions, limits to one image gen per response via `prepareStep`
- **Frontend**: `ToolGeneratedImages` component renders generated images inline; `ToolCallBlock` shows image generation status; `AssistantBubble` splits content around the image marker
- **Cleanup**: Deduplicated image model querying with `toImageModelInfos()` helper, removed dead `imageGenerationEnabled` option, fixed file extension to match actual content type

## Test plan
- [ ] Send a message asking a text model to generate an image — verify it calls Replicate and renders inline
- [ ] Verify web search still works independently and alongside image gen
- [ ] Retry an assistant message that had image gen — verify stale data is cleared
- [ ] Check that models without tool support don't get the image gen tool
- [ ] Verify the skeleton loading state appears while image is generating

🤖 Generated with [Claude Code](https://claude.com/claude-code)