### PR TITLE
fix: support multiple image generation tool calls in a single message

### DIFF
--- a/convex/ai/streaming_core.ts
+++ b/convex/ai/streaming_core.ts
@@ -291,7 +291,7 @@ export async function streamLLMToMessage({
                 ctx,
                 messageId,
                 replicateApiKey!,
-                imageModels
+                imageModels,
               ),
             }
           : {}),

--- a/convex/ai/tools/image_generation.ts
+++ b/convex/ai/tools/image_generation.ts
@@ -65,7 +65,7 @@ export function createImageGenerationTool(
   ctx: ActionCtx,
   messageId: Id<"messages">,
   replicateApiKey: string,
-  availableModels: ImageModelInfo[]
+  availableModels: ImageModelInfo[],
 ) {
   // Build dynamic description listing available models
   const modelListStr = availableModels
@@ -92,7 +92,7 @@ Tips for good prompts:
       prompt,
       model,
       aspectRatio,
-    }): Promise<ImageGenerationToolResult> => {
+    }, { toolCallId }): Promise<ImageGenerationToolResult> => {
       // Validate the requested model is in the available list
       const validModel = availableModels.find((m) => m.modelId === model);
       if (!validModel) {
@@ -223,6 +223,7 @@ Tips for good prompts:
                 source: "replicate",
                 model,
                 prompt,
+                toolCallId,
               },
             });
           } catch (imgError) {

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -181,6 +181,7 @@ export const attachmentSchema = v.object({
       model: v.optional(v.string()),
       prompt: v.optional(v.string()),
       seed: v.optional(v.number()),
+      toolCallId: v.optional(v.string()), // Link to tool call for multi-image ordering
     }),
   ),
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -278,6 +278,7 @@ export type Attachment = {
     source: string; // "replicate", etc.
     model?: string;
     prompt?: string;
+    toolCallId?: string; // Link to tool call for multi-image ordering
   };
 };
 


### PR DESCRIPTION
## Summary
- Replaces single `indexOf` split on `IMAGE_GEN_MARKER` with `split()` to handle multiple markers
- Each image generation tool call now renders at its correct position in the text, with per-position tool call and attachment data
- Old single-image and no-image messages continue to render correctly

## Test plan
- [ ] Ask a text model to generate two images in the same response — both should appear at the correct positions between text segments
- [ ] Verify single-image generation messages still render correctly
- [ ] Verify messages without image generation are unchanged
- [ ] Verify skeleton loading states appear per-position while images are generating

🤖 Generated with [Claude Code](https://claude.com/claude-code)