### PR TITLE
fix: prevent sending both reasoning.effort and reasoning.max_tokens to OpenRouter

### DIFF
--- a/shared/reasoning-config.test.ts
+++ b/shared/reasoning-config.test.ts
@@ -296,6 +296,24 @@ describe("getProviderReasoningOptions", () => {
     });
   });
 
+  test("returns OpenRouter reasoning config with only effort when both effort and maxTokens are provided", () => {
+    const result = getProviderReasoningOptions("openrouter", {
+      effort: "high",
+      maxTokens: 8000,
+    });
+
+    expect(result).toEqual({
+      providerOptions: {
+        openrouter: {
+          reasoning: {
+            effort: "high",
+            exclude: false,
+          },
+        },
+      },
+    });
+  });
+
   test("returns OpenRouter reasoning config with enabled flag when no explicit config", () => {
     const result = getProviderReasoningOptions("openrouter");
 

--- a/shared/reasoning-config.ts
+++ b/shared/reasoning-config.ts
@@ -256,24 +256,19 @@ export function getProviderReasoningOptions(
       // - max_tokens: Direct token allocation (for Gemini, Anthropic models)
       // - exclude: true/false to hide reasoning from response
       // - enabled: true to use default settings
+      // IMPORTANT: Only one of effort/max_tokens can be specified per request.
       // Must use providerOptions.openrouter (not extraBody) at the streamText level
       const reasoningOptions: OpenRouterReasoningOptions = {
         exclude: false,
       };
 
-      // Set effort level if provided (preferred for o-series and Grok models)
+      // effort and max_tokens are mutually exclusive on OpenRouter.
+      // Prefer effort when set; fall back to max_tokens only when effort is absent.
       if (reasoningConfig?.effort) {
         reasoningOptions.effort = reasoningConfig.effort;
-      }
-
-      // Set max tokens if provided (preferred for Gemini and Anthropic models)
-      if (reasoningConfig?.maxTokens) {
+      } else if (reasoningConfig?.maxTokens) {
         reasoningOptions["max_tokens"] = reasoningConfig.maxTokens;
       }
-
-      // Control reasoning token visibility - set to false to include reasoning in response
-      // We want reasoning tokens for our internal processing
-      reasoningOptions.exclude = false;
 
       // Enable reasoning with provided config or use enabled: true for defaults
       const hasExplicitConfig =


### PR DESCRIPTION
## Summary

- OpenRouter only allows one of `reasoning.effort` or `reasoning.max_tokens` per request, but we were sending both when the reasoning config had both fields set
- This caused errors like: `Only one of "reasoning.effort" and "reasoning.max_tokens" can be specified` (e.g. on moonshotai/kimi-k2.5)
- Previously this was masked by the error handler misclassifying it as "conversation too long" (fixed in #155)
- Fix: prefer `effort` when set, only fall back to `max_tokens` when effort is absent

## Test plan

- [x] New test: verifies only `effort` is sent when both `effort` and `maxTokens` are provided
- [x] Existing OpenRouter reasoning tests still pass (effort-only, maxTokens-only, enabled-only)
- [x] Full check passes (lint + types + build)
- [ ] Test with moonshotai/kimi-k2.5 on OpenRouter with reasoning enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)