### PR TITLE
fix: eliminate unnecessary re-renders causing battery drain on mobile

### DIFF
--- a/src/components/chat/unified-chat-view/index.tsx
+++ b/src/components/chat/unified-chat-view/index.tsx
@@ -502,7 +502,7 @@ export const UnifiedChatView = memo(
                     isArchived={isArchived}
                     onSavePrivateChat={onSavePrivateChat}
                     canSavePrivateChat={canSavePrivateChat}
-                    privateMessages={messages}
+                    privateMessages={conversationId ? undefined : messages}
                     privatePersonaId={currentPersonaId || undefined}
                   />
                 </div>

--- a/src/components/chat/virtualized-chat-messages.tsx
+++ b/src/components/chat/virtualized-chat-messages.tsx
@@ -16,6 +16,15 @@ import { ZenModeDialog } from "./message/zen-mode-dialog";
 
 export type PersonaInfo = { icon: string; name: string } | null;
 
+const VIRTUOSO_STYLE: React.CSSProperties = {
+  height: "100%",
+  width: "100%",
+  overflowX: "clip",
+  overflowY: "auto",
+  contain: "layout style size",
+  WebkitOverflowScrolling: "touch",
+};
+
 type VirtualizedChatMessagesProps = {
   messages: ChatMessageType[];
   isStreaming?: boolean;
@@ -682,14 +691,7 @@ export const VirtualizedChatMessages = memo(
           scrollerRef={handleScrollerRef}
           initialTopMostItemIndex={processedMessages.length - 1}
           overscan={overscan * 100}
-          style={{
-            height: "100%",
-            width: "100%",
-            overflowX: "clip",
-            overflowY: "auto",
-            contain: "layout style size",
-            WebkitOverflowScrolling: "touch",
-          }}
+          style={VIRTUOSO_STYLE}
           className="overscroll-contain scrollbar-thin"
           topItemCount={0}
           context={virtuosoContext}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -10,6 +10,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import { Button, type ButtonProps } from "@/components/ui/button";
@@ -128,20 +129,32 @@ function Carousel({
     };
   }, [api, onSelect]);
 
+  const contextValue = useMemo(
+    () => ({
+      carouselRef,
+      api: api,
+      opts,
+      orientation:
+        orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+      scrollPrev,
+      scrollNext,
+      canScrollPrev,
+      canScrollNext,
+    }),
+    [
+      carouselRef,
+      api,
+      opts,
+      orientation,
+      scrollPrev,
+      scrollNext,
+      canScrollPrev,
+      canScrollNext,
+    ]
+  );
+
   return (
-    <CarouselContext.Provider
-      value={{
-        carouselRef,
-        api: api,
-        opts,
-        orientation:
-          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
-        scrollPrev,
-        scrollNext,
-        canScrollPrev,
-        canScrollNext,
-      }}
-    >
+    <CarouselContext.Provider value={contextValue}>
       <section
         ref={ref}
         onKeyDownCapture={handleKeyDown}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -6,6 +6,7 @@ import {
   type RefCallback,
   useCallback,
   useContext,
+  useMemo,
   useState,
 } from "react";
 
@@ -32,8 +33,9 @@ const TriggerWidthCtx = createContext<TriggerWidthContextValue>({
 
 function SelectRoot<V>(props: SelectRootProps<V>) {
   const [width, setWidth] = useState<number | null>(null);
+  const ctxValue = useMemo(() => ({ width, setWidth }), [width]);
   return (
-    <TriggerWidthCtx value={{ width, setWidth }}>
+    <TriggerWidthCtx value={ctxValue}>
       <Select.Root<V> {...props} />
     </TriggerWidthCtx>
   );

--- a/src/providers/citation-context.tsx
+++ b/src/providers/citation-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useMemo } from "react";
 import type { WebSearchCitation } from "@/types";
 
 type CitationContextType = {
@@ -17,8 +17,13 @@ export function CitationProvider({
   citations: WebSearchCitation[];
   messageId?: string;
 }) {
+  const value = useMemo(
+    () => ({ citations, messageId }),
+    [citations, messageId]
+  );
+
   return (
-    <CitationContext.Provider value={{ citations, messageId }}>
+    <CitationContext.Provider value={value}>
       {children}
     </CitationContext.Provider>
   );

--- a/src/providers/scroll-container-context.tsx
+++ b/src/providers/scroll-container-context.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { createContext, useContext, useRef } from "react";
+import { createContext, useCallback, useContext, useMemo, useRef } from "react";
 
 type ScrollContainerContextValue = {
   scrollContainerRef: React.RefObject<HTMLElement | null>;
@@ -16,14 +16,17 @@ export function ScrollContainerProvider({
 }) {
   const scrollContainerRef = useRef<HTMLElement | null>(null);
 
-  const setScrollContainer = (element: HTMLElement | null) => {
+  const setScrollContainer = useCallback((element: HTMLElement | null) => {
     scrollContainerRef.current = element;
-  };
+  }, []);
+
+  const value = useMemo(
+    () => ({ scrollContainerRef, setScrollContainer }),
+    [setScrollContainer]
+  );
 
   return (
-    <ScrollContainerContext.Provider
-      value={{ scrollContainerRef, setScrollContainer }}
-    >
+    <ScrollContainerContext.Provider value={value}>
       {children}
     </ScrollContainerContext.Provider>
   );

--- a/src/providers/sidebar-width-context.tsx
+++ b/src/providers/sidebar-width-context.tsx
@@ -1,4 +1,11 @@
-import { createContext, type ReactNode, useContext, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 import { CACHE_KEYS, get, set } from "@/lib/local-storage";
 
 const MIN_SIDEBAR_WIDTH = 320;
@@ -24,24 +31,22 @@ export function SidebarWidthProvider({ children }: { children: ReactNode }) {
   });
   const [isResizing, setIsResizing] = useState(false);
 
-  const setSidebarWidth = (width: number) => {
+  const setSidebarWidth = useCallback((width: number) => {
     const constrainedWidth = Math.max(
       MIN_SIDEBAR_WIDTH,
       Math.min(MAX_SIDEBAR_WIDTH, width)
     );
     setSidebarWidthState(constrainedWidth);
     set(CACHE_KEYS.sidebarWidth, constrainedWidth);
-  };
+  }, []);
+
+  const value = useMemo(
+    () => ({ sidebarWidth, setSidebarWidth, isResizing, setIsResizing }),
+    [sidebarWidth, setSidebarWidth, isResizing]
+  );
 
   return (
-    <SidebarWidthContext.Provider
-      value={{
-        sidebarWidth,
-        setSidebarWidth,
-        isResizing,
-        setIsResizing,
-      }}
-    >
+    <SidebarWidthContext.Provider value={value}>
       {children}
     </SidebarWidthContext.Provider>
   );

--- a/src/providers/toast-context.tsx
+++ b/src/providers/toast-context.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
 } from "react";
 import { toast } from "sonner";
@@ -179,13 +180,10 @@ export function ToastProvider({ children }: ToastProviderProps) {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  const value: ToastContextValue = {
-    success,
-    error,
-    loading,
-    dismiss,
-    dismissAll,
-  };
+  const value = useMemo(
+    () => ({ success, error, loading, dismiss, dismissAll }),
+    [success, error, loading, dismiss, dismissAll]
+  );
 
   return (
     <ToastContext.Provider value={value}>{children}</ToastContext.Provider>


### PR DESCRIPTION
## Summary
- **Split chat handler memoization** — separated `serverHandlers` and `privateHandlers` into independent `useMemo` calls so server mode (the common case) has zero dependency on `messages`, preventing cascading re-renders on every Convex subscription update
- **Stabilized callback props** — extracted inline callbacks in `ConversationRoute` into `useCallback` hooks and deduplicated identical retry handlers, preserving `UnifiedChatView`'s `memo()` boundary
- **Fixed 6 unstable context providers** — added `useMemo` for context values in toast, sidebar-width, citation, scroll-container, select, and carousel providers that were creating new objects every render
- **Memoized activity-stream computation** — wrapped sort/filter/count logic in `useMemo` to avoid re-running every frame during streaming
- **Removed unnecessary effect dependencies** — used ref pattern for `managedToast`/`convex` in `useBackgroundJobs` effect, eliminating constant re-firing
- **Extracted static Virtuoso style** as module-level constant to avoid object allocation on each render

## What was happening
On a new conversation, `messages` state changes propagated through a single `chatHandlers` useMemo → all callback props → defeated `UnifiedChatView` memo → full component tree re-renders. Even on idle, Convex real-time subscription updates could trigger this cascade, causing battery drain on mobile.

## Test plan
- [ ] Verify new conversation loads and streams correctly
- [ ] Verify retry, edit, delete message actions work
- [ ] Verify private chat mode works (send, retry, edit, save)
- [ ] Verify image generation retry works
- [ ] Verify toast notifications appear for background jobs
- [ ] Verify sidebar resizing works
- [ ] Verify carousel and select components render correctly
- [ ] Profile with React DevTools — confirm reduced re-renders on idle conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)