### PR TITLE
feat: switch built-in model from Kimi K2 to K2.5

### DIFF
--- a/config/models/text-models.ts
+++ b/config/models/text-models.ts
@@ -24,8 +24,8 @@ export type TextModelConfig = {
  */
 export const builtInTextModels: TextModelConfig[] = [
   {
-    name: "Kimi K2",
-    modelId: "moonshotai/kimi-k2-0905",
+    name: "Kimi K2.5",
+    modelId: "moonshotai/kimi-k2.5",
     provider: "openrouter",
     free: true,
   },

--- a/convex/lib/shared/stream_utils.ts
+++ b/convex/lib/shared/stream_utils.ts
@@ -39,7 +39,7 @@ export const DEFAULT_STREAM_CONFIG: StreamConfig = {
 export function humanizeReasoningText(text: string): string {
   return text
     .replace(/<thinking>|<\/thinking>/g, "")
-    .replace(/<think>|<\/think>/g, "") // Moonshot Kimi K2 format
+    .replace(/<think>|<\/think>/g, "") // Moonshot Kimi format
     .replace(/<reasoning>|<\/reasoning>/g, "")
     .replace(/\[reasoning]|\[\/reasoning]/gi, "")
     .replace(/^Thinking:\s*/i, "");


### PR DESCRIPTION
## Summary
- Switches the built-in free model from Kimi K2 (`moonshotai/kimi-k2-0905`) to Kimi K2.5 (`moonshotai/kimi-k2.5`)
- No userModels migration needed — built-in model selection resolves from the `builtInModels` table at query time, and user-added K2 models (with their own API keys) should not be touched

## Post-deploy
```bash
bunx convex run migrations/seedBuiltInModels:runMigration
```

## Test plan
- [ ] Verify seed migration replaces K2 with K2.5 in builtInModels
- [ ] Verify new conversations use K2.5 as the free model
- [ ] Verify users with custom K2 models are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)