### PR TITLE
chore: replace CLAUDE.md prose with code enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,36 +18,18 @@ Guidance for Claude Code when working with this repository.
 
 ## Commands
 
-**Always use `bun`** - never npm, pnpm, or npx.
-
-```bash
-bun run dev          # Start dev server (React Router + Convex)
-bun run build        # Production build
-bun run fix          # Auto-fix formatting/linting (Biome)
-bun run check        # Full verification: lint + types + build
-bun run check:json   # Biome lint with JSON reporter (structured errors)
-bun run typecheck    # TypeScript only
-bun run test         # Run tests
-bun run lint:file <path>   # Auto-fix a single file
-bun run check:file <path>  # Lint-check a single file (no fix)
-bunx <package>       # Instead of npx
-```
+- `bun run dev` — start dev server
+- `bun run check` — full verification (lint + types + build)
+- `bun run fix` — auto-fix formatting/linting
+- `bun run test` — run tests (`bun:test`, not jest/vitest)
+- `bun run lint:file <path>` / `bun run check:file <path>` — single-file fix/check
 
 ## Testing
 
-- Framework: **bun:test** (not jest/vitest)
 - `bun test <path>` — run a single test file
 - `bun test --watch` — watch mode
 - Test utils in `test/` directory (`test-utils.tsx`, `convex-test-utils.ts`, `TestProviders.tsx`)
 - Run targeted tests for what you changed, not the full suite
-
-## Stack
-
-- **Frontend**: React 19 + TypeScript + Vite + React Router v7
-- **Backend**: Convex (serverless functions, realtime DB, auth, file storage)
-- **Styling**: TailwindCSS + Base UI + CVA
-- **AI**: Vercel AI SDK (Anthropic, OpenAI, Google, OpenRouter)
-- **Quality**: Biome (linting + formatting)
 
 ## Project Structure
 
@@ -70,20 +52,6 @@ convex/              # Backend: schema.ts, ai/, lib/
 
 `/`, `/chat/:id`, `/chat/favorites`, `/private`, `/settings/*`, `/share/:id`
 
-## Code Style (Biome)
-
-Run `bun run fix` before committing. Key rules:
-
-- **Types**: No `any`, use `import type`, prefer `?.` over `&&`
-- **React**: Exhaustive deps, no array index keys, use children composition
-- **Control**: No nested ternaries, use `===`, always use `{}`
-- **Backend**: Use `console.error`/`console.warn` in Convex (no custom logger)
-
-## React 19 Patterns
-
-- **Refs as props**: Pass `ref` as a regular prop - no `forwardRef` needed
-- **useTransition**: Use for async mutations instead of manual loading state
-
 ## React Compiler
 
 Trust the compiler for optimization. Keep `useMemo`/`useCallback` only for:
@@ -105,7 +73,6 @@ Never create hooks, utils, or context files inside component directories.
 ## UI Components
 
 - Base UI uses `render` prop (not `asChild`) to customize element rendering
-- Tooltip delays: Use `delayDuration={200}` on `TooltipTrigger` for quick actions (icon buttons, copy buttons). Default 600ms is for explanatory tooltips.
 - Model types: `Doc<"userModels"> | Doc<"builtInModels">` for selected models
 
 ## Styling
@@ -117,9 +84,7 @@ Never create hooks, utils, or context files inside component directories.
 
 ## Commits
 
-- Format: `<type>: <description>` (feat, fix, refactor, chore, test, docs)
-- Title only, no body. Split commits for different areas.
-- Branches: `<type>/<description>` in kebab-case
+See `CONTRIBUTING.md` for format and conventions.
 
 ## File Naming
 
@@ -131,12 +96,8 @@ Use barrel files: `@/components/ui`, `@/hooks`, `@/lib`. See JSDoc in each `inde
 
 ## Gotchas
 
-- **Streaming coordination**: Use `currentStreamingMessageId` on the conversation to detect/guard streaming, not `isStreaming` alone
 - **OCC (Optimistic Concurrency Control)**: Mutations that touch hot documents must be idempotent. Use `withRetry(fn, 5, 25)` for OCC-prone mutations
 - **Model capabilities**: Resolved at query time from `modelsDevCache` table, NOT stored on model documents. See hydration in `convex/lib/model-hydration.ts`
-- **Route params**: May be `undefined` in React Router v7 — always handle the missing case
-- **File deletion**: Always verify `userFiles` ownership (`entry.userId === currentUserId`) before deleting
-- **Private mode**: Client-side only, no server storage. Uses `usePrivateChat` hook with user's own API keys
 
 ## Code Review (GitHub)
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "license": "MIT",
   "type": "module",
+  "packageManager": "bun@1.3.2",
   "scripts": {
     "dev": "concurrently -n vite,convex -c cyan,magenta \"vite\" \"NODE_ENV=development convex dev\"",
     "dev:convex": "NODE_ENV=development convex dev",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -93,6 +93,7 @@ export { useHoverLinger } from "./use-hover-linger";
 export { useListSelection } from "./use-list-selection";
 export { useMediaQuery } from "./use-media-query";
 export { useOnline } from "./use-online";
+export { useRequiredParam } from "./use-required-param";
 export { useTextSelection } from "./use-text-selection";
 export { useVirtualizedPaginatedQuery } from "./use-virtualized-paginated-query";
 export type {

--- a/src/hooks/use-required-param.ts
+++ b/src/hooks/use-required-param.ts
@@ -1,0 +1,16 @@
+import { useParams } from "react-router-dom";
+
+/**
+ * Returns a required route parameter or throws a 404 Response
+ * (caught by React Router's error boundary).
+ */
+export function useRequiredParam(name: string): string {
+  const params = useParams();
+  const value = params[name];
+
+  if (!value) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  return value;
+}

--- a/src/pages/settings/edit-persona-page.tsx
+++ b/src/pages/settings/edit-persona-page.tsx
@@ -2,14 +2,14 @@ import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { useMutation, useQuery } from "convex/react";
 import { useEffect, useState, useTransition } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
   PersonaForm,
   type PersonaFormData,
 } from "@/components/settings/persona-form";
 import { SettingsPageLayout } from "@/components/settings/ui/settings-page-layout";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { NotFoundPage } from "@/components/ui/not-found-page";
+import { useRequiredParam } from "@/hooks";
 import { ROUTES } from "@/lib/routes";
 import { isPersona } from "@/lib/type-guards";
 import { useToast } from "@/providers/toast-context";
@@ -18,7 +18,7 @@ import { useToast } from "@/providers/toast-context";
 
 export default function EditPersonaPage() {
   const navigate = useNavigate();
-  const { id: personaId } = useParams();
+  const personaId = useRequiredParam("id");
   const managedToast = useToast();
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
   const [formData, setFormData] = useState<PersonaFormData | null>(null);
@@ -28,10 +28,9 @@ export default function EditPersonaPage() {
   const updatePersonaMutation = useMutation(api.personas.update);
   const deletePersonaMutation = useMutation(api.personas.remove);
 
-  const personaRaw = useQuery(
-    api.personas.get,
-    personaId ? { id: personaId as Id<"personas"> } : "skip"
-  );
+  const personaRaw = useQuery(api.personas.get, {
+    id: personaId as Id<"personas">,
+  });
 
   const persona = isPersona(personaRaw) ? personaRaw : null;
   useEffect(() => {
@@ -61,12 +60,8 @@ export default function EditPersonaPage() {
     }
   }, [persona]);
 
-  if (!personaId) {
-    return <NotFoundPage />;
-  }
-
   const handleUpdatePersona = () => {
-    if (!(formData?.name.trim() && formData?.prompt.trim() && personaId)) {
+    if (!(formData?.name.trim() && formData?.prompt.trim())) {
       return;
     }
 
@@ -95,10 +90,6 @@ export default function EditPersonaPage() {
   };
 
   const handleDeletePersona = () => {
-    if (!personaId) {
-      return;
-    }
-
     if (
       !window.confirm(
         "Are you sure you want to delete this persona? This action cannot be undone."

--- a/src/pages/shared-conversation-page.tsx
+++ b/src/pages/shared-conversation-page.tsx
@@ -3,12 +3,13 @@ import type { Doc } from "@convex/_generated/dataModel";
 import { useQuery } from "convex/react";
 import type { CSSProperties } from "react";
 import { useMemo } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { VirtualizedChatMessages } from "@/components/chat";
 import { Button } from "@/components/ui/button";
 import { NotFoundPage } from "@/components/ui/not-found-page";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { useRequiredParam } from "@/hooks";
 
 import { ROUTES } from "@/lib/routes";
 import type { ChatMessage, ConversationId } from "@/types";
@@ -25,12 +26,11 @@ const logoMaskStyle: CSSProperties = {
 };
 
 export default function SharedConversationPage() {
-  const { shareId } = useParams();
+  const shareId = useRequiredParam("shareId");
 
-  const sharedData = useQuery(
-    api.sharedConversations.getSharedConversation,
-    shareId ? { shareId } : "skip"
-  );
+  const sharedData = useQuery(api.sharedConversations.getSharedConversation, {
+    shareId,
+  });
 
   const pageTitle = useMemo(() => {
     const title = sharedData?.conversation?.title;
@@ -39,10 +39,6 @@ export default function SharedConversationPage() {
     }
     return "Polly";
   }, [sharedData?.conversation?.title]);
-
-  if (!shareId) {
-    return <NotFoundPage />;
-  }
 
   if (sharedData === undefined) {
     return <SharedConversationLoading />;


### PR DESCRIPTION
## Summary
- Added `packageManager: bun@1.3.2` to `package.json` so the bun requirement is machine-enforceable
- Created `useRequiredParam` hook that throws a 404 Response when a required route param is missing, replacing manual null-check boilerplate
- Migrated `shared-conversation-page` and `edit-persona-page` to use the new hook
- Stripped CLAUDE.md from ~160 to ~100 lines, removing sections that duplicate tooling enforcement (Biome rules, Stack, React 19 patterns) or are covered by domain rule files (streaming coordination, file deletion, private mode)

## Test plan
- [x] `bun run check` passes (lint + types + build)
- [x] `bun run test` passes (1263 tests, 0 failures)
- [ ] Verify `/share/:id` route still renders 404 for missing/invalid share IDs
- [ ] Verify `/settings/personas/:id` route still 404s for missing persona IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)