### PR TITLE
fix: gate queries on auth to prevent pre-auth UI flicker

### DIFF
--- a/src/hooks/use-enabled-image-models.ts
+++ b/src/hooks/use-enabled-image-models.ts
@@ -1,13 +1,18 @@
 import { api } from "@convex/_generated/api";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 
 /**
  * Returns all available image models (user + built-in).
  * Built-in models have `isBuiltIn: true` and `free: boolean`.
  */
 export function useEnabledImageModels() {
+  const { isAuthenticated } = useConvexAuth();
+
+  // Skip until auth is ready to avoid pre-auth results (built-in only)
+  // overwriting the cache before the user's full model list arrives.
   const availableImageModels = useQuery(
-    api.imageModels.getAvailableImageModels
+    api.imageModels.getAvailableImageModels,
+    isAuthenticated ? {} : "skip"
   );
   return Array.isArray(availableImageModels) ? availableImageModels : undefined;
 }

--- a/src/hooks/use-model-catalog.ts
+++ b/src/hooks/use-model-catalog.ts
@@ -1,5 +1,5 @@
 import { api } from "@convex/_generated/api";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { useEffect } from "react";
 import { shallow, useShallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
@@ -109,11 +109,14 @@ export const resetModelCatalogStoreApi = () => {
 };
 
 export function useModelCatalog() {
-  // Use single consolidated query instead of two separate ones
-  // Query returns hydrated models with capabilities from models.dev
-  const availableModels = useQuery(api.userModels.getAvailableModels, {}) as
-    | AvailableModel[]
-    | undefined;
+  const { isAuthenticated } = useConvexAuth();
+
+  // Skip query until auth is ready to prevent pre-auth results (built-in only)
+  // from overwriting the localStorage cache with incomplete data.
+  const availableModels = useQuery(
+    api.userModels.getAvailableModels,
+    isAuthenticated ? {} : "skip"
+  ) as AvailableModel[] | undefined;
 
   const setCatalog = useModelCatalogStore(s => s.setCatalog);
   const initialized = useModelCatalogStore(s => s.initialized);

--- a/src/hooks/use-selected-model.ts
+++ b/src/hooks/use-selected-model.ts
@@ -1,5 +1,5 @@
 import { api } from "@convex/_generated/api";
-import { useMutation, useQuery } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { useCallback, useEffect } from "react";
 import { CACHE_KEYS, get, set } from "@/lib/local-storage";
 import { useToast } from "@/providers/toast-context";
@@ -7,9 +7,13 @@ import { useChatInputStore } from "@/stores/chat-input-store";
 import type { HydratedModel } from "@/types";
 
 export function useSelectedModel() {
+  const { isAuthenticated } = useConvexAuth();
+
+  // Skip until auth is ready so the pre-auth default model doesn't
+  // overwrite the user's cached selection with a flash of wrong model.
   const selectedModelFromServer = useQuery(
     api.userModels.getUserSelectedModel,
-    {}
+    isAuthenticated ? {} : "skip"
   );
   const selectModelMutation = useMutation(api.userModels.selectModel);
   const selectedModel = useChatInputStore(

--- a/src/hooks/use-user-settings.ts
+++ b/src/hooks/use-user-settings.ts
@@ -1,6 +1,6 @@
 import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { useEffect, useMemo } from "react";
 import { CACHE_KEYS, get, set } from "@/lib/local-storage";
 
@@ -11,9 +11,13 @@ export function getInitialUserSettings(): UserSettings | null {
 }
 
 export function useUserSettings(): UserSettings | undefined {
-  const userSettingsRaw = useQuery(api.userSettings.getUserSettings, {}) as
-    | UserSettings
-    | undefined;
+  const { isAuthenticated } = useConvexAuth();
+
+  // Skip until auth is ready so pre-auth null doesn't override cached settings
+  const userSettingsRaw = useQuery(
+    api.userSettings.getUserSettings,
+    isAuthenticated ? {} : "skip"
+  ) as UserSettings | undefined;
 
   const userSettings = useMemo(() => {
     if (userSettingsRaw) {

--- a/src/lib/clerk-recovery.ts
+++ b/src/lib/clerk-recovery.ts
@@ -1,0 +1,87 @@
+/**
+ * Auto-recovery for stale Clerk sessions.
+ *
+ * When a Clerk session expires or becomes invalid (e.g., after a long dev
+ * server downtime, or on a mobile device left idle), the Clerk SDK enters
+ * a retry loop hitting 429 (rate-limited) then 422 (session invalid) on its
+ * token refresh endpoint. This utility detects that pattern and recovers by
+ * clearing stale session cookies and reloading the page once.
+ */
+
+const RECOVERY_FLAG = "polly:clerk-session-recovered";
+const FAILURE_THRESHOLD = 3;
+const FAILURE_WINDOW_MS = 10_000;
+
+export function clearClerkCookies() {
+  for (const cookie of document.cookie.split(";")) {
+    const [rawName] = cookie.split("=");
+    const name = rawName?.trim() ?? "";
+    if (
+      name.startsWith("__clerk") ||
+      name === "__session" ||
+      name === "__client_uat"
+    ) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=${window.location.hostname}`;
+    }
+  }
+}
+
+/**
+ * Install a fetch interceptor that monitors Clerk token-refresh responses.
+ * After {@link FAILURE_THRESHOLD} 429/422 responses within
+ * {@link FAILURE_WINDOW_MS}ms, clears stale cookies and reloads once.
+ *
+ * Call this once at app bootstrap, before ClerkProvider mounts.
+ */
+export function installClerkSessionRecovery() {
+  // Skip if we just recovered — prevents infinite reload loops
+  if (sessionStorage.getItem(RECOVERY_FLAG)) {
+    sessionStorage.removeItem(RECOVERY_FLAG);
+    return;
+  }
+
+  const originalFetch = window.fetch.bind(window);
+  let failures = 0;
+  let windowStart = 0;
+
+  // biome-ignore lint/suspicious/noExplicitAny: patching global fetch requires escaping Bun's extended type
+  (window as any).fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> => {
+    const response = await originalFetch(input, init);
+
+    const url = typeof input === "string" ? input : (input as Request)?.url;
+
+    // Only trigger on 422 (session invalid), not 429 (rate limited).
+    // A 429 is transient and Clerk's SDK handles retry-after internally.
+    // A 422 means the session is genuinely dead and needs clearing.
+    if (
+      url?.includes("clerk.") &&
+      url.includes("/tokens") &&
+      response.status === 422
+    ) {
+      const now = Date.now();
+      if (now - windowStart > FAILURE_WINDOW_MS) {
+        failures = 1;
+        windowStart = now;
+      } else {
+        failures++;
+      }
+
+      if (failures >= FAILURE_THRESHOLD) {
+        console.warn(
+          "[Auth] Stale Clerk session detected (%d failures in %dms). Clearing and reloading.",
+          failures,
+          now - windowStart
+        );
+        clearClerkCookies();
+        sessionStorage.setItem(RECOVERY_FLAG, "1");
+        window.location.reload();
+      }
+    }
+
+    return response;
+  };
+}

--- a/src/pages/chat-conversation-page.tsx
+++ b/src/pages/chat-conversation-page.tsx
@@ -1,6 +1,6 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
-import { useAction, useConvex, useQuery } from "convex/react";
+import { useAction, useConvex, useConvexAuth, useQuery } from "convex/react";
 import { useCallback, useEffect, useRef } from "react";
 import { useLoaderData, useLocation, useNavigate } from "react-router-dom";
 import { UnifiedChatView } from "@/components/chat";
@@ -73,6 +73,7 @@ export default function ConversationRoute() {
   const navigate = useNavigate();
   const location = useLocation();
   const convex = useConvex();
+  const { isAuthenticated } = useConvexAuth();
   const managedToast = useToast();
   const online = useOnline();
 
@@ -119,7 +120,11 @@ export default function ConversationRoute() {
     selectedModel
   );
 
-  const hasApiKeys = useQuery(api.apiKeys.hasAnyApiKey, {});
+  // Gate on isAuthenticated to prevent pre-auth result differing from post-auth
+  const hasApiKeys = useQuery(
+    api.apiKeys.hasAnyApiKey,
+    isAuthenticated ? {} : "skip"
+  );
 
   // Determine display state
   const hasRealMessages = realMessages.length > 0;

--- a/src/pages/private-chat-page.tsx
+++ b/src/pages/private-chat-page.tsx
@@ -1,6 +1,6 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
-import { useAction, useQuery } from "convex/react";
+import { useAction, useConvexAuth, useQuery } from "convex/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { UnifiedChatView } from "@/components/chat";
@@ -23,11 +23,19 @@ export default function PrivateChatPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { user } = useUserDataContext();
+  const { isAuthenticated } = useConvexAuth();
   const managedToast = useToast();
 
-  const hasApiKeys = useQuery(api.apiKeys.hasAnyApiKey, {});
+  // Gate on isAuthenticated to prevent pre-auth results overriding cached state
+  const hasApiKeys = useQuery(
+    api.apiKeys.hasAnyApiKey,
+    isAuthenticated ? {} : "skip"
+  );
 
-  const selectedModel = useQuery(api.userModels.getUserSelectedModel, {});
+  const selectedModel = useQuery(
+    api.userModels.getUserSelectedModel,
+    isAuthenticated ? {} : "skip"
+  );
 
   const saveConversationAction = useAction(
     api.conversations.savePrivateConversation

--- a/test/global-mocks.ts
+++ b/test/global-mocks.ts
@@ -31,6 +31,7 @@ const actualConvexReact = await import("convex/react");
 mock.module("convex/react", () => ({
   __esModule: true,
   ...actualConvexReact,
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
   useQuery: (query: any, args?: any) => {
     if (convexMockRegistry.useQuery) {
       return convexMockRegistry.useQuery(query, args);


### PR DESCRIPTION
## Summary

- **Gate all Convex queries behind `useConvexAuth().isAuthenticated`** so they don't run before auth is established. Before this, server queries ran without auth context → `getAuthUserId()` returned null → conversations.list returned `[]`, model queries returned built-in-only defaults, settings returned null. These pre-auth results overwrote localStorage caches and caused visible cache→empty→server-data flicker.
- **Harden auth timing** to prevent the anonymous→Clerk race condition. Delay anonymous auth by 2s when Clerk session cookies exist so the orgId flip doesn't pause the WebSocket and drop subscriptions.
- **Add Clerk session recovery** that detects dead sessions (422 on `/tokens`) and auto-clears stale cookies with a one-shot reload.
- **Fix token refresh recovery** so anonymous users don't get stuck after tab backgrounding — `scheduleRefresh` failure now falls back to fetching a fresh token instead of silently failing.
- **Fix StrictMode double-mount** — add `cancelled` flag so `fetchingRef` can't get stuck as `true` in dev mode.

## Files changed

**Auth infrastructure:**
- `src/providers/convex-provider.tsx` — anonymous auth delay, bothFailed fallback, cancelled flag, refresh recovery
- `src/lib/clerk-recovery.ts` — new: fetch interceptor for stale Clerk sessions
- `src/pages/auth-page.tsx` — loading state with 8s stuck recovery button

**Query gating (isAuthenticated skip):**
- `src/components/navigation/sidebar/conversation-list.tsx` — conversations.list + searchWithMatches
- `src/hooks/use-model-catalog.ts` — getAvailableModels
- `src/hooks/use-selected-model.ts` — getUserSelectedModel
- `src/hooks/use-enabled-image-models.ts` — getAvailableImageModels
- `src/hooks/use-user-settings.ts` — getUserSettings
- `src/pages/chat-conversation-page.tsx` — hasAnyApiKey
- `src/pages/private-chat-page.tsx` — hasAnyApiKey + getUserSelectedModel

## Test plan

- [ ] Sign in → hard refresh: sidebar shows cached conversations instantly, no empty flash
- [ ] Sign in → hard refresh: model picker shows cached selection, no flash to default model
- [ ] Anonymous user: conversations and models load after brief auth delay
- [ ] Tab background for >5min → resume: anonymous session refreshes or re-fetches cleanly
- [ ] Stale Clerk session (manually expire cookies): recovery clears cookies and reloads once
- [ ] Dev mode (StrictMode): no stuck loading state from double-mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)