### PR TITLE
fix: expose raw provider errors instead of lossy friendly messages

### DIFF
--- a/convex/ai/streaming/state.ts
+++ b/convex/ai/streaming/state.ts
@@ -15,7 +15,7 @@ import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";
 import type { Citation } from "../../types";
-import { getUserFriendlyErrorMessage } from "../error_handlers";
+import { getRawErrorMessage, getUserFriendlyErrorMessage } from "../error_handlers";
 import {
   createWebSearchTool,
   createImageGenerationTool,
@@ -458,9 +458,11 @@ export async function handleStreamError(
   console.error("Stream error in onError callback:", error);
   try {
     const errorMessage = getUserFriendlyErrorMessage(error);
+    const errorDetail = getRawErrorMessage(error);
     await ctx.runMutation(internal.messages.updateMessageError, {
       messageId,
       error: errorMessage,
+      errorDetail: errorDetail !== errorMessage ? errorDetail : undefined,
     });
   } catch (updateError) {
     console.error("Failed to update message with error:", updateError);

--- a/convex/ai/streaming_core.ts
+++ b/convex/ai/streaming_core.ts
@@ -14,7 +14,7 @@ import {
   isReasoningDelta,
 } from "../lib/shared/stream_utils";
 import type { Citation } from "../types";
-import { getUserFriendlyErrorMessage } from "./error_handlers";
+import { getRawErrorMessage, getUserFriendlyErrorMessage } from "./error_handlers";
 import { createStreamBuffer } from "./streaming/buffer";
 import {
   type StreamingParams,
@@ -279,9 +279,11 @@ export async function streamLLMToMessage({
   } catch (error) {
     console.error("Stream error: stream failed", error);
     const errorMessage = getUserFriendlyErrorMessage(error);
+    const errorDetail = getRawErrorMessage(error);
     await ctx.runMutation(internal.messages.updateMessageError, {
       messageId,
       error: errorMessage,
+      errorDetail: errorDetail !== errorMessage ? errorDetail : undefined,
     });
   } finally {
     if (buffer.state.userStopped) {

--- a/convex/lib/message/internal_handlers.ts
+++ b/convex/lib/message/internal_handlers.ts
@@ -867,9 +867,10 @@ export async function updateMessageErrorHandler(
   args: {
     messageId: Id<"messages">;
     error: string;
+    errorDetail?: string;
   }
 ) {
-  const { messageId, error } = args;
+  const { messageId, error, errorDetail } = args;
   try {
     const message = await ctx.db.get("messages", messageId);
     if (!message) {
@@ -880,6 +881,7 @@ export async function updateMessageErrorHandler(
     await ctx.db.patch("messages", messageId, {
       status: "error",
       error,
+      ...(errorDetail ? { errorDetail } : {}),
       metadata: {
         ...message.metadata,
         finishReason: "error",

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -867,6 +867,7 @@ export const messageSchema = v.object({
   imageGeneration: v.optional(imageGenerationSchema), // Add image generation support
   toolCalls: v.optional(v.array(toolCallSchema)), // Tool calls made during reasoning
   error: v.optional(v.string()), // Error message for failed text-to-text requests
+  errorDetail: v.optional(v.string()), // Raw technical error from the provider
   ttsAudioCache: v.optional(v.array(ttsAudioCacheEntrySchema)),
   // Persona snapshot — frozen at message creation time so changing the conversation persona
   // doesn't retroactively update existing messages.

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -481,6 +481,7 @@ export const updateMessageError = internalMutation({
   args: {
     messageId: v.id("messages"),
     error: v.string(),
+    errorDetail: v.optional(v.string()),
   },
   handler: updateMessageErrorHandler,
 });

--- a/convex/streaming_actions.ts
+++ b/convex/streaming_actions.ts
@@ -9,7 +9,10 @@ import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { internalAction } from "./_generated/server";
 import { getApiKey } from "./ai/encryption";
-import { getUserFriendlyErrorMessage } from "./ai/error_handlers";
+import {
+  getRawErrorMessage,
+  getUserFriendlyErrorMessage,
+} from "./ai/error_handlers";
 import {
   convertLegacyPartToAISDK,
   type LegacyMessagePart,
@@ -294,9 +297,11 @@ export const streamMessage = internalAction({
       // This prevents messages from being stuck in "thinking" status indefinitely
       console.error("Stream setup error:", error);
       const errorMessage = getUserFriendlyErrorMessage(error);
+      const errorDetail = getRawErrorMessage(error);
       await ctx.runMutation(internal.messages.updateMessageError, {
         messageId,
         error: errorMessage,
+        errorDetail: errorDetail !== errorMessage ? errorDetail : undefined,
       });
     } finally {
       // Use conditional clearing to prevent race conditions with newer streaming actions.

--- a/src/components/chat/message/message-error.tsx
+++ b/src/components/chat/message/message-error.tsx
@@ -1,4 +1,8 @@
-import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
+import {
+  ArrowCounterClockwiseIcon,
+  CaretDownIcon,
+} from "@phosphor-icons/react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { ChatMessage } from "@/types";
 import {
@@ -24,6 +28,8 @@ export function MessageError({
   onRetry,
   onRetryImage,
 }: MessageErrorProps) {
+  const [showDetail, setShowDetail] = useState(false);
+
   const hasImageError =
     message.imageGeneration?.status === "failed" ||
     message.imageGeneration?.status === "canceled";
@@ -36,6 +42,7 @@ export function MessageError({
   const errorMessage = hasImageError
     ? message.imageGeneration?.error
     : message.error;
+  const errorDetail = hasTextError ? message.errorDetail : undefined;
   const errorTitle = hasImageError
     ? `Image generation ${
         message.imageGeneration?.status === "canceled" ? "canceled" : "failed"
@@ -96,6 +103,25 @@ export function MessageError({
         <div className="flex-1">
           <h4 className="text-sm font-medium text-danger">{errorTitle}</h4>
           <p className="mt-1 text-sm text-danger">{errorMessage}</p>
+          {errorDetail && (
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => setShowDetail(prev => !prev)}
+                className="inline-flex items-center gap-1 text-xs text-danger/60 hover:text-danger/80"
+              >
+                <CaretDownIcon
+                  className={`size-3 transition-transform ${showDetail ? "rotate-0" : "-rotate-90"}`}
+                />
+                Technical details
+              </button>
+              {showDetail && (
+                <pre className="mt-1.5 overflow-x-auto whitespace-pre-wrap break-all rounded bg-danger/5 px-2 py-1.5 font-mono text-xs text-danger/70">
+                  {errorDetail}
+                </pre>
+              )}
+            </div>
+          )}
           {showRetry && <div className="mt-3">{renderRetryButton()}</div>}
         </div>
       </div>

--- a/src/lib/chat/message-utils.ts
+++ b/src/lib/chat/message-utils.ts
@@ -46,6 +46,7 @@ export function convertServerMessage(msg: Doc<"messages">): ChatMessage {
     reasoningParts: msg.reasoningParts as ChatMessage["reasoningParts"],
     toolCalls: msg.toolCalls as ChatMessage["toolCalls"],
     error: msg.error,
+    errorDetail: msg.errorDetail,
     personaName: msg.personaName,
     personaIcon: msg.personaIcon,
     memoriesExtracted:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -221,6 +221,7 @@ export type ChatMessage = {
   reasoningParts?: ReasoningPart[]; // Interleaved reasoning segments
   toolCalls?: ToolCall[]; // Tool calls made during reasoning
   error?: string; // Error message for failed text-to-text requests
+  errorDetail?: string; // Raw technical error from the provider
   // Persona snapshot — frozen at message creation time
   personaName?: string;
   personaIcon?: string;


### PR DESCRIPTION
## Summary

- Replaced the brittle substring-matching error classifier (`getUserFriendlyErrorMessage`) with direct passthrough of provider error messages — providers already return clear, actionable errors
- Only override remaining is for Convex OCC conflicts (`"Documents read from or written to have changed"`) which is meaningless to users
- Added `errorDetail` field to messages schema to store the raw technical error alongside the displayed message
- Added collapsible "Technical details" section in the error UI so users can inspect the actual provider error

Fixes false positives where `includes("token")` was catching auth token errors and showing "Your conversation has become too long" for unrelated failures.

## Test plan

- [x] All existing error handler tests updated and passing
- [x] TypeScript compiles cleanly
- [x] Biome lint passes
- [x] Production build succeeds
- [ ] Trigger a provider error (e.g. invalid API key) and verify the raw error is shown
- [ ] Verify "Technical details" toggle works in the error UI
- [ ] Verify OCC conflicts still show the friendly message

🤖 Generated with [Claude Code](https://claude.com/claude-code)