### PR TITLE
feat: conversation search with message-level matches

### DIFF
--- a/convex/conversations.ts
+++ b/convex/conversations.ts
@@ -50,6 +50,7 @@ import {
   isStreamingHandler,
   listHandler,
   searchHandler,
+  searchWithMatchesHandler,
 } from "./lib/conversation/query_handlers";
 import { paginationOptsSchema } from "./lib/pagination";
 import {
@@ -67,6 +68,7 @@ export {
   createConversationHandler,
   listHandler,
   searchHandler,
+  searchWithMatchesHandler,
   getHandler,
   getWithAccessInfoHandler,
   getForExportHandler,
@@ -97,6 +99,16 @@ export const search = query({
     limit: v.optional(v.number()),
   },
   handler: searchHandler,
+});
+
+export const searchWithMatches = query({
+  args: {
+    searchQuery: v.string(),
+    includeArchived: v.optional(v.boolean()),
+    limit: v.optional(v.number()),
+    maxMatchesPerConversation: v.optional(v.number()),
+  },
+  handler: searchWithMatchesHandler,
 });
 
 export const get = query({

--- a/convex/conversations.ts
+++ b/convex/conversations.ts
@@ -104,7 +104,6 @@ export const search = query({
 export const searchWithMatches = query({
   args: {
     searchQuery: v.string(),
-    includeArchived: v.optional(v.boolean()),
     limit: v.optional(v.number()),
     maxMatchesPerConversation: v.optional(v.number()),
   },

--- a/convex/lib/conversation/query_handlers.ts
+++ b/convex/lib/conversation/query_handlers.ts
@@ -470,7 +470,7 @@ export async function searchWithMatchesHandler(
   const matchCountPerConversation = new Map<string, number>();
 
   for (const msg of messageMatches) {
-    const convId = msg.conversationId as string;
+    const convId = msg.conversationId;
     const currentCount = matchCountPerConversation.get(convId) ?? 0;
     if (currentCount >= maxMatchesPerConversation) {
       continue;

--- a/convex/lib/conversation/query_handlers.ts
+++ b/convex/lib/conversation/query_handlers.ts
@@ -312,6 +312,222 @@ export async function getByClientIdHandler(
   return conversation._id;
 }
 
+// ============================================================================
+// Search with message-level matches
+// ============================================================================
+
+type MessageMatchResult = {
+  messageId: string;
+  snippet: string;
+  role: string;
+  createdAt: number;
+};
+
+type ConversationSearchWithMatchesResult = {
+  conversationId: string;
+  title: string;
+  updatedAt: number;
+  isPinned: boolean;
+  matchedIn: "title" | "messages" | "both";
+  messageMatches: MessageMatchResult[];
+};
+
+/** Minimum word length worth centering a snippet on (skip "a", "is", etc.) */
+const MIN_SNIPPET_WORD_LENGTH = 3;
+
+/**
+ * Extract a snippet centered around the best matching word from `query`.
+ *
+ * For multi-word queries, tries the full phrase first, then falls back to the
+ * longest individual word (>= 3 chars) that appears in the text. Short words
+ * are skipped to avoid centering on noise like "a" or "is".
+ */
+function extractSnippetAroundMatch(
+  text: string,
+  query: string,
+  maxLength = 150
+): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const lowerText = text.toLowerCase();
+
+  // Try full phrase first
+  let matchIndex = lowerText.indexOf(query.toLowerCase());
+  let matchLength = query.length;
+
+  // If full phrase not found, try individual words (longest first).
+  // Keep the last word even if short — it may be a partial word being typed.
+  if (matchIndex === -1) {
+    const allWords = query.split(/\s+/);
+    const words = allWords
+      .filter(
+        (w, i) => w.length >= MIN_SNIPPET_WORD_LENGTH || i === allWords.length - 1
+      )
+      .sort((a, b) => b.length - a.length);
+
+    for (const word of words) {
+      const idx = lowerText.indexOf(word.toLowerCase());
+      if (idx !== -1) {
+        matchIndex = idx;
+        matchLength = word.length;
+        break;
+      }
+    }
+  }
+
+  // No match at all — fall back to start of text
+  if (matchIndex === -1) {
+    const truncated = text.substring(0, maxLength);
+    const lastSpace = truncated.lastIndexOf(" ");
+    const end = lastSpace > maxLength * 0.7 ? lastSpace : maxLength;
+    return `${text.substring(0, end)}...`;
+  }
+
+  // Center the window around the match
+  const half = Math.floor((maxLength - matchLength) / 2);
+  let start = Math.max(0, matchIndex - half);
+  let end = Math.min(text.length, start + maxLength);
+
+  // If we hit the end, shift the window back
+  if (end === text.length) {
+    start = Math.max(0, end - maxLength);
+  }
+
+  // Snap to word boundaries
+  if (start > 0) {
+    const spaceAfterStart = text.indexOf(" ", start);
+    if (spaceAfterStart !== -1 && spaceAfterStart < matchIndex) {
+      start = spaceAfterStart + 1;
+    }
+  }
+  if (end < text.length) {
+    const spaceBeforeEnd = text.lastIndexOf(" ", end);
+    if (spaceBeforeEnd > matchIndex + matchLength) {
+      end = spaceBeforeEnd;
+    }
+  }
+
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < text.length ? "..." : "";
+  return `${prefix}${text.substring(start, end)}${suffix}`;
+}
+
+export async function searchWithMatchesHandler(
+  ctx: QueryCtx,
+  args: {
+    searchQuery: string;
+    includeArchived?: boolean;
+    limit?: number;
+    maxMatchesPerConversation?: number;
+  }
+): Promise<ConversationSearchWithMatchesResult[]> {
+  const userId = await getAuthUserId(ctx);
+  if (!userId) {
+    return [];
+  }
+
+  const userDocId = userId as Id<"users">;
+  const q = args.searchQuery.trim();
+  if (!q || q.length < 2) {
+    return [];
+  }
+
+  const limit = args.limit ?? 20;
+  const maxMatchesPerConversation = args.maxMatchesPerConversation ?? 5;
+
+  // Phase 1 — Title search using search_title index
+  const titleMatches = await ctx.db
+    .query("conversations")
+    .withSearchIndex("search_title", (sq) =>
+      sq.search("title", q).eq("userId", userDocId).eq("isArchived", false)
+    )
+    .take(limit);
+
+  // Build initial results from title matches
+  const resultsMap = new Map<string, ConversationSearchWithMatchesResult>();
+  for (const conv of titleMatches) {
+    resultsMap.set(conv._id, {
+      conversationId: conv._id,
+      title: conv.title || "Untitled",
+      updatedAt: conv.updatedAt,
+      isPinned: conv.isPinned ?? false,
+      matchedIn: "title",
+      messageMatches: [],
+    });
+  }
+
+  // Phase 2 — Message content search using search_content index
+  const messageMatches = await ctx.db
+    .query("messages")
+    .withSearchIndex("search_content", (sq) =>
+      sq.search("content", q).eq("isMainBranch", true)
+    )
+    .take(limit * 10);
+
+  // Track how many matches we've collected per conversation
+  const matchCountPerConversation = new Map<string, number>();
+
+  for (const msg of messageMatches) {
+    const convId = msg.conversationId as string;
+    const currentCount = matchCountPerConversation.get(convId) ?? 0;
+    if (currentCount >= maxMatchesPerConversation) {
+      continue;
+    }
+
+    // Look up conversation for ownership verification
+    const conversation = await ctx.db.get(msg.conversationId);
+    if (
+      !conversation ||
+      conversation.userId !== userDocId ||
+      conversation.isArchived
+    ) {
+      continue;
+    }
+
+    const snippet = extractSnippetAroundMatch(msg.content || "", q, 150);
+    const match: MessageMatchResult = {
+      messageId: msg._id,
+      snippet,
+      role: msg.role,
+      createdAt: msg.createdAt,
+    };
+
+    const existing = resultsMap.get(convId);
+    if (existing) {
+      // Conversation already found via title — upgrade to "both"
+      if (existing.matchedIn === "title") {
+        existing.matchedIn = "both";
+      }
+      existing.messageMatches.push(match);
+    } else {
+      resultsMap.set(convId, {
+        conversationId: convId,
+        title: conversation.title || "Untitled",
+        updatedAt: conversation.updatedAt,
+        isPinned: conversation.isPinned ?? false,
+        matchedIn: "messages",
+        messageMatches: [match],
+      });
+    }
+
+    matchCountPerConversation.set(convId, currentCount + 1);
+  }
+
+  // Sort: title matches first, then by updatedAt desc
+  const results = Array.from(resultsMap.values()).sort((a, b) => {
+    const aHasTitle = a.matchedIn === "title" || a.matchedIn === "both";
+    const bHasTitle = b.matchedIn === "title" || b.matchedIn === "both";
+    if (aHasTitle !== bHasTitle) {
+      return aHasTitle ? -1 : 1;
+    }
+    return b.updatedAt - a.updatedAt;
+  });
+
+  return results.slice(0, limit);
+}
+
 export async function isStreamingHandler(
   ctx: QueryCtx,
   args: { conversationId: Id<"conversations"> }

--- a/convex/lib/conversation/query_handlers.ts
+++ b/convex/lib/conversation/query_handlers.ts
@@ -418,7 +418,6 @@ export async function searchWithMatchesHandler(
   ctx: QueryCtx,
   args: {
     searchQuery: string;
-    includeArchived?: boolean;
     limit?: number;
     maxMatchesPerConversation?: number;
   }

--- a/src/components/chat/virtualized-chat-messages.tsx
+++ b/src/components/chat/virtualized-chat-messages.tsx
@@ -368,11 +368,63 @@ export const VirtualizedChatMessages = memo(
         }
       };
 
+      const handleSearchScroll = (event: Event) => {
+        const customEvent = event as CustomEvent<{
+          messageId?: string;
+          conversationId?: string | null;
+        }>;
+
+        const messageId = customEvent.detail?.messageId;
+        if (!messageId) {
+          return;
+        }
+
+        if (
+          conversationId &&
+          customEvent.detail?.conversationId &&
+          customEvent.detail.conversationId !== conversationId
+        ) {
+          return;
+        }
+
+        const targetIndex = processedMessages.findIndex(
+          msg => msg.id === messageId
+        );
+
+        if (targetIndex === -1) {
+          return;
+        }
+
+        if (virtuosoRef.current) {
+          virtuosoRef.current.scrollToIndex({
+            index: targetIndex,
+            align: "center",
+            behavior: "smooth",
+          });
+        }
+
+        // Highlight the message after scrolling
+        setTimeout(() => {
+          const el = document.getElementById(messageId);
+          if (el) {
+            el.classList.add("message-highlight");
+            setTimeout(() => {
+              el.classList.remove("message-highlight");
+            }, 2500);
+          }
+        }, 500);
+      };
+
       window.addEventListener("polly:zen-scroll-to-message", handleZenScroll);
+      window.addEventListener("polly:scroll-to-message", handleSearchScroll);
       return () => {
         window.removeEventListener(
           "polly:zen-scroll-to-message",
           handleZenScroll
+        );
+        window.removeEventListener(
+          "polly:scroll-to-message",
+          handleSearchScroll
         );
       };
     }, [conversationId, processedMessages]);

--- a/src/components/navigation/sidebar/conversation-list.tsx
+++ b/src/components/navigation/sidebar/conversation-list.tsx
@@ -7,8 +7,9 @@ import {
 } from "@/lib/conversations-cache";
 import { useUI } from "@/providers/ui-provider";
 import { useUserDataContext } from "@/providers/user-data-context";
-import type { ConversationId } from "@/types";
+import type { ConversationId, ConversationSearchResult } from "@/types";
 import { ConversationListContent } from "./conversation-list-content";
+import { SearchResultsContent } from "./search-results-content";
 
 type ConversationListProps = {
   searchQuery: string;
@@ -31,26 +32,37 @@ export const ConversationList = memo(
     // Skip query on mobile when sidebar is hidden to reduce initial load
     const shouldSkipQuery = isMobile && !isSidebarVisible;
 
-    const conversationQueryArg = (() => {
-      if (!user || shouldSkipQuery) {
+    const isSearching = searchQuery.trim().length > 0;
+
+    // Search with matches query (for searching)
+    const searchWithMatchesArg = (() => {
+      if (!user || shouldSkipQuery || !isSearching) {
         return "skip";
       }
-      if (searchQuery.trim()) {
-        return {
-          searchQuery,
-          includeArchived: false,
-          limit: 100,
-        };
+      return {
+        searchQuery,
+        includeArchived: false,
+        limit: 20,
+        maxMatchesPerConversation: 5,
+      };
+    })();
+
+    const searchResults = useQuery(
+      api.conversations.searchWithMatches,
+      searchWithMatchesArg
+    ) as ConversationSearchResult[] | undefined;
+
+    // List query (for non-searching)
+    const listArg = (() => {
+      if (!user || shouldSkipQuery || isSearching) {
+        return "skip";
       }
       return {
         includeArchived: false,
       };
     })();
 
-    const conversationDataRaw = useQuery(
-      searchQuery.trim() ? api.conversations.search : api.conversations.list,
-      conversationQueryArg
-    );
+    const conversationDataRaw = useQuery(api.conversations.list, listArg);
 
     const conversations = useMemo(() => {
       if (Array.isArray(conversationDataRaw)) {
@@ -64,9 +76,18 @@ export const ConversationList = memo(
       if (!userId) {
         return false;
       }
+      if (isSearching) {
+        return searchResults === undefined;
+      }
       const hasConversations = conversations && conversations.length > 0;
       return conversationDataRaw === undefined && !hasConversations;
-    }, [conversationDataRaw, conversations, userId]);
+    }, [
+      conversationDataRaw,
+      conversations,
+      userId,
+      isSearching,
+      searchResults,
+    ]);
 
     useEffect(() => {
       if (
@@ -78,6 +99,18 @@ export const ConversationList = memo(
         setCachedConversations(userId, conversations);
       }
     }, [conversations, searchQuery, userId]);
+
+    if (isSearching) {
+      return (
+        <SearchResultsContent
+          results={searchResults}
+          searchQuery={searchQuery}
+          isLoading={isLoading}
+          isMobile={isMobile}
+          onCloseSidebar={onCloseSidebar}
+        />
+      );
+    }
 
     return (
       <ConversationListContent

--- a/src/components/navigation/sidebar/conversation-list.tsx
+++ b/src/components/navigation/sidebar/conversation-list.tsx
@@ -41,7 +41,6 @@ export const ConversationList = memo(
       }
       return {
         searchQuery,
-        includeArchived: false,
         limit: 20,
         maxMatchesPerConversation: 5,
       };

--- a/src/components/navigation/sidebar/search-result-item.tsx
+++ b/src/components/navigation/sidebar/search-result-item.tsx
@@ -1,0 +1,131 @@
+import { RobotIcon, UserIcon } from "@phosphor-icons/react";
+import { memo } from "react";
+import { Link } from "react-router-dom";
+import { ROUTES } from "@/lib/routes";
+import { highlightMatches } from "@/lib/search-highlight";
+import { cn } from "@/lib/utils";
+import type { ConversationSearchResult, MessageMatch } from "@/types";
+
+type SearchResultItemProps = {
+  result: ConversationSearchResult;
+  searchQuery: string;
+  isMobile: boolean;
+  onCloseSidebar: () => void;
+};
+
+const HighlightedText = ({ text, query }: { text: string; query: string }) => {
+  const segments = highlightMatches(text, query);
+  return (
+    <>
+      {segments.map((segment, i) => (
+        <span
+          key={`${i}-${segment.text.substring(0, 8)}`}
+          className={
+            segment.isMatch ? "bg-primary/15 rounded-sm px-0.5" : undefined
+          }
+        >
+          {segment.text}
+        </span>
+      ))}
+    </>
+  );
+};
+
+const MessageMatchItem = memo(
+  ({
+    match,
+    conversationId,
+    searchQuery,
+    isMobile,
+    onCloseSidebar,
+  }: {
+    match: MessageMatch;
+    conversationId: string;
+    searchQuery: string;
+    isMobile: boolean;
+    onCloseSidebar: () => void;
+  }) => {
+    const isAssistant = match.role === "assistant";
+    const Icon = isAssistant ? RobotIcon : UserIcon;
+    const url = `${ROUTES.CHAT_CONVERSATION(conversationId)}?m=${match.messageId}`;
+
+    return (
+      <Link
+        to={url}
+        onClick={() => {
+          if (isMobile) {
+            onCloseSidebar();
+          }
+        }}
+        className="group/match flex items-start gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground transition-colors"
+      >
+        <Icon
+          className="mt-0.5 size-3 flex-shrink-0 opacity-50"
+          weight={isAssistant ? "fill" : "regular"}
+        />
+        <span className="line-clamp-2 min-w-0 break-words">
+          <HighlightedText text={match.snippet} query={searchQuery} />
+        </span>
+      </Link>
+    );
+  }
+);
+
+MessageMatchItem.displayName = "MessageMatchItem";
+
+export const SearchResultItem = memo(
+  ({
+    result,
+    searchQuery,
+    isMobile,
+    onCloseSidebar,
+  }: SearchResultItemProps) => {
+    const conversationUrl = ROUTES.CHAT_CONVERSATION(result.conversationId);
+    const hasMessageMatches = result.messageMatches.length > 0;
+    const showTitleHighlight =
+      result.matchedIn === "title" || result.matchedIn === "both";
+
+    return (
+      <div className="stack-xs py-0.5">
+        <Link
+          to={conversationUrl}
+          onClick={() => {
+            if (isMobile) {
+              onCloseSidebar();
+            }
+          }}
+          className={cn(
+            "flex items-center rounded-lg px-2 py-1.5 text-sm font-medium",
+            "text-sidebar-foreground hover:bg-sidebar-accent transition-colors",
+            "truncate"
+          )}
+        >
+          <span className="truncate">
+            {showTitleHighlight ? (
+              <HighlightedText text={result.title} query={searchQuery} />
+            ) : (
+              result.title
+            )}
+          </span>
+        </Link>
+
+        {hasMessageMatches ? (
+          <div className="ml-1 stack-xs border-l border-border/50 pl-1">
+            {result.messageMatches.map(match => (
+              <MessageMatchItem
+                key={match.messageId}
+                match={match}
+                conversationId={result.conversationId}
+                searchQuery={searchQuery}
+                isMobile={isMobile}
+                onCloseSidebar={onCloseSidebar}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+SearchResultItem.displayName = "SearchResultItem";

--- a/src/components/navigation/sidebar/search-result-item.tsx
+++ b/src/components/navigation/sidebar/search-result-item.tsx
@@ -15,18 +15,23 @@ type SearchResultItemProps = {
 
 const HighlightedText = ({ text, query }: { text: string; query: string }) => {
   const segments = highlightMatches(text, query);
+  let offset = 0;
   return (
     <>
-      {segments.map((segment, i) => (
-        <span
-          key={`${i}-${segment.text.substring(0, 8)}`}
-          className={
-            segment.isMatch ? "bg-primary/15 rounded-sm px-0.5" : undefined
-          }
-        >
-          {segment.text}
-        </span>
-      ))}
+      {segments.map(segment => {
+        const key = offset;
+        offset += segment.text.length;
+        return (
+          <span
+            key={key}
+            className={
+              segment.isMatch ? "bg-primary/15 rounded-sm px-0.5" : undefined
+            }
+          >
+            {segment.text}
+          </span>
+        );
+      })}
     </>
   );
 };

--- a/src/components/navigation/sidebar/search-results-content.tsx
+++ b/src/components/navigation/sidebar/search-results-content.tsx
@@ -1,0 +1,65 @@
+import type { ConversationSearchResult } from "@/types";
+import { SearchResultItem } from "./search-result-item";
+
+type SearchResultsContentProps = {
+  results: ConversationSearchResult[] | undefined;
+  searchQuery: string;
+  isLoading: boolean;
+  isMobile: boolean;
+  onCloseSidebar: () => void;
+};
+
+export const SearchResultsContent = ({
+  results,
+  searchQuery,
+  isLoading,
+  isMobile,
+  onCloseSidebar,
+}: SearchResultsContentProps) => {
+  if (isLoading) {
+    return (
+      <div className="pt-3 pb-3">
+        <SearchResultsSkeleton />
+      </div>
+    );
+  }
+
+  if (!results || results.length === 0) {
+    return (
+      <div className="px-2.5 pt-4 pb-3">
+        <p className="text-xs text-sidebar-muted">No matching conversations</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-3 pb-3 stack-sm">
+      {results.map(result => (
+        <SearchResultItem
+          key={result.conversationId}
+          result={result}
+          searchQuery={searchQuery}
+          isMobile={isMobile}
+          onCloseSidebar={onCloseSidebar}
+        />
+      ))}
+    </div>
+  );
+};
+
+const SearchResultsSkeleton = () => {
+  return (
+    <div className="stack-sm pl-2" data-testid="search-results-skeleton">
+      <div className="h-8 animate-pulse rounded-lg bg-muted/40 px-2" />
+      <div className="ml-3 stack-xs">
+        <div className="h-5 w-4/5 animate-pulse rounded bg-muted/30" />
+        <div className="h-5 w-3/5 animate-pulse rounded bg-muted/30" />
+      </div>
+      <div className="h-8 animate-pulse rounded-lg bg-muted/40 px-2" />
+      <div className="ml-3 stack-xs">
+        <div className="h-5 w-4/5 animate-pulse rounded bg-muted/30" />
+      </div>
+      <div className="h-8 animate-pulse rounded-lg bg-muted/40 px-2" />
+    </div>
+  );
+};

--- a/src/globals.css
+++ b/src/globals.css
@@ -2587,3 +2587,17 @@ pre {
 .switch-root[data-checked]:active .switch-thumb {
   transform: translateX(1rem) scale(0.95);
 }
+
+/* Search scroll-to-message highlight */
+@keyframes message-highlight {
+  0% {
+    background-color: hsl(var(--primary) / 0.15);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+.message-highlight {
+  animation: message-highlight 2s ease-out forwards;
+  border-radius: 0.75rem;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -71,6 +71,7 @@ export { useArchiveConversation } from "./use-archive-conversation";
 export { useConversationImport } from "./use-conversation-import";
 export { useDeleteConversation } from "./use-delete-conversation";
 export { usePaginatedConversations } from "./use-paginated-conversations";
+export { useScrollToMessage } from "./use-scroll-to-message";
 
 // =============================================================================
 // File Hooks

--- a/src/hooks/use-scroll-to-message.ts
+++ b/src/hooks/use-scroll-to-message.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * Reads `?m={messageId}` from the URL, dispatches a scroll event when messages
+ * are loaded, and cleans up the query param afterwards.
+ */
+export function useScrollToMessage(
+  conversationId: string | undefined,
+  messagesLoaded: boolean
+): { targetMessageId: string | null } {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const targetMessageId = searchParams.get("m");
+  const dispatchedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!(targetMessageId && messagesLoaded && conversationId)) {
+      return;
+    }
+
+    // Only dispatch once per target
+    if (dispatchedRef.current === targetMessageId) {
+      return;
+    }
+    dispatchedRef.current = targetMessageId;
+
+    // Dispatch scroll event after a brief delay to let the virtualized list settle
+    const scrollTimer = setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent("polly:scroll-to-message", {
+          detail: { messageId: targetMessageId, conversationId },
+        })
+      );
+    }, 100);
+
+    // Clean up the ?m= param
+    const cleanupTimer = setTimeout(() => {
+      setSearchParams(
+        prev => {
+          prev.delete("m");
+          return prev;
+        },
+        { replace: true }
+      );
+    }, 300);
+
+    return () => {
+      clearTimeout(scrollTimer);
+      clearTimeout(cleanupTimer);
+    };
+  }, [targetMessageId, messagesLoaded, conversationId, setSearchParams]);
+
+  return { targetMessageId };
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -201,3 +201,9 @@ export {
   isMessageMetadata,
   isMessageStreaming,
 } from "./chat/message-utils";
+
+// =============================================================================
+// Search Utils
+// =============================================================================
+
+export { highlightMatches } from "./search-highlight";

--- a/src/lib/search-highlight.tsx
+++ b/src/lib/search-highlight.tsx
@@ -45,6 +45,9 @@ export function highlightMatches(
 
   for (const m of text.matchAll(pattern)) {
     const matchStart = m.index;
+    if (matchStart === undefined) {
+      continue;
+    }
     if (matchStart > lastIndex) {
       segments.push({
         text: text.substring(lastIndex, matchStart),

--- a/src/lib/search-highlight.tsx
+++ b/src/lib/search-highlight.tsx
@@ -1,0 +1,63 @@
+/** Minimum word length to highlight individually in multi-word queries. */
+const MIN_WORD_LENGTH = 3;
+
+/**
+ * Split text into highlighted/non-highlighted segments based on a search query.
+ *
+ * - Single-word queries: exact substring match.
+ * - Multi-word queries: each word is matched independently, but short words
+ *   (< 3 chars) are skipped to avoid noisy highlights on "a", "is", etc.
+ */
+export function highlightMatches(
+  text: string,
+  query: string
+): Array<{ text: string; isMatch: boolean }> {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return [{ text, isMatch: false }];
+  }
+
+  // Build list of words to match.
+  // For single-word queries keep as-is; for multi-word, drop short words
+  // EXCEPT the last word (which may be a partial word still being typed).
+  const words = trimmed.split(/\s+/);
+  const needles =
+    words.length === 1
+      ? [trimmed.toLowerCase()]
+      : words
+          .filter(
+            (w, i) => w.length >= MIN_WORD_LENGTH || i === words.length - 1
+          )
+          .map(w => w.toLowerCase());
+
+  if (needles.length === 0) {
+    return [{ text, isMatch: false }];
+  }
+
+  // Build a regex that matches any of the needles (longest first to prefer
+  // longer matches when needles overlap).
+  const sorted = [...needles].sort((a, b) => b.length - a.length);
+  const escaped = sorted.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const pattern = new RegExp(`(${escaped.join("|")})`, "gi");
+
+  const segments: Array<{ text: string; isMatch: boolean }> = [];
+  let lastIndex = 0;
+
+  for (const m of text.matchAll(pattern)) {
+    const matchStart = m.index;
+    if (matchStart > lastIndex) {
+      segments.push({
+        text: text.substring(lastIndex, matchStart),
+        isMatch: false,
+      });
+    }
+    segments.push({ text: m[0], isMatch: true });
+    lastIndex = matchStart + m[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ text: text.substring(lastIndex), isMatch: false });
+  }
+
+  return segments.length > 0 ? segments : [{ text, isMatch: false }];
+}

--- a/src/pages/chat-conversation-page.tsx
+++ b/src/pages/chat-conversation-page.tsx
@@ -10,6 +10,7 @@ import { OfflinePlaceholder } from "@/components/ui/offline-placeholder";
 import { useChat } from "@/hooks/use-chat";
 import { useConversationModelOverride } from "@/hooks/use-conversation-model-override";
 import { useOnline } from "@/hooks/use-online";
+import { useScrollToMessage } from "@/hooks/use-scroll-to-message";
 import { useSelectedModel } from "@/hooks/use-selected-model";
 import { retryImageGeneration } from "@/lib/ai/image-generation-handlers";
 import { ROUTES } from "@/lib/routes";
@@ -123,6 +124,9 @@ export default function ConversationRoute() {
   // Determine display state
   const hasRealMessages = realMessages.length > 0;
   const isOptimistic = !!initialMessageRef.current && !hasRealMessages;
+
+  // Scroll-to-message from search results (?m= URL param)
+  useScrollToMessage(resolvedId ?? undefined, hasRealMessages);
 
   // Track whether we've transitioned from optimistic to real messages
   // to preserve displayKey stability during streaming.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -337,6 +337,26 @@ export type ChatStreamRequest = {
 export type WebSearchCitation = Infer<typeof webCitationSchema>;
 
 // ============================================================================
+// CONVERSATION SEARCH TYPES
+// ============================================================================
+
+export type MessageMatch = {
+  messageId: string;
+  snippet: string;
+  role: string;
+  createdAt: number;
+};
+
+export type ConversationSearchResult = {
+  conversationId: string;
+  title: string;
+  updatedAt: number;
+  isPinned: boolean;
+  matchedIn: "title" | "messages" | "both";
+  messageMatches: MessageMatch[];
+};
+
+// ============================================================================
 // API KEYS TYPES
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Add `searchWithMatches` Convex query that returns conversations grouped with their matching messages (title + message content search)
- New sidebar search results UI showing conversation titles with indented message match snippets, each linking directly to the message
- Word-aware highlighting and snippet extraction — multi-word queries highlight each word independently, skipping short stop-words (except the last word being typed)
- Scroll-to-message via `?m={messageId}` URL param: smooth scroll + highlight animation when clicking a message match from search results

## Test plan
- [ ] Type in sidebar search, verify results show conversation titles with message-level matches underneath
- [ ] Verify multi-word queries highlight each word independently in both title and snippets
- [ ] Click a message match, verify it navigates to the conversation and scrolls to the specific message with a highlight animation
- [ ] Verify `?m=` param is cleaned from URL after scroll completes
- [ ] Test same-conversation match: click a match for the conversation you're already viewing, verify scroll happens without full page reload
- [ ] Test mobile: sidebar closes on match click, scroll works
- [ ] Test empty state: search for something with no matches, verify "No matching conversations" text appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)