### PR TITLE
feat: add animated hover icons using framer-motion

### DIFF
--- a/src/components/chat/message/action-button.tsx
+++ b/src/components/chat/message/action-button.tsx
@@ -1,14 +1,15 @@
-import {
-  ArrowCounterClockwiseIcon,
-  CheckIcon,
-  CopyIcon,
-  GitBranchIcon,
-  HeartIcon,
-  NotePencilIcon,
-  TextAaIcon,
-  TrashIcon,
-} from "@phosphor-icons/react";
+import { TextAaIcon } from "@phosphor-icons/react";
 import { memo } from "react";
+import {
+  AnimatedCheckIcon,
+  AnimatedCopyIcon,
+  AnimatedDeleteIcon,
+  AnimatedEditIcon,
+  AnimatedGitBranchIcon,
+  AnimatedHeartIcon,
+  AnimatedRetryIcon,
+  useAnimatedIcon,
+} from "@/components/ui/animated-icons";
 import {
   Tooltip,
   TooltipContent,
@@ -102,6 +103,8 @@ export function ActionButton({
           aria-label={props["aria-label"] || tooltip}
           disabled={props.disabled}
           onClick={props.onClick}
+          onMouseEnter={props.onMouseEnter}
+          onMouseLeave={props.onMouseLeave}
         >
           {props.children}
         </TooltipTrigger>
@@ -138,93 +141,151 @@ type PresetActionButtonProps = {
 };
 
 export const ActionButtons = {
-  Copy: memo(
-    ({ copied, tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
+  Copy: memo(function CopyActionButton({
+    copied,
+    tooltip,
+    ariaLabel,
+    ...props
+  }: PresetActionButtonProps) {
+    const { controls, onHoverStart, onHoverEnd } = useAnimatedIcon();
+    return (
       <ActionButton
         tooltip={tooltip || (copied ? "Copied!" : "Copy")}
         aria-label={ariaLabel || tooltip || (copied ? "Copied!" : "Copy")}
+        onMouseEnter={onHoverStart}
+        onMouseLeave={onHoverEnd}
         {...props}
       >
         {copied ? (
-          <CheckIcon
+          <AnimatedCheckIcon
+            controls={controls}
             className={cn(iconClass, "text-primary animate-copy-success")}
-            aria-hidden="true"
           />
         ) : (
-          <CopyIcon className={iconClass} aria-hidden="true" />
+          <AnimatedCopyIcon controls={controls} className={iconClass} />
         )}
       </ActionButton>
-    )
-  ),
+    );
+  }),
 
-  Delete: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
-    <ActionButton
-      variant="destructive"
-      tooltip={tooltip || "Delete"}
-      aria-label={ariaLabel || tooltip || "Delete"}
-      {...props}
-    >
-      <TrashIcon className={iconClass} aria-hidden="true" />
-    </ActionButton>
-  )),
+  Delete: memo(function DeleteActionButton({
+    tooltip,
+    ariaLabel,
+    ...props
+  }: PresetActionButtonProps) {
+    const { controls, onHoverStart, onHoverEnd } = useAnimatedIcon();
+    return (
+      <ActionButton
+        variant="destructive"
+        tooltip={tooltip || "Delete"}
+        aria-label={ariaLabel || tooltip || "Delete"}
+        onMouseEnter={onHoverStart}
+        onMouseLeave={onHoverEnd}
+        {...props}
+      >
+        <AnimatedDeleteIcon controls={controls} className={iconClass} />
+      </ActionButton>
+    );
+  }),
 
-  Edit: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
-    <ActionButton
-      tooltip={tooltip || "Edit"}
-      aria-label={ariaLabel || tooltip || "Edit"}
-      {...props}
-    >
-      <NotePencilIcon className={iconClass} aria-hidden="true" />
-    </ActionButton>
-  )),
+  Edit: memo(function EditActionButton({
+    tooltip,
+    ariaLabel,
+    ...props
+  }: PresetActionButtonProps) {
+    const { controls, onHoverStart, onHoverEnd } = useAnimatedIcon();
+    return (
+      <ActionButton
+        tooltip={tooltip || "Edit"}
+        aria-label={ariaLabel || tooltip || "Edit"}
+        onMouseEnter={onHoverStart}
+        onMouseLeave={onHoverEnd}
+        {...props}
+      >
+        <AnimatedEditIcon controls={controls} className={iconClass} />
+      </ActionButton>
+    );
+  }),
 
-  Favorite: memo(
-    ({ favorited, tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
+  Favorite: memo(function FavoriteActionButton({
+    favorited,
+    tooltip,
+    ariaLabel,
+    ...props
+  }: PresetActionButtonProps) {
+    const { controls, onHoverStart, onHoverEnd } = useAnimatedIcon();
+    return (
       <ActionButton
         tooltip={tooltip || (favorited ? "Unfavorite" : "Favorite")}
         aria-label={
           ariaLabel || tooltip || (favorited ? "Unfavorite" : "Favorite")
         }
+        onMouseEnter={onHoverStart}
+        onMouseLeave={onHoverEnd}
         {...props}
       >
-        <HeartIcon
+        <AnimatedHeartIcon
+          controls={controls}
           className={cn(iconClass, favorited && "text-destructive")}
-          weight={favorited ? "fill" : "regular"}
-          aria-hidden="true"
+          filled={!!favorited}
         />
       </ActionButton>
-    )
-  ),
+    );
+  }),
 
-  Branch: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
-    <ActionButton
-      tooltip={tooltip || "Branch from here"}
-      aria-label={ariaLabel || tooltip || "Branch from here"}
-      {...props}
-    >
-      <GitBranchIcon className={iconClass} aria-hidden="true" />
-    </ActionButton>
-  )),
+  Branch: memo(function BranchActionButton({
+    tooltip,
+    ariaLabel,
+    ...props
+  }: PresetActionButtonProps) {
+    const { controls, onHoverStart, onHoverEnd } = useAnimatedIcon();
+    return (
+      <ActionButton
+        tooltip={tooltip || "Branch from here"}
+        aria-label={ariaLabel || tooltip || "Branch from here"}
+        onMouseEnter={onHoverStart}
+        onMouseLeave={onHoverEnd}
+        {...props}
+      >
+        <AnimatedGitBranchIcon controls={controls} className={iconClass} />
+      </ActionButton>
+    );
+  }),
 
-  Retry: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
-    <ActionButton
-      tooltip={tooltip || "Retry"}
-      aria-label={ariaLabel || tooltip || "Retry"}
-      {...props}
-    >
-      <ArrowCounterClockwiseIcon className={iconClass} aria-hidden="true" />
-    </ActionButton>
-  )),
+  Retry: memo(function RetryActionButton({
+    tooltip,
+    ariaLabel,
+    ...props
+  }: PresetActionButtonProps) {
+    const { controls, onHoverStart, onHoverEnd } = useAnimatedIcon();
+    return (
+      <ActionButton
+        tooltip={tooltip || "Retry"}
+        aria-label={ariaLabel || tooltip || "Retry"}
+        onMouseEnter={onHoverStart}
+        onMouseLeave={onHoverEnd}
+        {...props}
+      >
+        <AnimatedRetryIcon controls={controls} className={iconClass} />
+      </ActionButton>
+    );
+  }),
 
-  ZenMode: memo(({ tooltip, ariaLabel, ...props }: PresetActionButtonProps) => (
-    <ActionButton
-      tooltip={tooltip || "Zen mode"}
-      aria-label={ariaLabel || tooltip || "Zen mode"}
-      {...props}
-    >
-      <TextAaIcon className={iconClass} aria-hidden="true" />
-    </ActionButton>
-  )),
+  ZenMode: memo(function ZenModeActionButton({
+    tooltip,
+    ariaLabel,
+    ...props
+  }: PresetActionButtonProps) {
+    return (
+      <ActionButton
+        tooltip={tooltip || "Zen mode"}
+        aria-label={ariaLabel || tooltip || "Zen mode"}
+        {...props}
+      >
+        <TextAaIcon className={iconClass} aria-hidden="true" />
+      </ActionButton>
+    );
+  }),
 };
 
 ActionButtons.Copy.displayName = "ActionButtons.Copy";

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -1,9 +1,5 @@
 import { api } from "@convex/_generated/api";
-import {
-  HeartIcon,
-  NotePencilIcon,
-  SidebarSimpleIcon,
-} from "@phosphor-icons/react";
+import { SidebarSimpleIcon } from "@phosphor-icons/react";
 import { useQuery } from "convex/react";
 import {
   AnimatePresence,
@@ -20,6 +16,11 @@ import { BatchActions } from "@/components/navigation/sidebar/batch-actions";
 import { ConversationList } from "@/components/navigation/sidebar/conversation-list";
 import { SidebarSearch } from "@/components/navigation/sidebar/search";
 import { UserSection } from "@/components/navigation/sidebar/user-section";
+import {
+  AnimatedEditIcon,
+  AnimatedHeartIcon,
+  useAnimatedIcon,
+} from "@/components/ui/animated-icons";
 import { Backdrop } from "@/components/ui/backdrop";
 import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
@@ -72,6 +73,8 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
   const { isSelectionMode, hasSelection } = useBatchSelection();
   const location = useLocation();
   const { isPrivateMode } = usePrivateMode();
+  const favoritesIcon = useAnimatedIcon();
+  const newChatIcon = useAnimatedIcon();
 
   // Framer Motion for gestures
   const dragControls = useDragControls();
@@ -460,14 +463,13 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
                         title="Favorites"
                         variant="ghost"
                         className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover h-8 w-8"
+                        onMouseEnter={favoritesIcon.onHoverStart}
+                        onMouseLeave={favoritesIcon.onHoverEnd}
                       >
-                        <HeartIcon
+                        <AnimatedHeartIcon
+                          controls={favoritesIcon.controls}
                           className="size-4.5"
-                          weight={
-                            location.pathname === ROUTES.FAVORITES
-                              ? "fill"
-                              : "regular"
-                          }
+                          filled={location.pathname === ROUTES.FAVORITES}
                         />
                       </Button>
                     </Link>
@@ -479,8 +481,13 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
                       title={`New chat (${isMac ? "⌘⇧O" : "Ctrl+Shift+O"})`}
                       variant="ghost"
                       className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover h-8 w-8"
+                      onMouseEnter={newChatIcon.onHoverStart}
+                      onMouseLeave={newChatIcon.onHoverEnd}
                     >
-                      <NotePencilIcon className="size-4.5" />
+                      <AnimatedEditIcon
+                        controls={newChatIcon.controls}
+                        className="size-4.5"
+                      />
                     </Button>
                   </Link>
                   {!isPrivateMode && (

--- a/src/components/ui/animated-icons/check.tsx
+++ b/src/components/ui/animated-icons/check.tsx
@@ -1,0 +1,44 @@
+import type { Variants } from "framer-motion";
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+const pathVariants: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    scale: 1,
+    transition: { duration: 0.3, opacity: { duration: 0.1 } },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    scale: [0.5, 1],
+    transition: { duration: 0.4, opacity: { duration: 0.1 } },
+  },
+};
+
+export function AnimatedCheckIcon({
+  controls,
+  className,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedIconProps) {
+  return (
+    <svg
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+    >
+      <motion.path
+        animate={controls}
+        d="M4 12 9 17L20 6"
+        variants={pathVariants}
+      />
+    </svg>
+  );
+}

--- a/src/components/ui/animated-icons/copy.tsx
+++ b/src/components/ui/animated-icons/copy.tsx
@@ -1,0 +1,49 @@
+import type { Transition } from "framer-motion";
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+const t: Transition = { type: "spring", stiffness: 160, damping: 17, mass: 1 };
+
+export function AnimatedCopyIcon({
+  controls,
+  className,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedIconProps) {
+  return (
+    <svg
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+    >
+      <motion.rect
+        animate={controls}
+        height="14"
+        rx="2"
+        ry="2"
+        width="14"
+        x="8"
+        y="8"
+        transition={t}
+        variants={{
+          normal: { translateY: 0, translateX: 0 },
+          animate: { translateY: -3, translateX: -3 },
+        }}
+      />
+      <motion.path
+        animate={controls}
+        d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+        transition={t}
+        variants={{
+          normal: { x: 0, y: 0 },
+          animate: { x: 3, y: 3 },
+        }}
+      />
+    </svg>
+  );
+}

--- a/src/components/ui/animated-icons/delete.tsx
+++ b/src/components/ui/animated-icons/delete.tsx
@@ -1,0 +1,68 @@
+import type { Transition, Variants } from "framer-motion";
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+const t: Transition = { type: "spring", stiffness: 500, damping: 30 };
+
+const lidVariants: Variants = {
+  normal: { y: 0 },
+  animate: { y: -1.1 },
+};
+
+export function AnimatedDeleteIcon({
+  controls,
+  className,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedIconProps) {
+  return (
+    <svg
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+    >
+      <motion.g animate={controls} variants={lidVariants} transition={t}>
+        <path d="M3 6h18" />
+        <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+      </motion.g>
+      <motion.path
+        animate={controls}
+        d="M19 8v12c0 1-1 2-2 2H7c-1 0-2-1-2-2V8"
+        transition={t}
+        variants={{
+          normal: { d: "M19 8v12c0 1-1 2-2 2H7c-1 0-2-1-2-2V8" },
+          animate: { d: "M19 9v12c0 1-1 2-2 2H7c-1 0-2-1-2-2V9" },
+        }}
+      />
+      <motion.line
+        animate={controls}
+        x1="10"
+        x2="10"
+        y1="11"
+        y2="17"
+        transition={t}
+        variants={{
+          normal: { y1: 11, y2: 17 },
+          animate: { y1: 11.5, y2: 17.5 },
+        }}
+      />
+      <motion.line
+        animate={controls}
+        x1="14"
+        x2="14"
+        y1="11"
+        y2="17"
+        transition={t}
+        variants={{
+          normal: { y1: 11, y2: 17 },
+          animate: { y1: 11.5, y2: 17.5 },
+        }}
+      />
+    </svg>
+  );
+}

--- a/src/components/ui/animated-icons/download.tsx
+++ b/src/components/ui/animated-icons/download.tsx
@@ -1,0 +1,37 @@
+import type { Variants } from "framer-motion";
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+const arrowVariants: Variants = {
+  normal: { y: 0 },
+  animate: {
+    y: 2,
+    transition: { type: "spring", stiffness: 200, damping: 10, mass: 1 },
+  },
+};
+
+export function AnimatedDownloadIcon({
+  controls,
+  className,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedIconProps) {
+  return (
+    <svg
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <motion.g animate={controls} variants={arrowVariants}>
+        <polyline points="7 10 12 15 17 10" />
+        <line x1="12" x2="12" y1="15" y2="3" />
+      </motion.g>
+    </svg>
+  );
+}

--- a/src/components/ui/animated-icons/edit.tsx
+++ b/src/components/ui/animated-icons/edit.tsx
@@ -1,0 +1,40 @@
+import type { Variants } from "framer-motion";
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+const penVariants: Variants = {
+  normal: { rotate: 0, x: 0, y: 0 },
+  animate: {
+    rotate: [-0.5, 0.5, -0.5],
+    x: [0, -1, 1.5, 0],
+    y: [0, 1.5, -1, 0],
+  },
+};
+
+export function AnimatedEditIcon({
+  controls,
+  className,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedIconProps) {
+  return (
+    <svg
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      style={{ overflow: "visible" }}
+      aria-hidden={ariaHidden}
+    >
+      <path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+      <motion.path
+        animate={controls}
+        d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"
+        variants={penVariants}
+      />
+    </svg>
+  );
+}

--- a/src/components/ui/animated-icons/git-branch.tsx
+++ b/src/components/ui/animated-icons/git-branch.tsx
@@ -1,0 +1,111 @@
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+const DURATION = 0.3;
+const calcDelay = (i: number) => (i === 0 ? 0.1 : i * DURATION + 0.1);
+
+export function AnimatedGitBranchIcon({
+  controls,
+  className,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedIconProps) {
+  return (
+    <svg
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+    >
+      <motion.circle
+        animate={controls}
+        cx="18"
+        cy="6"
+        r="3"
+        transition={{
+          duration: DURATION,
+          delay: calcDelay(0),
+          opacity: { delay: calcDelay(0) },
+        }}
+        variants={{
+          normal: {
+            pathLength: 1,
+            opacity: 1,
+            transition: { delay: 0 },
+          },
+          animate: { pathLength: [0, 1], opacity: [0, 1] },
+        }}
+      />
+      <motion.line
+        animate={controls}
+        x1="6"
+        x2="6"
+        y1="3"
+        y2="15"
+        transition={{
+          duration: DURATION,
+          delay: calcDelay(1),
+          opacity: { delay: calcDelay(1) },
+        }}
+        variants={{
+          normal: {
+            pathLength: 1,
+            pathOffset: 0,
+            opacity: 1,
+            transition: { delay: 0 },
+          },
+          animate: {
+            pathLength: [0, 1],
+            opacity: [0, 1],
+            pathOffset: [1, 0],
+          },
+        }}
+      />
+      <motion.circle
+        animate={controls}
+        cx="6"
+        cy="18"
+        r="3"
+        transition={{
+          duration: DURATION,
+          delay: calcDelay(2),
+          opacity: { delay: calcDelay(2) },
+        }}
+        variants={{
+          normal: {
+            pathLength: 1,
+            opacity: 1,
+            transition: { delay: 0 },
+          },
+          animate: { pathLength: [0, 1], opacity: [0, 1] },
+        }}
+      />
+      <motion.path
+        animate={controls}
+        d="M18 9a9 9 0 0 1-9 9"
+        transition={{
+          duration: DURATION,
+          delay: calcDelay(1),
+          opacity: { delay: calcDelay(1) },
+        }}
+        variants={{
+          normal: {
+            pathLength: 1,
+            pathOffset: 0,
+            opacity: 1,
+            transition: { delay: 0 },
+          },
+          animate: {
+            pathLength: [0, 1],
+            opacity: [0, 1],
+            pathOffset: [1, 0],
+          },
+        }}
+      />
+    </svg>
+  );
+}

--- a/src/components/ui/animated-icons/heart.tsx
+++ b/src/components/ui/animated-icons/heart.tsx
@@ -1,0 +1,35 @@
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+type AnimatedHeartIconProps = AnimatedIconProps & {
+  filled?: boolean;
+};
+
+export function AnimatedHeartIcon({
+  controls,
+  className,
+  filled = false,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedHeartIconProps) {
+  return (
+    <motion.svg
+      className={cn("shrink-0", className)}
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+      animate={controls}
+      variants={{
+        normal: { scale: 1 },
+        animate: { scale: [1, 1.08, 1] },
+      }}
+      transition={{ duration: 0.45, repeat: 2 }}
+    >
+      <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+    </motion.svg>
+  );
+}

--- a/src/components/ui/animated-icons/index.ts
+++ b/src/components/ui/animated-icons/index.ts
@@ -1,0 +1,12 @@
+export { AnimatedCheckIcon } from "./check";
+export { AnimatedCopyIcon } from "./copy";
+export { AnimatedDeleteIcon } from "./delete";
+export { AnimatedDownloadIcon } from "./download";
+export { AnimatedEditIcon } from "./edit";
+export { AnimatedGitBranchIcon } from "./git-branch";
+export { AnimatedHeartIcon } from "./heart";
+export { AnimatedRetryIcon } from "./retry";
+export { AnimatedSearchIcon } from "./search";
+export { AnimatedSettingsIcon } from "./settings";
+export type { AnimatedIconProps } from "./types";
+export { useAnimatedIcon } from "./use-animated-icon";

--- a/src/components/ui/animated-icons/retry.tsx
+++ b/src/components/ui/animated-icons/retry.tsx
@@ -1,0 +1,31 @@
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+export function AnimatedRetryIcon({
+  controls,
+  className,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedIconProps) {
+  return (
+    <motion.svg
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+      animate={controls}
+      variants={{
+        normal: { rotate: 0 },
+        animate: { rotate: -50 },
+      }}
+      transition={{ type: "spring", stiffness: 250, damping: 25 }}
+    >
+      <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+      <path d="M3 3v5h5" />
+    </motion.svg>
+  );
+}

--- a/src/components/ui/animated-icons/search.tsx
+++ b/src/components/ui/animated-icons/search.tsx
@@ -1,0 +1,34 @@
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+export function AnimatedSearchIcon({
+  controls,
+  className,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedIconProps) {
+  return (
+    <motion.svg
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+      animate={controls}
+      variants={{
+        normal: { x: 0, y: 0 },
+        animate: {
+          x: [0, 0, -3, 0],
+          y: [0, -4, 0, 0],
+        },
+      }}
+      transition={{ duration: 1, bounce: 0.3 }}
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </motion.svg>
+  );
+}

--- a/src/components/ui/animated-icons/settings.tsx
+++ b/src/components/ui/animated-icons/settings.tsx
@@ -1,0 +1,31 @@
+import { motion } from "framer-motion";
+import { cn } from "@/lib";
+import type { AnimatedIconProps } from "./types";
+
+export function AnimatedSettingsIcon({
+  controls,
+  className,
+  "aria-hidden": ariaHidden = true,
+}: AnimatedIconProps) {
+  return (
+    <motion.svg
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+      animate={controls}
+      variants={{
+        normal: { rotate: 0 },
+        animate: { rotate: 180 },
+      }}
+      transition={{ type: "spring", stiffness: 50, damping: 10 }}
+    >
+      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+      <circle cx="12" cy="12" r="3" />
+    </motion.svg>
+  );
+}

--- a/src/components/ui/animated-icons/types.ts
+++ b/src/components/ui/animated-icons/types.ts
@@ -1,0 +1,7 @@
+import type { useAnimation } from "framer-motion";
+
+export type AnimatedIconProps = {
+  controls: ReturnType<typeof useAnimation>;
+  className?: string;
+  "aria-hidden"?: boolean;
+};

--- a/src/components/ui/animated-icons/use-animated-icon.ts
+++ b/src/components/ui/animated-icons/use-animated-icon.ts
@@ -1,0 +1,24 @@
+import { useAnimation } from "framer-motion";
+import { useCallback } from "react";
+import { useMediaQuery } from "@/hooks";
+
+export function useAnimatedIcon() {
+  const controls = useAnimation();
+  const prefersReducedMotion = useMediaQuery(
+    "(prefers-reduced-motion: reduce)"
+  );
+
+  const onHoverStart = useCallback(() => {
+    if (!prefersReducedMotion) {
+      controls.start("animate");
+    }
+  }, [controls, prefersReducedMotion]);
+
+  const onHoverEnd = useCallback(() => {
+    if (!prefersReducedMotion) {
+      controls.start("normal");
+    }
+  }, [controls, prefersReducedMotion]);
+
+  return { controls, onHoverStart, onHoverEnd };
+}

--- a/src/components/ui/code-block.tsx
+++ b/src/components/ui/code-block.tsx
@@ -1,13 +1,13 @@
-import {
-  CheckIcon,
-  CopyIcon,
-  DownloadIcon,
-  TextAlignJustifyIcon,
-  TextAlignLeftIcon,
-} from "@phosphor-icons/react";
+import { TextAlignJustifyIcon, TextAlignLeftIcon } from "@phosphor-icons/react";
 import { Highlight } from "prism-react-renderer";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 
+import {
+  AnimatedCheckIcon,
+  AnimatedCopyIcon,
+  AnimatedDownloadIcon,
+  useAnimatedIcon,
+} from "@/components/ui/animated-icons";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -34,6 +34,8 @@ const CodeBlockComponent = ({
   const [wordWrap, setWordWrap] = useState(true);
   const { theme } = useTheme();
   const managedToast = useToast();
+  const copyIcon = useAnimatedIcon();
+  const downloadIcon = useAnimatedIcon();
   const codeContainerRef = useRef<HTMLDivElement>(null);
   const componentRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
@@ -172,8 +174,13 @@ const CodeBlockComponent = ({
                   size="sm"
                   variant="ghost"
                   onClick={handleDownload}
+                  onMouseEnter={downloadIcon.onHoverStart}
+                  onMouseLeave={downloadIcon.onHoverEnd}
                 >
-                  <DownloadIcon className="size-3" />
+                  <AnimatedDownloadIcon
+                    controls={downloadIcon.controls}
+                    className="size-3"
+                  />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
@@ -219,13 +226,21 @@ const CodeBlockComponent = ({
                     size="sm"
                     variant="ghost"
                     onClick={handleCopy}
+                    onMouseEnter={copyIcon.onHoverStart}
+                    onMouseLeave={copyIcon.onHoverEnd}
                     aria-label="Copy code to clipboard"
                   >
                     <div className="relative h-4 w-4">
                       {copied ? (
-                        <CheckIcon className="absolute inset-0 size-3 text-primary animate-copy-success" />
+                        <AnimatedCheckIcon
+                          controls={copyIcon.controls}
+                          className="absolute inset-0 size-3 text-primary animate-copy-success"
+                        />
                       ) : (
-                        <CopyIcon className="absolute inset-0 size-3 transition-all duration-200" />
+                        <AnimatedCopyIcon
+                          controls={copyIcon.controls}
+                          className="absolute inset-0 size-3 transition-all duration-200"
+                        />
                       )}
                     </div>
                   </Button>

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -238,6 +238,25 @@ export {
 } from "./share-conversation-dialog";
 
 // =============================================================================
+// Animated Icons
+// =============================================================================
+
+export type { AnimatedIconProps } from "./animated-icons";
+export {
+  AnimatedCheckIcon,
+  AnimatedCopyIcon,
+  AnimatedDeleteIcon,
+  AnimatedDownloadIcon,
+  AnimatedEditIcon,
+  AnimatedGitBranchIcon,
+  AnimatedHeartIcon,
+  AnimatedRetryIcon,
+  AnimatedSearchIcon,
+  AnimatedSettingsIcon,
+  useAnimatedIcon,
+} from "./animated-icons";
+
+// =============================================================================
 // Status & Indicators
 // =============================================================================
 

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -1,6 +1,10 @@
-import { MagnifyingGlassIcon, XIcon } from "@phosphor-icons/react";
+import { XIcon } from "@phosphor-icons/react";
 import { useCallback, useEffect, useImperativeHandle, useRef } from "react";
 
+import {
+  AnimatedSearchIcon,
+  useAnimatedIcon,
+} from "@/components/ui/animated-icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -23,6 +27,7 @@ export const SearchInput = ({
   ref,
 }: SearchInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const { controls } = useAnimatedIcon();
 
   // Expose the input element via the forwarded ref
   useImperativeHandle(ref, () => inputRef.current as HTMLInputElement, []);
@@ -46,7 +51,10 @@ export const SearchInput = ({
 
   return (
     <div className={cn("relative", className)}>
-      <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+      <AnimatedSearchIcon
+        controls={controls}
+        className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+      />
       <Input
         ref={inputRef}
         className={cn(
@@ -57,6 +65,8 @@ export const SearchInput = ({
         placeholder={placeholder}
         value={value}
         onChange={e => onChange(e.target.value)}
+        onFocus={() => controls.start("animate")}
+        onBlur={() => controls.start("normal")}
       />
       {!value && showShortcut && (
         <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-0.5 pointer-events-none">


### PR DESCRIPTION
## Summary

- Add 11 hand-crafted animated SVG icon components (`src/components/ui/animated-icons/`) inspired by [lucide-animated](https://github.com/pqoqubbw/icons), adapted to our headless pattern (no wrapper div, `controls` prop driven by parent)
- Shared `useAnimatedIcon()` hook provides framer-motion animation controls + mouse handlers, with automatic `prefers-reduced-motion` support
- Integrate animated icons into message action buttons (Copy, Delete, Edit, Favorite, Branch, Retry), code block copy/download, sidebar new chat/favorites, and search input focus

## Test plan

- [ ] Hover over message action buttons — each animates uniquely (copy sheets separate, trash lid lifts, pen wiggles, heart pulses, branch draws in, retry rotates)
- [ ] Hover over code block copy button — copy icon animates; click shows animated check
- [ ] Hover over code block download button — arrow drops
- [ ] Hover over sidebar New Chat button — pen wiggles
- [ ] Hover over sidebar Favorites button — heart pulses; filled state shows when on favorites page
- [ ] Focus search input — magnifying glass bounces
- [ ] Enable "Reduce motion" in OS accessibility settings — all hover animations disabled, icons render static
- [ ] Verify ZenMode button still uses static Phosphor icon (no animated equivalent)
- [ ] `bun run check` passes (lint + types + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)