### PR TITLE
feat: add memory system with conversation scan backfill

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -110,6 +110,8 @@ import type * as lib_image_models_replicate_actions from "../lib/image_models/re
 import type * as lib_image_models_replicate_utils from "../lib/image_models/replicate_utils.js";
 import type * as lib_image_models_schema_analysis from "../lib/image_models/schema_analysis.js";
 import type * as lib_image_models_types from "../lib/image_models/types.js";
+import type * as lib_memory_embedding from "../lib/memory/embedding.js";
+import type * as lib_memory_extraction from "../lib/memory/extraction.js";
 import type * as lib_message_action_handlers from "../lib/message/action_handlers.js";
 import type * as lib_message_attachment_handlers from "../lib/message/attachment_handlers.js";
 import type * as lib_message_branch_delete_handlers from "../lib/message/branch_delete_handlers.js";
@@ -140,6 +142,8 @@ import type * as lib_user_mutation_handlers from "../lib/user/mutation_handlers.
 import type * as lib_user_query_handlers from "../lib/user/query_handlers.js";
 import type * as lib_user_models_mutation_handlers from "../lib/user_models/mutation_handlers.js";
 import type * as lib_user_models_query_handlers from "../lib/user_models/query_handlers.js";
+import type * as memory from "../memory.js";
+import type * as memory_actions from "../memory_actions.js";
 import type * as messages from "../messages.js";
 import type * as migrations_addUserIdToMessages from "../migrations/addUserIdToMessages.js";
 import type * as migrations_populateUserFiles from "../migrations/populateUserFiles.js";
@@ -265,6 +269,8 @@ declare const fullApi: ApiFromModules<{
   "lib/image_models/replicate_utils": typeof lib_image_models_replicate_utils;
   "lib/image_models/schema_analysis": typeof lib_image_models_schema_analysis;
   "lib/image_models/types": typeof lib_image_models_types;
+  "lib/memory/embedding": typeof lib_memory_embedding;
+  "lib/memory/extraction": typeof lib_memory_extraction;
   "lib/message/action_handlers": typeof lib_message_action_handlers;
   "lib/message/attachment_handlers": typeof lib_message_attachment_handlers;
   "lib/message/branch_delete_handlers": typeof lib_message_branch_delete_handlers;
@@ -295,6 +301,8 @@ declare const fullApi: ApiFromModules<{
   "lib/user/query_handlers": typeof lib_user_query_handlers;
   "lib/user_models/mutation_handlers": typeof lib_user_models_mutation_handlers;
   "lib/user_models/query_handlers": typeof lib_user_models_query_handlers;
+  memory: typeof memory;
+  memory_actions: typeof memory_actions;
   messages: typeof messages;
   "migrations/addUserIdToMessages": typeof migrations_addUserIdToMessages;
   "migrations/populateUserFiles": typeof migrations_populateUserFiles;

--- a/convex/backgroundJobs.ts
+++ b/convex/backgroundJobs.ts
@@ -43,7 +43,8 @@ const jobTypeSchema = v.union(
   v.literal("conversation_summary"),
   v.literal("data_migration"),
   v.literal("model_migration"),
-  v.literal("backup")
+  v.literal("backup"),
+  v.literal("memory_scan")
 );
 
 const jobStatusSchema = v.union(

--- a/convex/lib/background_jobs/helpers.ts
+++ b/convex/lib/background_jobs/helpers.ts
@@ -72,7 +72,8 @@ export type CreateJobArgs = {
     | "conversation_summary"
     | "data_migration"
     | "model_migration"
-    | "backup";
+    | "backup"
+    | "memory_scan";
   category?:
     | "data_transfer"
     | "bulk_operations"
@@ -102,7 +103,8 @@ export async function handleCreateBackgroundJob(
       category = "bulk_operations";
     } else if (
       args.type === "conversation_summary" ||
-      args.type === "model_migration"
+      args.type === "model_migration" ||
+      args.type === "memory_scan"
     ) {
       category = "ai_processing";
     } else {

--- a/convex/lib/background_jobs/query_handlers.ts
+++ b/convex/lib/background_jobs/query_handlers.ts
@@ -51,7 +51,8 @@ export async function handleListUserJobs(
       | "conversation_summary"
       | "data_migration"
       | "model_migration"
-      | "backup";
+      | "backup"
+      | "memory_scan";
     status?:
       | "scheduled"
       | "processing"

--- a/convex/lib/conversation/context_building.ts
+++ b/convex/lib/conversation/context_building.ts
@@ -6,6 +6,7 @@ import {
   getPersonaPrompt,
   mergeSystemPrompts,
 } from "./message_handling";
+import { buildMemoryContext } from "@shared/system-prompts";
 import { getBaselineInstructions } from "../../constants";
 import { processAttachmentsForLLM } from "../process_attachments";
 import {
@@ -46,6 +47,8 @@ export const buildContextMessages = async (
     }>;
     /** Pre-resolved model info to avoid redundant queries */
     prefetchedModelInfo?: { contextLength?: number };
+    /** Retrieved memories to inject into system prompt */
+    memories?: Array<{ content: string; category: string }>;
   },
 ): Promise<{
   contextMessages: Array<{
@@ -92,9 +95,13 @@ export const buildContextMessages = async (
 
     // Add baseline instructions with persona
     const baselineInstructions = getBaselineInstructions("default", "UTC");
+    const memoryContext = args.memories
+      ? buildMemoryContext(args.memories)
+      : undefined;
     const mergedInstructions = mergeSystemPrompts(
       baselineInstructions,
       personaPrompt,
+      memoryContext,
     );
     systemMessages.push({
       role: "system" as const,

--- a/convex/lib/memory/embedding.ts
+++ b/convex/lib/memory/embedding.ts
@@ -1,0 +1,21 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { embed } from "ai";
+import { CONFIG } from "../../ai/config";
+
+/**
+ * Generate a 1536-dimensional embedding using OpenAI text-embedding-3-small.
+ * Used for semantic memory search via Convex vector indexes.
+ */
+export async function generateEmbedding(text: string): Promise<number[]> {
+  const apiKey = process.env[CONFIG.PROVIDER_ENV_KEYS.openai];
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY required for memory embeddings");
+  }
+
+  const openai = createOpenAI({ apiKey });
+  const { embedding } = await embed({
+    model: openai.embedding("text-embedding-3-small"),
+    value: text,
+  });
+  return embedding;
+}

--- a/convex/lib/memory/extraction.ts
+++ b/convex/lib/memory/extraction.ts
@@ -1,0 +1,44 @@
+import { z } from "zod/v3";
+import dedent from "dedent";
+
+/** Schema for a single extracted memory from the LLM */
+export const extractedMemorySchema = z.object({
+  content: z.string(),
+  category: z.enum(["preference", "fact", "instruction"]),
+});
+
+export type ExtractedMemoryItem = z.infer<typeof extractedMemorySchema>;
+
+/**
+ * Build the extraction prompt for the LLM.
+ * Dedup is handled at save time via vector search — the LLM just extracts candidates.
+ */
+export function buildExtractionPrompt(
+  recentMessages: Array<{ role: string; content: string }>,
+): string {
+  const messagesText = recentMessages
+    .map((m) => `${m.role.toUpperCase()}: ${m.content}`)
+    .join("\n\n");
+
+  return dedent`
+    Analyze the following conversation and extract DURABLE facts about the USER that would be useful to remember across future conversations.
+
+    CATEGORIES:
+    - "preference": Likes/dislikes, style choices, tool preferences (e.g., "Prefers TypeScript over JavaScript")
+    - "fact": Personal info, job, location, projects, skills (e.g., "Works as a backend engineer at Google")
+    - "instruction": Standing instructions for AI behavior (e.g., "Always explain code changes before making them")
+
+    RULES:
+    1. Only extract facts ABOUT THE USER, not about the conversation topic
+    2. Only extract DURABLE facts that would be relevant in future conversations
+    3. Do NOT extract: conversation-specific context, temporary states, task details, or things the user is asking about (vs things about themselves)
+    4. Be concise — each memory should be a single clear statement
+    5. Extract 0-3 memories per conversation turn — prefer quality over quantity. Most conversations will have 0 new memories.
+    6. If there is nothing NEW and durable to extract, return an empty array
+
+    RECENT CONVERSATION:
+    ${messagesText}
+
+    Extract memories as a JSON array.
+  `;
+}

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -510,6 +510,7 @@ export const backgroundJobTypeSchema = v.union(
   v.literal("data_migration"),
   v.literal("model_migration"),
   v.literal("backup"),
+  v.literal("memory_scan"),
 );
 
 // Background job category schema
@@ -750,6 +751,7 @@ export const userSettingsSchema = v.object({
   ),
   showMessageMetadata: v.optional(v.boolean()),
   showTemperaturePicker: v.optional(v.boolean()),
+  memoryEnabled: v.optional(v.boolean()),
   createdAt: v.number(),
   updatedAt: v.number(),
 });
@@ -785,6 +787,34 @@ export const toolCallSchema = v.object({
   ),
   error: v.optional(v.string()),
 });
+
+// Memory category schema
+export const memoryCategorySchema = v.union(
+  v.literal("preference"),
+  v.literal("fact"),
+  v.literal("instruction"),
+);
+
+// User memory schema for cross-conversation memory
+export const userMemorySchema = v.object({
+  userId: v.id("users"),
+  content: v.string(),
+  category: memoryCategorySchema,
+  sourceConversationId: v.optional(v.id("conversations")),
+  sourceConversationTitle: v.optional(v.string()),
+  embedding: v.array(v.float64()),
+  isActive: v.boolean(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+});
+
+// Extracted memory summary stored on assistant messages
+export const memoriesExtractedSchema = v.array(
+  v.object({
+    content: v.string(),
+    category: memoryCategorySchema,
+  }),
+);
 
 // Image generation schema
 export const imageGenerationSchema = v.object({
@@ -841,6 +871,7 @@ export const messageSchema = v.object({
   // doesn't retroactively update existing messages.
   personaName: v.optional(v.string()),
   personaIcon: v.optional(v.string()),
+  memoriesExtracted: v.optional(memoriesExtractedSchema),
   createdAt: v.number(),
   completedAt: v.optional(v.number()),
 });

--- a/convex/memory.ts
+++ b/convex/memory.ts
@@ -1,0 +1,310 @@
+/**
+ * Memory CRUD operations — queries and mutations for user memories.
+ * The extraction action lives in memory_actions.ts (requires "use node").
+ */
+
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { v } from "convex/values";
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from "./_generated/server";
+import {
+  createEmptyPaginationResult,
+  paginationOptsSchema,
+  validatePaginationOpts,
+} from "./lib/pagination";
+import { memoryCategorySchema } from "./lib/schemas";
+
+// ============================================================================
+// INTERNAL QUERIES (used by extraction action)
+// ============================================================================
+
+/** Check if user has memory enabled */
+export const getUserMemorySettings = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args) => {
+    const settings = await ctx.db
+      .query("userSettings")
+      .withIndex("by_user", q => q.eq("userId", args.userId))
+      .first();
+    return settings ? { memoryEnabled: settings.memoryEnabled ?? false } : null;
+  },
+});
+
+/** Get recent messages from a conversation */
+export const getRecentMessages = internalQuery({
+  args: {
+    conversationId: v.id("conversations"),
+    limit: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const messages = await ctx.db
+      .query("messages")
+      .withIndex("by_conversation", q =>
+        q.eq("conversationId", args.conversationId)
+      )
+      .order("desc")
+      .take(args.limit);
+    return messages
+      .reverse()
+      .filter(m => m.role === "user" || m.role === "assistant")
+      .map(m => ({
+        role: m.role,
+        content: m.content,
+      }));
+  },
+});
+
+/** Get eligible conversations for memory scan (non-archived, >= 4 messages).
+ *  Note: Uses N+1 pattern (1 conversation query + N message queries). This is
+ *  bounded by `limit` (max 50) and each sub-query only reads 4 indexed docs,
+ *  which is acceptable for a one-off background scan trigger. */
+export const getEligibleConversations = internalQuery({
+  args: { userId: v.id("users"), limit: v.number() },
+  handler: async (ctx, args) => {
+    const conversations = await ctx.db
+      .query("conversations")
+      .withIndex("by_user_archived", q =>
+        q.eq("userId", args.userId).eq("isArchived", false)
+      )
+      .order("desc")
+      .take(args.limit);
+
+    const eligible = [];
+    for (const conv of conversations) {
+      const msgs = await ctx.db
+        .query("messages")
+        .withIndex("by_conversation", q => q.eq("conversationId", conv._id))
+        .take(4);
+      if (msgs.length >= 4) {
+        eligible.push({ _id: conv._id, title: conv.title });
+      }
+    }
+    return eligible;
+  },
+});
+
+// ============================================================================
+// INTERNAL MUTATIONS (used by extraction action)
+// ============================================================================
+
+/** Insert a new memory */
+export const insertMemory = internalMutation({
+  args: {
+    userId: v.id("users"),
+    content: v.string(),
+    category: memoryCategorySchema,
+    sourceConversationId: v.optional(v.id("conversations")),
+    embedding: v.array(v.float64()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+
+    // Look up conversation title if sourceConversationId is provided
+    let sourceConversationTitle: string | undefined;
+    if (args.sourceConversationId) {
+      const conversation = await ctx.db.get(args.sourceConversationId);
+      sourceConversationTitle = conversation?.title;
+    }
+
+    return await ctx.db.insert("userMemories", {
+      userId: args.userId,
+      content: args.content,
+      category: args.category,
+      sourceConversationId: args.sourceConversationId,
+      sourceConversationTitle,
+      embedding: args.embedding,
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+/** Update an existing memory's content and embedding */
+export const updateMemoryContent = internalMutation({
+  args: {
+    memoryId: v.id("userMemories"),
+    content: v.string(),
+    category: memoryCategorySchema,
+    embedding: v.array(v.float64()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.memoryId, {
+      content: args.content,
+      category: args.category,
+      embedding: args.embedding,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/** Patch assistant message with extracted memories */
+export const patchMemoriesExtracted = internalMutation({
+  args: {
+    messageId: v.id("messages"),
+    memories: v.array(
+      v.object({
+        content: v.string(),
+        category: memoryCategorySchema,
+      })
+    ),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.messageId, {
+      memoriesExtracted: args.memories,
+    });
+  },
+});
+
+/** Get a single memory by ID (internal, no auth check) */
+export const getMemoryById = internalQuery({
+  args: { id: v.id("userMemories") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
+});
+
+// ============================================================================
+// PUBLIC QUERIES (for settings UI)
+// ============================================================================
+
+/** Get approximate memory count for the authenticated user.
+ *  Uses .take(100) to avoid scanning the full table — returns "99+" for large sets. */
+export const getMemoryCount = query({
+  args: {},
+  handler: async ctx => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      return { count: 0, isApproximate: false };
+    }
+
+    const memories = await ctx.db
+      .query("userMemories")
+      .withIndex("by_user_active", q =>
+        q.eq("userId", userId).eq("isActive", true)
+      )
+      .take(100);
+    return {
+      count: memories.length,
+      isApproximate: memories.length === 100,
+    };
+  },
+});
+
+/** List memories with pagination (for VirtualizedDataList) */
+export const listPaginated = query({
+  args: {
+    paginationOpts: paginationOptsSchema,
+    sortDirection: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+    searchQuery: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      return createEmptyPaginationResult();
+    }
+
+    const validatedOpts = validatePaginationOpts(args.paginationOpts);
+    if (!validatedOpts) {
+      return createEmptyPaginationResult();
+    }
+
+    const searchQuery = args.searchQuery?.trim();
+    const sortDirection = args.sortDirection ?? "desc";
+
+    if (searchQuery) {
+      const result = await ctx.db
+        .query("userMemories")
+        .withSearchIndex("search_content", q =>
+          q.search("content", searchQuery).eq("userId", userId)
+        )
+        .paginate(validatedOpts);
+      return result;
+    }
+
+    const result = await ctx.db
+      .query("userMemories")
+      .withIndex("by_user", q => q.eq("userId", userId))
+      .order(sortDirection)
+      .paginate(validatedOpts);
+
+    return result;
+  },
+});
+
+/** Get a single memory by ID */
+export const get = query({
+  args: { id: v.id("userMemories") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      return null;
+    }
+    const memory = await ctx.db.get(args.id);
+    if (!memory || memory.userId !== userId) {
+      return null;
+    }
+    return memory;
+  },
+});
+
+// ============================================================================
+// PUBLIC MUTATIONS (for settings UI)
+// ============================================================================
+
+/** Toggle a memory active/inactive */
+export const toggleActive = mutation({
+  args: { id: v.id("userMemories") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+    const memory = await ctx.db.get(args.id);
+    if (!memory || memory.userId !== userId) {
+      throw new Error("Memory not found");
+    }
+    await ctx.db.patch(args.id, {
+      isActive: !memory.isActive,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/** Delete a memory */
+export const remove = mutation({
+  args: { id: v.id("userMemories") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+    const memory = await ctx.db.get(args.id);
+    if (!memory || memory.userId !== userId) {
+      throw new Error("Memory not found");
+    }
+    await ctx.db.delete(args.id);
+  },
+});
+
+/** Delete a batch of memories. Returns whether more remain so the caller can re-invoke. */
+export const clearAll = mutation({
+  handler: async ctx => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+    const batch = await ctx.db
+      .query("userMemories")
+      .withIndex("by_user", q => q.eq("userId", userId))
+      .take(100);
+    for (const memory of batch) {
+      await ctx.db.delete(memory._id);
+    }
+    return { deleted: batch.length, hasMore: batch.length === 100 };
+  },
+});

--- a/convex/memory_actions.ts
+++ b/convex/memory_actions.ts
@@ -1,0 +1,430 @@
+"use node";
+
+/**
+ * Memory extraction action — runs in Node.js runtime for AI SDK access.
+ * Scheduled after streaming completes to extract durable user facts.
+ */
+
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { v } from "convex/values";
+import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { ActionCtx } from "./_generated/server";
+import { action, internalAction } from "./_generated/server";
+import { generateArrayWithProvider } from "./ai/text_generation";
+import { generateEmbedding } from "./lib/memory/embedding";
+import {
+  buildExtractionPrompt,
+  extractedMemorySchema,
+} from "./lib/memory/extraction";
+
+/**
+ * Retrieve relevant memories for a user message via vector search.
+ * Must run in Node.js runtime because embedding generation uses AI SDK.
+ */
+export const retrieveMemories = internalAction({
+  args: {
+    userId: v.id("users"),
+    messageContent: v.string(),
+  },
+  returns: v.array(v.object({ content: v.string(), category: v.string() })),
+  handler: async (ctx, args) => {
+    try {
+      const vector = await generateEmbedding(args.messageContent);
+
+      const results = await ctx.vectorSearch("userMemories", "by_embedding", {
+        vector,
+        limit: 8,
+        filter: q => q.eq("userId", args.userId),
+      });
+
+      if (results.length === 0) {
+        return [];
+      }
+
+      // Post-filter for isActive since vector search filters don't support AND.
+      const memories: Array<{ content: string; category: string }> = [];
+      for (const result of results) {
+        if (result._score < 0.1) {
+          continue;
+        }
+        const doc = await ctx.runQuery(internal.memory.getMemoryById, {
+          id: result._id,
+        });
+        if (doc?.isActive) {
+          memories.push({
+            content: doc.content,
+            category: doc.category,
+          });
+        }
+      }
+
+      return memories;
+    } catch (error) {
+      console.error("[retrieveMemories] Failed to retrieve memories:", error);
+      return [];
+    }
+  },
+});
+
+/**
+ * Shared helper: embed, dedup via vector search, and save extracted memory items.
+ * Dedup thresholds:
+ *   - score > 0.95 → near-duplicate, skip
+ *   - score > 0.8  → semantically similar, update existing memory
+ *   - score < 0.8  → new memory, insert
+ * Returns the list of memories that were actually saved.
+ */
+async function processExtractedMemories(
+  ctx: ActionCtx,
+  {
+    items,
+    userId,
+    sourceConversationId,
+  }: {
+    items: Array<{
+      content: string;
+      category: "preference" | "fact" | "instruction";
+    }>;
+    userId: Id<"users">;
+    sourceConversationId?: Id<"conversations">;
+  }
+): Promise<Array<{ content: string; category: string }>> {
+  const savedMemories: Array<{ content: string; category: string }> = [];
+
+  for (const item of items) {
+    try {
+      const embedding = await generateEmbedding(item.content);
+
+      const similar = await ctx.vectorSearch("userMemories", "by_embedding", {
+        vector: embedding,
+        limit: 1,
+        filter: q => q.eq("userId", userId),
+      });
+      const topMatch = similar.length > 0 ? similar[0] : null;
+
+      // Near-duplicate — skip
+      if (topMatch && topMatch._score > 0.95) {
+        continue;
+      }
+
+      // Semantically similar — update existing memory (only if active)
+      if (topMatch && topMatch._score > 0.8) {
+        const existingDoc = await ctx.runQuery(internal.memory.getMemoryById, {
+          id: topMatch._id,
+        });
+        if (existingDoc?.isActive) {
+          await ctx.runMutation(internal.memory.updateMemoryContent, {
+            memoryId: topMatch._id,
+            content: item.content,
+            category: item.category,
+            embedding,
+          });
+          savedMemories.push({
+            content: item.content,
+            category: item.category,
+          });
+          continue;
+        }
+        // Inactive memory — fall through to insert as new
+      }
+
+      // New memory — insert
+      await ctx.runMutation(internal.memory.insertMemory, {
+        userId,
+        content: item.content,
+        category: item.category,
+        sourceConversationId,
+        embedding,
+      });
+      savedMemories.push({
+        content: item.content,
+        category: item.category,
+      });
+    } catch (error) {
+      console.error(
+        `[processExtractedMemories] Failed to save memory "${item.content}":`,
+        error
+      );
+    }
+  }
+
+  return savedMemories;
+}
+
+export const extractMemories = internalAction({
+  args: {
+    conversationId: v.id("conversations"),
+    userId: v.id("users"),
+    assistantMessageId: v.id("messages"),
+  },
+  handler: async (ctx, args) => {
+    // 1. Check if user has memory enabled
+    const settings = await ctx.runQuery(internal.memory.getUserMemorySettings, {
+      userId: args.userId,
+    });
+    if (!settings?.memoryEnabled) {
+      return;
+    }
+
+    // 2. Fetch recent messages from the conversation (last 10)
+    const messages = await ctx.runQuery(internal.memory.getRecentMessages, {
+      conversationId: args.conversationId,
+      limit: 10,
+    });
+    if (messages.length === 0) {
+      return;
+    }
+
+    // 3. Build prompt and extract memory candidates via LLM
+    const prompt = buildExtractionPrompt(
+      messages.map((m: { role: string; content: string }) => ({
+        role: m.role,
+        content: m.content,
+      }))
+    );
+
+    let extracted;
+    try {
+      extracted = await generateArrayWithProvider({
+        prompt,
+        elementSchema: extractedMemorySchema,
+        schemaName: "ExtractedMemory",
+        schemaDescription: "A durable fact about the user",
+        temperature: 0.1,
+        maxOutputTokens: 1024,
+      });
+    } catch (error) {
+      console.error("[extractMemories] LLM extraction failed:", error);
+      return;
+    }
+
+    if (!extracted || extracted.length === 0) {
+      return;
+    }
+
+    // 4. Dedup via vector search and save
+    const savedMemories = await processExtractedMemories(ctx, {
+      items: extracted,
+      userId: args.userId,
+      sourceConversationId: args.conversationId,
+    });
+
+    // 5. Patch assistant message with extracted memories
+    if (savedMemories.length > 0) {
+      try {
+        await ctx.runMutation(internal.memory.patchMemoriesExtracted, {
+          messageId: args.assistantMessageId,
+          memories: savedMemories.map(m => ({
+            content: m.content,
+            category: m.category as "preference" | "fact" | "instruction",
+          })),
+        });
+      } catch (error) {
+        console.error(
+          "[extractMemories] Failed to patch message with memories:",
+          error
+        );
+      }
+    }
+  },
+});
+
+// ============================================================================
+// MEMORY SCAN (background job to scan existing conversations)
+// ============================================================================
+
+/** Public action: schedule a memory scan background job */
+export const scheduleMemoryScan = action({
+  args: { jobId: v.string() },
+  returns: v.union(
+    v.null(),
+    v.object({ jobId: v.string(), totalConversations: v.number() })
+  ),
+  handler: async (
+    ctx,
+    args
+  ): Promise<{
+    jobId: string;
+    totalConversations: number;
+  } | null> => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    // Verify memory is enabled before scanning
+    const memSettings = await ctx.runQuery(
+      internal.memory.getUserMemorySettings,
+      { userId }
+    );
+    if (!memSettings?.memoryEnabled) {
+      throw new Error("Memory feature is not enabled");
+    }
+
+    // Check for existing active scan
+    const existingJobs = await ctx.runQuery(api.backgroundJobs.listUserJobs, {
+      type: "memory_scan",
+      limit: 10,
+    });
+    const hasActive = existingJobs?.some(
+      (j: { status: string }) =>
+        j.status === "scheduled" || j.status === "processing"
+    );
+    if (hasActive) {
+      throw new Error("A memory scan is already in progress");
+    }
+
+    // Get eligible conversations
+    type EligibleConversation = {
+      _id: Id<"conversations">;
+      title: string | undefined;
+    };
+    const eligible: EligibleConversation[] = await ctx.runQuery(
+      internal.memory.getEligibleConversations,
+      { userId, limit: 50 }
+    );
+
+    if (eligible.length === 0) {
+      return null;
+    }
+
+    const dateStr = new Date().toLocaleDateString();
+    const title = `Memory Scan - ${dateStr}`;
+    const description = `Scanning ${eligible.length} conversation${eligible.length !== 1 ? "s" : ""} for memories`;
+
+    await ctx.runMutation(api.backgroundJobs.create, {
+      jobId: args.jobId,
+      type: "memory_scan",
+      totalItems: eligible.length,
+      title,
+      description,
+    });
+
+    await ctx.scheduler.runAfter(
+      100,
+      internal.memory_actions.processMemoryScan,
+      {
+        userId,
+        jobId: args.jobId,
+        conversationIds: eligible.map(c => c._id),
+      }
+    );
+
+    return { jobId: args.jobId, totalConversations: eligible.length };
+  },
+});
+
+/** Internal action: process memory scan in background */
+export const processMemoryScan = internalAction({
+  args: {
+    userId: v.id("users"),
+    jobId: v.string(),
+    conversationIds: v.array(v.id("conversations")),
+  },
+  handler: async (ctx, args) => {
+    const { userId, jobId, conversationIds } = args;
+
+    // Update status to processing
+    await ctx.runMutation(internal.backgroundJobs.internalUpdateStatus, {
+      jobId,
+      status: "processing",
+    });
+
+    let memoriesExtracted = 0;
+    let conversationsProcessed = 0;
+    const errors: string[] = [];
+
+    let processedIndex = 0;
+    for (const conversationId of conversationIds) {
+      processedIndex++;
+      try {
+        // Fetch recent messages
+        const messages = await ctx.runQuery(internal.memory.getRecentMessages, {
+          conversationId,
+          limit: 10,
+        });
+
+        // Skip if not enough user+assistant messages
+        const relevantMessages = messages.filter(
+          (m: { role: string }) => m.role === "user" || m.role === "assistant"
+        );
+        if (relevantMessages.length < 2) {
+          conversationsProcessed++;
+          await ctx.runMutation(
+            internal.backgroundJobs.internalUpdateProgress,
+            {
+              jobId,
+              processedItems: processedIndex,
+              totalItems: conversationIds.length,
+            }
+          );
+          continue;
+        }
+
+        // Build extraction prompt
+        const prompt = buildExtractionPrompt(
+          messages.map((m: { role: string; content: string }) => ({
+            role: m.role,
+            content: m.content,
+          }))
+        );
+
+        // Call LLM for extraction
+        const extracted = await generateArrayWithProvider({
+          prompt,
+          elementSchema: extractedMemorySchema,
+          schemaName: "ExtractedMemory",
+          schemaDescription: "A durable fact about the user",
+          temperature: 0.1,
+          maxOutputTokens: 1024,
+        });
+
+        if (extracted && extracted.length > 0) {
+          const saved = await processExtractedMemories(ctx, {
+            items: extracted,
+            userId,
+            sourceConversationId: conversationId,
+          });
+
+          memoriesExtracted += saved.length;
+        }
+
+        conversationsProcessed++;
+      } catch (error) {
+        const errorMsg =
+          error instanceof Error ? error.message : "Unknown error";
+        console.error(
+          `[processMemoryScan] Error scanning conversation ${conversationId}:`,
+          error
+        );
+        errors.push(`Conversation ${conversationId}: ${errorMsg}`);
+        conversationsProcessed++;
+      }
+
+      // Update progress after each conversation
+      await ctx.runMutation(internal.backgroundJobs.internalUpdateProgress, {
+        jobId,
+        processedItems: processedIndex,
+        totalItems: conversationIds.length,
+      });
+    }
+
+    // Complete the job
+    const finalStatus =
+      errors.length > 0 && memoriesExtracted === 0
+        ? ("failed" as const)
+        : ("completed" as const);
+
+    await ctx.runMutation(internal.backgroundJobs.internalSaveImportResult, {
+      jobId,
+      result: {
+        totalImported: memoriesExtracted,
+        totalProcessed: conversationsProcessed,
+        errors,
+      },
+      status: finalStatus,
+      ...(finalStatus === "failed" ? { error: errors[0] } : {}),
+    });
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -18,6 +18,7 @@ import {
   userApiKeySchema,
   userFileSchema,
   userImageModelSchema,
+  userMemorySchema,
   userModelSchema,
   userPersonaSettingsSchema,
   userSchema,
@@ -162,6 +163,20 @@ export default defineSchema({
     .index("by_user_created", ["userId", "createdAt"])
     .index("by_user_message", ["userId", "messageId"])
     .index("by_user_conversation", ["userId", "conversationId", "createdAt"]),
+
+  userMemories: defineTable(userMemorySchema)
+    .index("by_user", ["userId"])
+    .index("by_user_active", ["userId", "isActive"])
+    .index("by_user_category", ["userId", "category"])
+    .searchIndex("search_content", {
+      searchField: "content",
+      filterFields: ["userId"],
+    })
+    .vectorIndex("by_embedding", {
+      vectorField: "embedding",
+      dimensions: 1536,
+      filterFields: ["userId"],
+    }),
 
   userFiles: defineTable(userFileSchema)
     .index("by_user_created", ["userId", "createdAt"])

--- a/convex/userSettings.test.ts
+++ b/convex/userSettings.test.ts
@@ -87,6 +87,7 @@ describe("userSettings.getUserSettings", () => {
       ttsModelId: "eleven_v3",
       showMessageMetadata: false,
       showTemperaturePicker: true,
+      memoryEnabled: false,
     });
   });
 

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -71,6 +71,7 @@ export async function getUserSettingsHandler(ctx: QueryCtx) {
       ttsModelId: "eleven_v3",
       showMessageMetadata: false,
       showTemperaturePicker: true, // Default to enabled
+      memoryEnabled: false, // Default to disabled (opt-in)
     };
   }
 
@@ -87,6 +88,7 @@ export async function getUserSettingsHandler(ctx: QueryCtx) {
     ttsModelId: settings.ttsModelId ?? "eleven_v3",
     showMessageMetadata: settings.showMessageMetadata ?? false,
     showTemperaturePicker: settings.showTemperaturePicker ?? true, // Default to enabled
+    memoryEnabled: settings.memoryEnabled ?? false, // Default to disabled (opt-in)
   };
 }
 
@@ -107,6 +109,7 @@ type UpdateUserSettingsArgs = {
   ttsStabilityMode?: "creative" | "natural" | "robust";
   showMessageMetadata?: boolean;
   showTemperaturePicker?: boolean;
+  memoryEnabled?: boolean;
 };
 
 export async function updateUserSettingsHandler(
@@ -147,6 +150,9 @@ export async function updateUserSettingsHandler(
     }),
     ...(args.showTemperaturePicker !== undefined && {
       showTemperaturePicker: args.showTemperaturePicker,
+    }),
+    ...(args.memoryEnabled !== undefined && {
+      memoryEnabled: args.memoryEnabled,
     }),
   };
 
@@ -190,6 +196,7 @@ export const updateUserSettings = mutation({
     ttsStabilityMode: v.optional(
       v.union(v.literal("creative"), v.literal("natural"), v.literal("robust"))
     ),
+    memoryEnabled: v.optional(v.boolean()),
   },
   handler: updateUserSettingsHandler,
 });

--- a/shared/system-prompts.ts
+++ b/shared/system-prompts.ts
@@ -105,16 +105,38 @@ export function getBaselineInstructions(
 }
 
 /**
- * Merge baseline instructions with optional persona prompt
- * Order: baseline -> default Polly persona -> custom persona
+ * Build a memory context block for system prompt injection.
+ * Memories are referenced naturally — the AI should not mention them explicitly.
+ */
+export function buildMemoryContext(
+  memories: { content: string; category: string }[]
+): string {
+  if (!memories.length) {
+    return "";
+  }
+
+  const lines = memories.map(m => `- ${m.content}`).join("\n");
+  return `ABOUT THE USER (from previous conversations — reference naturally, never mention these notes explicitly):\n${lines}`;
+}
+
+/**
+ * Merge baseline instructions with optional memory context and persona prompt
+ * Order: baseline -> memory context -> default Polly persona -> custom persona
  */
 export function mergeSystemPrompts(
   baselineInstructions: string,
-  personaPrompt?: string
+  personaPrompt?: string,
+  memoryContext?: string
 ): string {
-  if (!personaPrompt) {
-    return baselineInstructions;
+  let result = baselineInstructions;
+
+  if (memoryContext) {
+    result += `\n\n${memoryContext}`;
   }
 
-  return `${baselineInstructions}\n\n${DEFAULT_POLLY_PERSONA}\n\n${personaPrompt}`;
+  if (personaPrompt) {
+    result += `\n\n${DEFAULT_POLLY_PERSONA}\n\n${personaPrompt}`;
+  }
+
+  return result;
 }

--- a/src/components/chat/activity-stream.tsx
+++ b/src/components/chat/activity-stream.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react";
 import type { AssistantPhase } from "@/hooks";
 import { cn } from "@/lib/utils";
-import type { ReasoningPart, ToolCall } from "@/types";
+import type { ExtractedMemory, ReasoningPart, ToolCall } from "@/types";
+import { MemoryIndicator } from "./memory-indicator";
 import { ReasoningSegment } from "./reasoning-segment";
 import { ToolCallBlock } from "./tool-call-block";
 
@@ -16,6 +17,7 @@ type ActivityStreamProps = {
   reasoning?: string;
   thinkingDurationMs?: number;
   toolCalls?: ToolCall[];
+  memoriesExtracted?: ExtractedMemory[];
   isActive: boolean;
   phase?: AssistantPhase;
 };
@@ -58,6 +60,7 @@ export function ActivityStream({
   reasoning,
   thinkingDurationMs,
   toolCalls,
+  memoriesExtracted,
   isActive,
   phase,
 }: ActivityStreamProps) {
@@ -120,7 +123,18 @@ export function ActivityStream({
     return { reasoningCount: rCount, toolCallCount: tCount };
   }, [items]);
 
+  const hasMemories =
+    memoriesExtracted && memoriesExtracted.length > 0 && !isActive;
+
   if (items.length === 0) {
+    // No activity but memories were extracted — show standalone indicator
+    if (hasMemories) {
+      return (
+        <div className="flex items-center gap-2 py-0.5">
+          <MemoryIndicator memories={memoriesExtracted} />
+        </div>
+      );
+    }
     return null;
   }
 
@@ -173,29 +187,37 @@ export function ActivityStream({
   // Complete: plain toggle + expandable card below
   return (
     <div className="mb-3">
-      <button
-        type="button"
-        onClick={() => setExpanded(prev => !prev)}
-        className="flex items-center gap-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <svg
-          className={cn(
-            ICON_SIZE,
-            "shrink-0 transition-transform duration-200",
-            expanded ? "rotate-90" : "rotate-0"
-          )}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => setExpanded(prev => !prev)}
+          className="flex items-center gap-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
-          <path d="M9 6l6 6-6 6" />
-        </svg>
-        <span>{summaryLabel}</span>
-      </button>
+          <svg
+            className={cn(
+              ICON_SIZE,
+              "shrink-0 transition-transform duration-200",
+              expanded ? "rotate-90" : "rotate-0"
+            )}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M9 6l6 6-6 6" />
+          </svg>
+          <span>{summaryLabel}</span>
+        </button>
+        {hasMemories && (
+          <>
+            <span className="text-xs text-muted-foreground/50">·</span>
+            <MemoryIndicator memories={memoriesExtracted} />
+          </>
+        )}
+      </div>
 
       <div
         className="mx-0 sm:-mx-6 grid transition-[grid-template-rows] duration-200 ease-out"

--- a/src/components/chat/memory-indicator.tsx
+++ b/src/components/chat/memory-indicator.tsx
@@ -1,0 +1,69 @@
+import { BrainIcon } from "@phosphor-icons/react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { ExtractedMemory } from "@/types";
+
+export const CATEGORY_LABELS: Record<ExtractedMemory["category"], string> = {
+  preference: "Preference",
+  fact: "Fact",
+  instruction: "Instruction",
+};
+
+export const CATEGORY_COLORS: Record<ExtractedMemory["category"], string> = {
+  preference: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
+  fact: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+  instruction: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+};
+
+export function MemoryIndicator({ memories }: { memories: ExtractedMemory[] }) {
+  if (!memories || memories.length === 0) {
+    return null;
+  }
+
+  const label =
+    memories.length === 1
+      ? "Memory updated"
+      : `${memories.length} memories saved`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger delayDuration={200}>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center gap-2",
+            "text-xs text-muted-foreground",
+            "transition-colors duration-150 hover:text-foreground"
+          )}
+        >
+          <BrainIcon size={16} weight="duotone" className="shrink-0" />
+          <span>{label}</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-xs">
+        <div className="stack-xs py-0.5">
+          {memories.map((memory, i) => (
+            <div
+              key={`${memory.category}-${i}`}
+              className="flex items-start gap-2 text-xs"
+            >
+              <span
+                className={cn(
+                  "shrink-0 rounded px-1 py-0.5 text-[10px] font-medium leading-tight",
+                  CATEGORY_COLORS[memory.category]
+                )}
+              >
+                {CATEGORY_LABELS[memory.category]}
+              </span>
+              <span className="text-foreground">{memory.content}</span>
+            </div>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/chat/message/assistant-bubble.tsx
+++ b/src/components/chat/message/assistant-bubble.tsx
@@ -343,6 +343,7 @@ const TextMessageBubble = ({
           toolCalls={message.toolCalls?.filter(
             tc => tc.name !== "generateImage"
           )}
+          memoriesExtracted={message.memoriesExtracted}
           suppressSkeleton={message.toolCalls?.some(
             tc => tc.name === "generateImage"
           )}

--- a/src/components/chat/message/assistant-loading-state.tsx
+++ b/src/components/chat/message/assistant-loading-state.tsx
@@ -1,6 +1,6 @@
 import { SkeletonText } from "@/components/ui/skeleton-text";
 import type { AssistantPhase } from "@/hooks";
-import type { ReasoningPart, ToolCall } from "@/types";
+import type { ExtractedMemory, ReasoningPart, ToolCall } from "@/types";
 import { ActivityStream } from "../activity-stream";
 
 type AssistantLoadingStateProps = {
@@ -10,6 +10,7 @@ type AssistantLoadingStateProps = {
   reasoningParts?: ReasoningPart[];
   thinkingDurationMs?: number;
   toolCalls?: ToolCall[];
+  memoriesExtracted?: ExtractedMemory[];
   /** Suppress the text skeleton when another loading indicator is visible (e.g. image gen). */
   suppressSkeleton?: boolean;
 };
@@ -26,6 +27,7 @@ export function AssistantLoadingState({
   reasoningParts,
   thinkingDurationMs,
   toolCalls,
+  memoriesExtracted,
   suppressSkeleton,
 }: AssistantLoadingStateProps) {
   const hasActivity =
@@ -46,6 +48,7 @@ export function AssistantLoadingState({
         reasoning={reasoning}
         thinkingDurationMs={thinkingDurationMs}
         toolCalls={toolCalls}
+        memoriesExtracted={memoriesExtracted}
         isActive={reasoningIsActive}
         phase={phase}
       />

--- a/src/components/settings/mobile/mobile-settings-nav.tsx
+++ b/src/components/settings/mobile/mobile-settings-nav.tsx
@@ -1,5 +1,6 @@
 import {
   ArchiveIcon,
+  BrainIcon,
   CloudArrowDownIcon,
   GearIcon,
   KeyIcon,
@@ -49,6 +50,7 @@ const ChatHistoryPage = lazy(
   () => import("@/pages/settings/chat-history-page")
 );
 const AttachmentsPage = lazy(() => import("@/pages/settings/attachments-page"));
+const MemoryPage = lazy(() => import("@/pages/settings/memory-page"));
 
 // Define settings routes with their components
 const settingsRoutes: (SettingsTabItem & {
@@ -77,6 +79,12 @@ const settingsRoutes: (SettingsTabItem & {
     label: "Personas",
     icon: UsersIcon,
     component: PersonasTab,
+  },
+  {
+    path: ROUTES.SETTINGS.MEMORY,
+    label: "Memory",
+    icon: BrainIcon,
+    component: MemoryPage,
   },
   {
     path: ROUTES.SETTINGS.SHARED_CONVERSATIONS,

--- a/src/components/settings/settings-container.tsx
+++ b/src/components/settings/settings-container.tsx
@@ -1,5 +1,6 @@
 import {
   ArchiveIcon,
+  BrainIcon,
   ChatTextIcon,
   CloudArrowDownIcon,
   GearIcon,
@@ -31,6 +32,7 @@ const mainTabs: SettingsTabItem[] = [
   { path: ROUTES.SETTINGS.API_KEYS, label: "API Keys", icon: KeyIcon },
   { path: ROUTES.SETTINGS.TEXT_MODELS, label: "Models", icon: RobotIcon },
   { path: ROUTES.SETTINGS.PERSONAS, label: "Personas", icon: UsersIcon },
+  { path: ROUTES.SETTINGS.MEMORY, label: "Memory", icon: BrainIcon },
   {
     path: ROUTES.SETTINGS.SHARED_CONVERSATIONS,
     label: "Shares",

--- a/src/components/settings/settings-tabs.tsx
+++ b/src/components/settings/settings-tabs.tsx
@@ -130,7 +130,7 @@ export function SettingsTabs({
             );
 
             const tabClassName = cn(
-              "relative z-10 flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium transition-colors duration-200",
+              "relative z-10 flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-2 py-2 text-sm font-medium transition-colors duration-200",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-muted",
               "sm:flex-1",
               isActive ? "text-foreground" : "text-muted-foreground"

--- a/src/components/settings/ui/activity-section.tsx
+++ b/src/components/settings/ui/activity-section.tsx
@@ -21,30 +21,6 @@ interface ActivitySectionProps {
   showDetailed?: boolean;
   title?: string;
   description?: string;
-  confirmDialog?: {
-    isOpen: boolean;
-    options: {
-      title: string;
-      description: string;
-      confirmText?: string;
-      cancelText?: string;
-      variant?: "default" | "destructive";
-    };
-    confirm: (
-      opts: {
-        title: string;
-        description: string;
-        confirmText?: string;
-        cancelText?: string;
-        variant?: "default" | "destructive";
-      },
-      onConfirm: () => void,
-      onCancel?: () => void
-    ) => void;
-    handleConfirm: () => void;
-    handleCancel: () => void;
-    handleOpenChange: (open: boolean) => void;
-  };
 }
 
 function DetailedJobCard({
@@ -66,6 +42,7 @@ function DetailedJobCard({
   const isExport = job.type === "export";
   const isImport = job.type === "import";
   const isBulkDelete = job.type === "bulk_delete";
+  const isMemoryScan = job.type === "memory_scan";
 
   const getStatusIcon = () => {
     if (isCompleted) {
@@ -89,6 +66,8 @@ function DetailedJobCard({
         action = "Importing";
       } else if (isBulkDelete) {
         action = "Deleting";
+      } else if (isMemoryScan) {
+        action = "Scanning";
       }
 
       return `${action} ${job.processed} of ${job.total} conversations...`;
@@ -97,6 +76,10 @@ function DetailedJobCard({
     if (isCompleted) {
       if (isExport && job.manifest) {
         return `Exported ${job.manifest.totalConversations} conversation${job.manifest.totalConversations === 1 ? "" : "s"}`;
+      }
+      if (isMemoryScan) {
+        const total = job.result?.totalProcessed ?? job.total;
+        return `Scanned ${total} conversation${total === 1 ? "" : "s"}`;
       }
       if ((isImport || isBulkDelete) && job.result) {
         const processed = job.result.totalImported || 0;
@@ -127,6 +110,8 @@ function DetailedJobCard({
         action = "import";
       } else if (isBulkDelete) {
         action = "delete";
+      } else if (isMemoryScan) {
+        action = "scan";
       }
 
       return `Failed to ${action} conversations`;
@@ -139,6 +124,8 @@ function DetailedJobCard({
       action = "Import";
     } else if (isBulkDelete) {
       action = "Deletion";
+    } else if (isMemoryScan) {
+      action = "Memory scan";
     }
 
     return `${action} scheduled`;
@@ -268,7 +255,8 @@ export function ActivitySection({
               | "export"
               | "import"
               | "bulk_archive"
-              | "bulk_delete",
+              | "bulk_delete"
+              | "memory_scan",
             status: job.status as
               | "scheduled"
               | "processing"

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,5 +1,6 @@
 import { Progress as ProgressPrimitive } from "@base-ui/react/progress";
 import {
+  BrainIcon,
   CheckCircleIcon,
   ClockIcon,
   DownloadIcon,
@@ -90,6 +91,9 @@ function JobProgressCard({ job, onRemove, ref }: JobProgressCardProps) {
     if (job.type === "bulk_delete") {
       return <TrashIcon className="size-3.5" />;
     }
+    if (job.type === "memory_scan") {
+      return <BrainIcon className="size-3.5" />;
+    }
     return <UploadIcon className="size-3.5" />;
   };
 
@@ -116,6 +120,8 @@ function JobProgressCard({ job, onRemove, ref }: JobProgressCardProps) {
       action = "Importing";
     } else if (job.type === "bulk_delete") {
       action = "Deleting";
+    } else if (job.type === "memory_scan") {
+      action = "Scanning";
     }
 
     const itemText = job.total === 1 ? "conversation" : "conversations";

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -48,6 +48,8 @@ export function mapServerMessageToChatMessage(
     error: msg.error,
     personaName: msg.personaName,
     personaIcon: msg.personaIcon,
+    memoriesExtracted:
+      msg.memoriesExtracted as ChatMessage["memoriesExtracted"],
     metadata: msg.metadata,
     imageGeneration: msg.imageGeneration
       ? {

--- a/src/lib/chat/message-utils.ts
+++ b/src/lib/chat/message-utils.ts
@@ -48,6 +48,8 @@ export function convertServerMessage(msg: Doc<"messages">): ChatMessage {
     error: msg.error,
     personaName: msg.personaName,
     personaIcon: msg.personaIcon,
+    memoriesExtracted:
+      msg.memoriesExtracted as ChatMessage["memoriesExtracted"],
     metadata: isMessageMetadata(msg.metadata)
       ? (msg.metadata as ChatMessage["metadata"])
       : undefined,

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -19,6 +19,7 @@ export const ROUTES = {
     ARCHIVED_CONVERSATIONS: "/settings/archived-conversations",
     CHAT_HISTORY: "/settings/chat-history",
     ATTACHMENTS: "/settings/attachments",
+    MEMORY: "/settings/memory",
     GENERAL: "/settings/general",
   },
   FAVORITES: "/chat/favorites",

--- a/src/pages/settings/chat-history-page.tsx
+++ b/src/pages/settings/chat-history-page.tsx
@@ -17,9 +17,9 @@ import {
   VirtualizedDataList,
   type VirtualizedDataListColumn,
 } from "@/components/data-list";
-import { ActivitySection } from "@/components/settings/chat-history-tab/activity-section";
 import { ImportExportActions } from "@/components/settings/chat-history-tab/import-export-actions";
 import { SettingsHeader } from "@/components/settings/settings-header";
+import { ActivitySection } from "@/components/settings/ui/activity-section";
 import { SettingsPageLayout } from "@/components/settings/ui/settings-page-layout";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/src/pages/settings/memory-page.tsx
+++ b/src/pages/settings/memory-page.tsx
@@ -1,0 +1,494 @@
+import { api } from "@convex/_generated/api";
+import type { Doc } from "@convex/_generated/dataModel";
+import { BrainIcon, ToggleLeftIcon, TrashIcon } from "@phosphor-icons/react";
+import { useMutation, useQuery } from "convex/react";
+import { useCallback, useMemo, useState, useTransition } from "react";
+import {
+  CATEGORY_COLORS,
+  CATEGORY_LABELS,
+} from "@/components/chat/memory-indicator";
+import type { MobileDrawerConfig } from "@/components/data-list/data-list-mobile-drawer";
+import type { VirtualizedDataListColumn } from "@/components/data-list/virtualized-data-list";
+import { VirtualizedDataList } from "@/components/data-list/virtualized-data-list";
+import { SettingsHeader } from "@/components/settings/settings-header";
+import { ActivitySection } from "@/components/settings/ui/activity-section";
+import { SettingsPageLayout } from "@/components/settings/ui/settings-page-layout";
+import { SettingsZeroState } from "@/components/settings/ui/settings-zero-state";
+import { Button } from "@/components/ui/button";
+import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
+import { SearchInput } from "@/components/ui/search-input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useBackgroundJobs } from "@/hooks/use-background-jobs";
+import { useDebounce } from "@/hooks/use-debounce";
+import { useConfirmationDialog } from "@/hooks/use-dialog-management";
+import type { SortDirection } from "@/hooks/use-list-sort";
+import { useUserSettings } from "@/hooks/use-user-settings";
+import { cn } from "@/lib/utils";
+import { useToast } from "@/providers/toast-context";
+
+type MemoryItem = Doc<"userMemories">;
+
+type SortField = "createdAt";
+
+export default function MemoryPage() {
+  const userSettings = useUserSettings();
+  const updateSettings = useMutation(api.userSettings.updateUserSettings);
+  const memoryCountResult = useQuery(api.memory.getMemoryCount);
+  const memoryCount = memoryCountResult?.count;
+  const memoryCountLabel = memoryCountResult?.isApproximate
+    ? "99+"
+    : String(memoryCount ?? 0);
+  const toggleActive = useMutation(api.memory.toggleActive);
+  const removeMemory = useMutation(api.memory.remove);
+  const clearAllMutation = useMutation(api.memory.clearAll);
+  const confirmationDialog = useConfirmationDialog();
+  const managedToast = useToast();
+  const backgroundJobs = useBackgroundJobs();
+
+  const memoryScanJobs = useMemo(
+    () => backgroundJobs.activeJobs.filter(j => j.type === "memory_scan"),
+    [backgroundJobs.activeJobs]
+  );
+  const hasActiveScan = memoryScanJobs.some(
+    j => j.status === "scheduled" || j.status === "processing"
+  );
+
+  const [isPending, startTransition] = useTransition();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+
+  const memoryEnabled = userSettings?.memoryEnabled ?? false;
+
+  const handleToggleMemory = () => {
+    startTransition(async () => {
+      await updateSettings({ memoryEnabled: !memoryEnabled });
+    });
+  };
+
+  const handleSort = useCallback(() => {
+    setSortDirection(prev => (prev === "asc" ? "desc" : "asc"));
+  }, []);
+
+  const handleToggleActive = useCallback(
+    (memory: MemoryItem) => {
+      startTransition(async () => {
+        await toggleActive({ id: memory._id });
+      });
+    },
+    [toggleActive]
+  );
+
+  const handleDelete = useCallback(
+    (memory: MemoryItem) => {
+      setDeletingId(memory._id);
+      startTransition(async () => {
+        try {
+          await removeMemory({ id: memory._id });
+          managedToast.success("Memory deleted");
+        } finally {
+          setDeletingId(null);
+        }
+      });
+    },
+    [removeMemory, managedToast.success]
+  );
+
+  const handleClearAll = useCallback(() => {
+    confirmationDialog.confirm(
+      {
+        title: "Clear all memories?",
+        description: `This will permanently delete all ${memoryCountLabel} saved memories. This action cannot be undone.`,
+        confirmText: "Clear all memories",
+        cancelText: "Cancel",
+        variant: "destructive",
+      },
+      async () => {
+        let hasMore = true;
+        try {
+          while (hasMore) {
+            const result = await clearAllMutation();
+            hasMore = result?.hasMore ?? false;
+          }
+          managedToast.success("All memories cleared");
+        } catch {
+          managedToast.error("Failed to clear all memories. Some may remain.");
+        }
+      }
+    );
+  }, [
+    confirmationDialog,
+    clearAllMutation,
+    managedToast.success,
+    managedToast.error,
+    memoryCountLabel,
+  ]);
+
+  const columns: VirtualizedDataListColumn<MemoryItem, SortField>[] = useMemo(
+    () => [
+      {
+        key: "category",
+        label: "Category",
+        width: "w-24",
+        hideOnMobile: true,
+        render: memory => (
+          <span
+            className={cn(
+              "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
+              CATEGORY_COLORS[memory.category] ??
+                "bg-muted text-muted-foreground"
+            )}
+          >
+            {CATEGORY_LABELS[memory.category] ?? memory.category}
+          </span>
+        ),
+      },
+      {
+        key: "content",
+        label: "Memory",
+        render: memory => (
+          <div className="min-w-0">
+            <p
+              className={cn(
+                "text-sm truncate",
+                !memory.isActive && "text-muted-foreground"
+              )}
+              title={memory.content}
+            >
+              {memory.content}
+            </p>
+            {memory.sourceConversationTitle && (
+              <span className="text-xs text-muted-foreground truncate block">
+                from &ldquo;{memory.sourceConversationTitle}&rdquo;
+              </span>
+            )}
+          </div>
+        ),
+      },
+      {
+        key: "createdAt",
+        label: "Added",
+        width: "w-28",
+        hideOnMobile: true,
+        sortable: true,
+        sortField: "createdAt" as SortField,
+        render: memory => (
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
+            {new Date(memory.createdAt).toLocaleDateString()}
+          </span>
+        ),
+      },
+      {
+        key: "status",
+        label: "",
+        width: "w-24",
+        className: "text-center",
+        hideOnMobile: true,
+        render: memory => (
+          <div className="flex justify-center">
+            <Switch
+              checked={memory.isActive}
+              onCheckedChange={() => handleToggleActive(memory)}
+              disabled={isPending}
+            />
+          </div>
+        ),
+      },
+      {
+        key: "actions",
+        label: "",
+        width: "w-12",
+        className: "text-right",
+        render: memory => {
+          const isMemoryDeleting = deletingId === memory._id;
+          return (
+            <div
+              className="flex items-center justify-end"
+              onClick={e => e.stopPropagation()}
+              onKeyDown={e => e.stopPropagation()}
+            >
+              <Tooltip>
+                <TooltipTrigger delayDuration={200}>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-8 px-2 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                    onClick={() => handleDelete(memory)}
+                    disabled={isMemoryDeleting}
+                  >
+                    {isMemoryDeleting ? (
+                      <Spinner size="sm" className="size-4" />
+                    ) : (
+                      <TrashIcon className="size-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{isMemoryDeleting ? "Deleting..." : "Delete memory"}</p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          );
+        },
+      },
+    ],
+    [deletingId, handleToggleActive, handleDelete, isPending]
+  );
+
+  const mobileDrawerConfig: MobileDrawerConfig<MemoryItem> = useMemo(
+    () => ({
+      title: memory => memory.content,
+      subtitle: memory =>
+        `${CATEGORY_LABELS[memory.category] ?? memory.category} · Added ${new Date(memory.createdAt).toLocaleDateString()}`,
+      actions: [
+        {
+          key: "toggle",
+          label: memory =>
+            memory.isActive ? "Disable memory" : "Enable memory",
+          icon: ToggleLeftIcon,
+          onClick: () => {
+            // Toggle actions use the toggle config below, onClick is required by type
+          },
+          toggle: {
+            checked: memory => memory.isActive,
+            onCheckedChange: memory => handleToggleActive(memory),
+          },
+        },
+        {
+          key: "delete",
+          label: memory =>
+            deletingId === memory._id ? "Deleting..." : "Delete memory",
+          icon: TrashIcon,
+          onClick: memory => handleDelete(memory),
+          className:
+            "text-destructive hover:bg-destructive/10 hover:text-destructive",
+          disabled: memory => deletingId === memory._id,
+        },
+      ],
+    }),
+    [handleToggleActive, handleDelete, deletingId]
+  );
+
+  const getEmptyDescription = () => {
+    if (searchQuery) {
+      return "Try adjusting your search terms.";
+    }
+    if (memoryEnabled) {
+      return "Start chatting and Polly will remember important details about you.";
+    }
+    return "Enable memory above to start saving facts across conversations.";
+  };
+
+  const emptyState = (
+    <SettingsZeroState
+      icon={<BrainIcon className="size-12" weight="duotone" />}
+      title={searchQuery ? "No memories found" : "No memories yet"}
+      description={getEmptyDescription()}
+    />
+  );
+
+  if (!userSettings) {
+    return (
+      <SettingsPageLayout>
+        <SettingsHeader
+          title="Memory"
+          description="Polly can remember things about you across conversations to provide more personalized responses."
+        />
+        <div className="stack-sm">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      </SettingsPageLayout>
+    );
+  }
+
+  return (
+    <>
+      <SettingsPageLayout>
+        <SettingsHeader
+          title="Memory"
+          description="Polly can remember things about you across conversations to provide more personalized responses."
+        />
+
+        {/* Global Memory Toggle */}
+        <div className="rounded-lg bg-muted/20 p-4 shadow-sm ring-1 ring-border/30 mb-8">
+          <div className="flex items-start justify-between gap-4">
+            <div className="stack-sm flex-1">
+              <h3 className="text-base font-semibold">Enable Memory</h3>
+              <p className="text-sm text-muted-foreground">
+                Automatically extract and remember relevant facts about you from
+                conversations.
+              </p>
+            </div>
+            <Switch
+              checked={memoryEnabled}
+              onCheckedChange={handleToggleMemory}
+              disabled={isPending}
+              className="flex-shrink-0"
+            />
+          </div>
+        </div>
+
+        {/* Scan Existing Conversations */}
+        {memoryEnabled && (
+          <div className="rounded-lg bg-muted/20 p-4 shadow-sm ring-1 ring-border/30 mb-8">
+            <div className="flex items-start justify-between gap-4">
+              <div className="stack-sm flex-1">
+                <h3 className="text-base font-semibold">
+                  Scan Existing Conversations
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Extract memories from your recent conversations. Only
+                  processes conversations with enough messages.
+                </p>
+              </div>
+              <Tooltip>
+                <TooltipTrigger delayDuration={200}>
+                  <Button
+                    onClick={async () => {
+                      await backgroundJobs.startMemoryScan();
+                    }}
+                    disabled={hasActiveScan}
+                  >
+                    {hasActiveScan ? (
+                      <>
+                        <Spinner size="sm" className="mr-1.5" /> Scanning...
+                      </>
+                    ) : (
+                      "Start Scan"
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                {hasActiveScan && (
+                  <TooltipContent>
+                    <p>A scan is already in progress</p>
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            </div>
+          </div>
+        )}
+
+        {/* Scan Activity */}
+        {memoryScanJobs.length > 0 && (
+          <div className="mb-8">
+            <ActivitySection
+              jobs={memoryScanJobs}
+              onDownload={() => {
+                // Memory scan jobs don't have downloadable files
+              }}
+              onRemove={backgroundJobs.removeJob}
+              isDownloading={false}
+              downloadingJobId={null}
+              showDetailed={true}
+              title="Scan Activity"
+            />
+          </div>
+        )}
+
+        {/* Saved Memories */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold">
+              Saved Memories
+              {memoryCount !== undefined && memoryCount > 0 && (
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  ({memoryCountLabel})
+                </span>
+              )}
+            </h2>
+            <div className="flex items-center gap-2">
+              <SearchInput
+                placeholder="Search memories..."
+                value={searchQuery}
+                onChange={setSearchQuery}
+                className="w-48"
+              />
+              {memoryCount !== undefined && memoryCount > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleClearAll}
+                  className="text-destructive hover:text-destructive"
+                >
+                  <TrashIcon className="mr-1.5 size-4" />
+                  Clear all
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <VirtualizedDataList<MemoryItem, SortField>
+            query={api.memory.listPaginated}
+            queryArgs={{
+              sortDirection,
+              searchQuery: debouncedSearchQuery || undefined,
+            }}
+            getItemKey={memory => memory._id}
+            columns={columns}
+            sort={{
+              field: "createdAt",
+              direction: sortDirection,
+              onSort: handleSort,
+            }}
+            mobileTitleRender={memory => (
+              <div className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
+                    CATEGORY_COLORS[memory.category] ??
+                      "bg-muted text-muted-foreground"
+                  )}
+                >
+                  {CATEGORY_LABELS[memory.category] ?? memory.category}
+                </span>
+                <span
+                  className={cn(
+                    "truncate text-sm",
+                    !memory.isActive && "text-muted-foreground"
+                  )}
+                >
+                  {memory.content}
+                </span>
+              </div>
+            )}
+            mobileMetadataRender={memory => (
+              <span className="text-xs text-muted-foreground">
+                {memory.sourceConversationTitle
+                  ? `from "${memory.sourceConversationTitle}" · `
+                  : ""}
+                Added {new Date(memory.createdAt).toLocaleDateString()}
+              </span>
+            )}
+            mobileDrawerConfig={mobileDrawerConfig}
+            emptyState={emptyState}
+            initialNumItems={20}
+            loadMoreCount={20}
+          />
+        </section>
+      </SettingsPageLayout>
+
+      <ConfirmationDialog
+        open={confirmationDialog.state.isOpen}
+        onOpenChange={confirmationDialog.handleOpenChange}
+        title={confirmationDialog.state.title}
+        description={confirmationDialog.state.description}
+        confirmText={confirmationDialog.state.confirmText}
+        cancelText={confirmationDialog.state.cancelText}
+        variant={confirmationDialog.state.variant}
+        onConfirm={confirmationDialog.handleConfirm}
+        onCancel={confirmationDialog.handleCancel}
+      />
+    </>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -56,6 +56,7 @@ const SettingsChatHistoryPage = lazy(
   () => import("./pages/settings/chat-history-page")
 );
 const SettingsGeneralPage = lazy(() => import("./pages/settings/general-page"));
+const SettingsMemoryPage = lazy(() => import("./pages/settings/memory-page"));
 const SettingsNewPersonaPage = lazy(
   () => import("./pages/settings/new-persona-page")
 );
@@ -231,6 +232,11 @@ export const routes: RouteObject[] = [
           {
             path: "attachments",
             element: withSuspense(<SettingsAttachmentsPage />, "partial"),
+            errorElement: routeErrorElement,
+          },
+          {
+            path: "memory",
+            element: withSuspense(<SettingsMemoryPage />, "partial"),
             errorElement: routeErrorElement,
           },
           {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,17 @@ export type MessageId = Id<"messages">;
 export type UserId = Id<"users">;
 
 // ============================================================================
+// MEMORY TYPES
+// ============================================================================
+
+export type MemoryCategory = "preference" | "fact" | "instruction";
+
+export type ExtractedMemory = {
+  content: string;
+  category: MemoryCategory;
+};
+
+// ============================================================================
 // AI & MODEL TYPES
 // ============================================================================
 
@@ -213,6 +224,7 @@ export type ChatMessage = {
   // Persona snapshot — frozen at message creation time
   personaName?: string;
   personaIcon?: string;
+  memoriesExtracted?: ExtractedMemory[];
   metadata?: {
     tokenCount?: number;
     finishReason?: string;


### PR DESCRIPTION
## Summary
- Adds a complete **memory system** that extracts, stores, and retrieves user memories across conversations
- Memories are injected into the system prompt for personalized responses
- Includes a **background scan** feature to extract memories from existing conversations
- Memory indicator shows extracted memories inline on assistant messages

## Core Memory Infrastructure
- **Schema**: `userMemories` table with vector embeddings, `memoryEnabled` on userSettings, `memoriesExtracted` on messages
- **Extraction**: After each streaming response, schedules memory extraction via LLM (5s delay, non-blocking)
- **Retrieval**: Vector search finds relevant memories and injects them into system prompt via `buildMemoryContext()`
- **Dedup**: Cosine similarity thresholds — >0.95 skip, >0.8 update existing, <0.8 create new
- **UI**: Memory settings page, memory indicator on messages, `ActivityStream` integration

## Conversation Scan Backfill
- Background job iterates eligible conversations (non-archived, ≥4 messages), extracts memories via LLM
- Real-time progress tracking via existing `backgroundJobs` system
- Relocated `ActivitySection` to `settings/ui/` for shared use

## Files Changed
- **Schema/DB**: `schemas.ts`, `schema.ts`, `userSettings.ts`
- **Backend**: `memory.ts`, `memory_actions.ts`, `context_building.ts`, `action_handlers.ts`, `streaming_actions.ts`, `system-prompts.ts`
- **Frontend**: `memory-page.tsx`, `memory-indicator.tsx`, `activity-stream.tsx`, `assistant-bubble.tsx`, `use-background-jobs.ts`, `use-chat.ts`, `message-utils.ts`
- **Navigation**: `routes.tsx`, `routes.ts`, `settings-container.tsx`, `mobile-settings-nav.tsx`

## Test plan
- [ ] Enable memory in settings → toggle persists
- [ ] Send a message → memory extraction scheduled (check Convex logs)
- [ ] Extracted memories appear on assistant messages (brain icon indicator)
- [ ] Memory settings page lists saved memories with search/filter
- [ ] Toggle individual memories active/inactive
- [ ] Delete individual memories and clear all
- [ ] Start scan → progress bar updates, memories appear after completion
- [ ] Scan button disabled during active scan
- [ ] No eligible conversations → toast message, no job created
- [ ] Memory disabled → scan card hidden
- [ ] Chat history page still renders ActivitySection correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)