### PR TITLE
fix: use providerOptions instead of extraBody for OpenRouter reasoning

### DIFF
--- a/convex/types.ts
+++ b/convex/types.ts
@@ -195,21 +195,19 @@ export type OpenRouterReasoningConfig = {
 export type ProviderStreamOptions =
   | Record<string, never> // Empty object for non-reasoning models
   | { openai: { reasoning: boolean } }
-  | {
-      providerOptions: {
-        google: {
-          thinkingConfig: { thinkingBudget: number };
-        };
-      };
-    }
   | { anthropic: { thinking: { type: "enabled"; budgetTokens: number } } }
   | {
-      extraBody: {
-        reasoning: {
-          effort?: "low" | "medium" | "high";
-          max_tokens?: number;
-          exclude?: boolean;
-          enabled?: boolean;
+      providerOptions: {
+        google?: {
+          thinkingConfig: { thinkingBudget: number };
+        };
+        openrouter?: {
+          reasoning: {
+            effort?: "low" | "medium" | "high";
+            max_tokens?: number;
+            exclude?: boolean;
+            enabled?: boolean;
+          };
         };
       };
     };

--- a/shared/reasoning-config.test.ts
+++ b/shared/reasoning-config.test.ts
@@ -268,10 +268,12 @@ describe("getProviderReasoningOptions", () => {
     });
 
     expect(result).toEqual({
-      extraBody: {
-        reasoning: {
-          effort: "high",
-          exclude: false,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: "high",
+            exclude: false,
+          },
         },
       },
     });
@@ -283,10 +285,12 @@ describe("getProviderReasoningOptions", () => {
     });
 
     expect(result).toEqual({
-      extraBody: {
-        reasoning: {
-          max_tokens: 8000,
-          exclude: false,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            max_tokens: 8000,
+            exclude: false,
+          },
         },
       },
     });
@@ -296,10 +300,12 @@ describe("getProviderReasoningOptions", () => {
     const result = getProviderReasoningOptions("openrouter");
 
     expect(result).toEqual({
-      extraBody: {
-        reasoning: {
-          enabled: true,
-          exclude: false,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            enabled: true,
+            exclude: false,
+          },
         },
       },
     });
@@ -360,9 +366,11 @@ describe("getProviderBaseOptions", () => {
 describe("getReasoningDisabledOptions", () => {
   test("returns explicit disable for OpenRouter", () => {
     expect(getReasoningDisabledOptions("openrouter")).toEqual({
-      extraBody: {
-        reasoning: {
-          enabled: false,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            enabled: false,
+          },
         },
       },
     });
@@ -476,9 +484,11 @@ describe("getProviderReasoningConfig", () => {
 
     const result = getProviderReasoningConfig(model, { enabled: false });
     expect(result).toEqual({
-      extraBody: {
-        reasoning: {
-          enabled: false,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            enabled: false,
+          },
         },
       },
     });
@@ -494,9 +504,11 @@ describe("getProviderReasoningConfig", () => {
 
     const result = getProviderReasoningConfig(model, { enabled: false });
     expect(result).toEqual({
-      extraBody: {
-        reasoning: {
-          enabled: false,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            enabled: false,
+          },
         },
       },
     });
@@ -511,9 +523,11 @@ describe("getProviderReasoningConfig", () => {
 
     const result = getProviderReasoningConfig(model);
     expect(result).toEqual({
-      extraBody: {
-        reasoning: {
-          enabled: false,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            enabled: false,
+          },
         },
       },
     });
@@ -528,9 +542,11 @@ describe("getProviderReasoningConfig", () => {
 
     const result = getProviderReasoningConfig(model);
     expect(result).toEqual({
-      extraBody: {
-        reasoning: {
-          enabled: false,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            enabled: false,
+          },
         },
       },
     });

--- a/shared/reasoning-config.ts
+++ b/shared/reasoning-config.ts
@@ -46,25 +46,19 @@ export type GoogleProviderOptions = {
 export type ProviderStreamOptions =
   | Record<string, never> // Empty object for non-reasoning models
   | { openai: { reasoning: boolean } }
-  | {
-      providerOptions: {
-        google: GoogleProviderOptions;
-      };
-    }
   | { anthropic: { thinking: { type: "enabled"; budgetTokens: number } } }
   | {
       providerOptions: {
-        groq: {
+        google?: GoogleProviderOptions;
+        groq?: {
           reasoningFormat: "parsed";
           reasoningEffort: "low" | "default" | "high";
           maxOutputTokens?: number;
           parallelToolCalls: boolean;
         };
-      };
-    }
-  | {
-      extraBody: {
-        reasoning: OpenRouterReasoningOptions;
+        openrouter?: {
+          reasoning: OpenRouterReasoningOptions;
+        };
       };
     };
 
@@ -262,6 +256,7 @@ export function getProviderReasoningOptions(
       // - max_tokens: Direct token allocation (for Gemini, Anthropic models)
       // - exclude: true/false to hide reasoning from response
       // - enabled: true to use default settings
+      // Must use providerOptions.openrouter (not extraBody) at the streamText level
       const reasoningOptions: OpenRouterReasoningOptions = {
         exclude: false,
       };
@@ -289,8 +284,10 @@ export function getProviderReasoningOptions(
       }
 
       return {
-        extraBody: {
-          reasoning: reasoningOptions,
+        providerOptions: {
+          openrouter: {
+            reasoning: reasoningOptions,
+          },
         },
       };
     }
@@ -320,9 +317,11 @@ export function getReasoningDisabledOptions(
 ): ProviderStreamOptions {
   if (provider === "openrouter") {
     return {
-      extraBody: {
-        reasoning: {
-          enabled: false,
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            enabled: false,
+          },
         },
       },
     };


### PR DESCRIPTION
## Summary
- `extraBody` is only valid at the model/factory level in `@openrouter/ai-sdk-provider`, not at the `streamText()` call level where it gets silently ignored
- This meant `reasoning: { enabled: false }` was never sent to OpenRouter, causing models like Kimi K2.5 to always use reasoning regardless of user settings
- Switched to `providerOptions.openrouter` — the correct way to pass provider-specific options at the `streamText` level, matching how Google and Groq already work

## Test plan
- [x] All 1328 tests pass
- [x] TypeScript compiles cleanly
- [x] Verified Kimi K2.5 on OpenRouter no longer defaults to reasoning when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)