### PR TITLE
refactor: strip chat header down to floating controls

### DIFF
--- a/src/components/chat/index.ts
+++ b/src/components/chat/index.ts
@@ -3,7 +3,7 @@
  * @description Chat interface components for conversations
  *
  * ## Main Components
- * - ChatHeader: Top header with title, actions, sharing
+ * - ChatHeader: Floating controls (sidebar toggle, branch selector, shared indicator, private mode actions)
  * - ChatMessage: Individual message display
  * - VirtualizedChatMessages: Scrollable virtualized message list
  * - ChatZeroState: Empty conversation welcome state

--- a/src/components/chat/unified-chat-view/index.tsx
+++ b/src/components/chat/unified-chat-view/index.tsx
@@ -493,20 +493,16 @@ export const UnifiedChatView = memo(
             <div className="pointer-events-none absolute inset-x-0 top-0">
               <header
                 ref={headerOverlayRef}
-                className="pointer-events-auto p-4 bg-background/50 sm:bg-transparent backdrop-blur-lg sm:backdrop-blur-none"
+                className="pointer-events-auto p-2"
               >
-                <div className="flex w-full items-center">
-                  <ChatHeader
-                    conversationId={conversationId}
-                    conversation={conversation}
-                    isPrivateMode={!conversationId}
-                    isArchived={isArchived}
-                    onSavePrivateChat={onSavePrivateChat}
-                    canSavePrivateChat={canSavePrivateChat}
-                    privateMessages={conversationId ? undefined : messages}
-                    privatePersonaId={currentPersonaId || undefined}
-                  />
-                </div>
+                <ChatHeader
+                  conversationId={conversationId}
+                  conversation={conversation}
+                  isPrivateMode={!conversationId}
+                  onSavePrivateChat={onSavePrivateChat}
+                  canSavePrivateChat={canSavePrivateChat}
+                  privateMessages={conversationId ? undefined : messages}
+                />
               </header>
             </div>
 


### PR DESCRIPTION
## Summary
- Gut `ChatHeader` from ~800 lines to ~260 lines by removing the duplicated "..." dropdown menu, mobile drawer, and all confirmation dialogs (edit title, share, archive, delete) — every action is already available via sidebar context menu and command palette
- Keep sidebar toggle, branch selector, and shared indicator as compact floating controls
- Add private mode floating Save pill and Export dropdown (needed since command palette can't export private chats without a `conversationId`)
- Remove mobile blur backdrop (`bg-background/50 backdrop-blur-lg`) that was blocking conversation content, replace with transparent `p-2` container

## Test plan
- [ ] Regular conversation: sidebar toggle works when sidebar hidden, branch selector shows when branches exist, shared indicator shows for shared conversations, no "..." menu
- [ ] Private mode: Save pill visible when `canSavePrivateChat` is true, Export dropdown visible when messages exist, both JSON and Markdown export work
- [ ] Mobile: no blur overlay blocking messages at top, messages visible to top edge
- [ ] All regular-chat actions (pin, edit title, share, export, archive, delete) still accessible via sidebar context menu and command palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)