### PR TITLE
fix: resolve Access Denied error when retrying image generation

### DIFF
--- a/convex/ai/replicate.ts
+++ b/convex/ai/replicate.ts
@@ -902,6 +902,13 @@ export const pollPrediction = internalAction({
         return;
       }
 
+      // Check if a retry has replaced this prediction with a newer one.
+      // Without this guard, a stale poll from the previous generation can
+      // overwrite the retry's in-progress state with old results.
+      if (messageDoc?.imageGeneration?.replicateId !== args.predictionId) {
+        return;
+      }
+
       // Get the model from the message metadata to check if it's a free built-in model
       const modelId = messageDoc?.imageGeneration?.metadata?.model;
       let isFreeBuiltInModel = false;

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -352,12 +352,10 @@ export async function getFileUrlHandler(
     // If no userFiles entries exist at all, the file may have just been uploaded
     // and the message hasn't been saved yet. Allow access if the file exists in storage.
     // This handles the race condition between file upload and message creation.
+    // Also handles the case where both the file and userFiles entries were deleted
+    // (e.g., during message retry cleanup) — return null instead of throwing.
     if (!hasAccess && allUserFileEntries.length === 0) {
-      const fileExists = await ctx.storage.getUrl(args.storageId);
-      if (fileExists) {
-        // File exists but no userFiles entry yet - likely a pending upload
-        return fileExists;
-      }
+      return await ctx.storage.getUrl(args.storageId);
     }
 
     if (!hasAccess) {


### PR DESCRIPTION
## Summary
- **`getFileUrl` now returns `null` instead of throwing "Access denied"** when both the storage file and `userFiles` entries have been deleted (e.g., during message retry cleanup). Previously, the query would re-evaluate after deletion but before the frontend component unmounted, hitting an edge case that threw incorrectly.
- **`pollPrediction` now checks that the `replicateId` matches** the current prediction on the message. This prevents stale polls from a previous generation from overwriting retry state with old results.

## Test plan
- [x] Retry a standalone image generation message (Replicate) — no more "Access denied" error
- [ ] Retry a text message that used image generation as a tool — verify no errors
- [ ] Generate an image, then retry before it completes — verify new generation proceeds correctly
- [ ] Verify normal (non-retry) image generation still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)