### PR TITLE
feat: add color scheme system with 5 themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,17 +56,25 @@
     />
     <style>
       /* Critical theme styles — applied instantly before external CSS loads */
-      html.dark {
-        color-scheme: dark;
-        background-color: hsl(0 0% 8%);
-        color: hsl(0 0% 98%);
-      }
-      html.light,
-      html:not(.dark):not(.light) {
-        color-scheme: light;
-        background-color: hsl(0 0% 99%);
-        color: hsl(0 0% 5%);
-      }
+      /* Classic (grayscale fallback) */
+      html.dark[data-color-scheme="classic"],
+      html.dark:not([data-color-scheme]) { color-scheme: dark; background-color: hsl(0 0% 8%); color: hsl(0 0% 98%); }
+      html.light[data-color-scheme="classic"],
+      html.light:not([data-color-scheme]),
+      html:not(.dark):not(.light):not([data-color-scheme]) { color-scheme: light; background-color: hsl(0 0% 99%); color: hsl(0 0% 5%); }
+      /* Polly */
+      html.dark[data-color-scheme="polly"] { color-scheme: dark; background-color: hsl(264 35% 7%); color: hsl(264 25% 95%); }
+      html.light[data-color-scheme="polly"],
+      html:not(.dark):not(.light)[data-color-scheme="polly"] { color-scheme: light; background-color: hsl(264 40% 97%); color: hsl(264 25% 8%); }
+      /* Catppuccin */
+      html.dark[data-color-scheme="catppuccin"] { color-scheme: dark; background-color: hsl(240 21% 15%); color: hsl(226 64% 88%); }
+      html.light[data-color-scheme="catppuccin"] { color-scheme: light; background-color: hsl(220 23% 95%); color: hsl(234 16% 35%); }
+      /* Dracula */
+      html.dark[data-color-scheme="dracula"] { color-scheme: dark; background-color: hsl(231 15% 18%); color: hsl(60 30% 96%); }
+      html.light[data-color-scheme="dracula"] { color-scheme: light; background-color: hsl(48 100% 96%); color: hsl(0 0% 12%); }
+      /* Nord */
+      html.dark[data-color-scheme="nord"] { color-scheme: dark; background-color: hsl(220 16% 22%); color: hsl(219 28% 88%); }
+      html.light[data-color-scheme="nord"] { color-scheme: light; background-color: hsl(218 27% 94%); color: hsl(220 16% 22%); }
       /* Available immediately so disable-animations works before globals.css loads */
       .disable-animations *,
       .disable-animations *::before,

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -36,6 +36,29 @@
 
   document.documentElement.classList.add(actualTheme);
 
+  // Apply color scheme before first paint
+  var validSchemes = ["polly", "catppuccin", "dracula", "nord", "classic"];
+  var schemeKey = "polly:color-scheme/v1";
+  var colorScheme = "polly";
+  var storedScheme = localStorage.getItem(schemeKey);
+  if (storedScheme) {
+    try {
+      var parsed2 = JSON.parse(storedScheme);
+      if (
+        parsed2 &&
+        typeof parsed2 === "object" &&
+        "version" in parsed2 &&
+        "data" in parsed2 &&
+        validSchemes.indexOf(parsed2.data) !== -1
+      ) {
+        colorScheme = parsed2.data;
+      }
+    } catch (e) {
+      colorScheme = "polly";
+    }
+  }
+  document.documentElement.setAttribute("data-color-scheme", colorScheme);
+
   setTimeout(() => {
     document.documentElement.classList.remove("disable-animations");
   }, 100);

--- a/src/components/navigation/command-palette-theme-menu.tsx
+++ b/src/components/navigation/command-palette-theme-menu.tsx
@@ -1,0 +1,155 @@
+import {
+  CheckIcon,
+  CircleHalfIcon,
+  MoonIcon,
+  SunIcon,
+} from "@phosphor-icons/react";
+import { useEffect } from "react";
+import {
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+} from "@/components/ui/command";
+import type { ColorScheme } from "@/lib/color-schemes";
+import { COLOR_SCHEME_DEFINITIONS } from "@/lib/color-schemes";
+
+type Theme = "light" | "dark" | "system";
+
+type CommandPaletteThemeMenuProps = {
+  colorScheme: ColorScheme;
+  theme: Theme;
+  selectedValue: string;
+  onSelectColorScheme: (scheme: ColorScheme) => void;
+  onSelectTheme: (theme: Theme) => void;
+  previewScheme: (scheme: string) => void;
+  previewMode: (mode: string) => void;
+  endPreview: () => void;
+};
+
+const MODE_OPTIONS: { id: Theme; label: string; icon: typeof SunIcon }[] = [
+  { id: "light", label: "Light", icon: SunIcon },
+  { id: "dark", label: "Dark", icon: MoonIcon },
+  { id: "system", label: "System", icon: CircleHalfIcon },
+];
+
+export function CommandPaletteThemeMenu({
+  colorScheme,
+  theme,
+  selectedValue,
+  onSelectColorScheme,
+  onSelectTheme,
+  previewScheme,
+  previewMode,
+  endPreview,
+}: CommandPaletteThemeMenuProps) {
+  // Preview on highlight change
+  useEffect(() => {
+    if (selectedValue.startsWith("scheme-")) {
+      previewScheme(selectedValue.replace("scheme-", ""));
+    } else if (selectedValue.startsWith("mode-")) {
+      previewMode(selectedValue.replace("mode-", ""));
+    }
+  }, [selectedValue, previewScheme, previewMode]);
+
+  // Restore committed values on unmount
+  useEffect(() => {
+    return () => {
+      endPreview();
+    };
+  }, [endPreview]);
+
+  return (
+    <>
+      <CommandGroup
+        heading="Color Scheme"
+        className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
+      >
+        {COLOR_SCHEME_DEFINITIONS.map(definition => {
+          const isActive = colorScheme === definition.id;
+
+          return (
+            <CommandItem
+              key={definition.id}
+              value={`scheme-${definition.id}`}
+              onSelect={() => onSelectColorScheme(definition.id)}
+              className="flex items-center gap-3 px-4 py-3 text-sm transition-colors rounded-md mx-2"
+            >
+              <PreviewDots definition={definition} />
+              <div className="flex-1 min-w-0">
+                <span className="font-medium">{definition.name}</span>
+                <span className="ml-2 text-muted-foreground">
+                  {definition.description}
+                </span>
+              </div>
+              {isActive && (
+                <CheckIcon
+                  className="size-4 text-primary flex-shrink-0"
+                  weight="bold"
+                />
+              )}
+            </CommandItem>
+          );
+        })}
+      </CommandGroup>
+
+      <CommandSeparator className="my-2" />
+
+      <CommandGroup
+        heading="Mode"
+        className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
+      >
+        {MODE_OPTIONS.map(option => {
+          const isActive = theme === option.id;
+          const IconComponent = option.icon;
+
+          return (
+            <CommandItem
+              key={option.id}
+              value={`mode-${option.id}`}
+              onSelect={() => onSelectTheme(option.id)}
+              className="flex items-center gap-3 px-4 py-3 text-sm transition-colors rounded-md mx-2"
+            >
+              <IconComponent className="size-4 flex-shrink-0 text-muted-foreground" />
+              <span className="flex-1">{option.label}</span>
+              {isActive && (
+                <CheckIcon
+                  className="size-4 text-primary flex-shrink-0"
+                  weight="bold"
+                />
+              )}
+            </CommandItem>
+          );
+        })}
+      </CommandGroup>
+    </>
+  );
+}
+
+function PreviewDots({
+  definition,
+}: {
+  definition: (typeof COLOR_SCHEME_DEFINITIONS)[number];
+}) {
+  const isDark = document.documentElement.classList.contains("dark");
+  const preview = isDark ? definition.preview.dark : definition.preview.light;
+
+  return (
+    <div className="flex gap-0.5 flex-shrink-0">
+      <div
+        className="size-3 rounded-full"
+        style={{
+          backgroundColor: preview.bg,
+          border: "1px solid var(--color-border)",
+        }}
+      />
+      <div
+        className="size-3 rounded-full"
+        style={{ backgroundColor: preview.primary }}
+      />
+      <div
+        className="size-3 rounded-full"
+        style={{ backgroundColor: preview.accent }}
+      />
+    </div>
+  );
+}

--- a/src/components/navigation/command-palette-types.ts
+++ b/src/components/navigation/command-palette-types.ts
@@ -6,7 +6,8 @@ export type NavigationState = {
     | "main"
     | "conversation-actions"
     | "model-categories"
-    | "conversation-browser";
+    | "conversation-browser"
+    | "theme";
   selectedConversationId?: string;
   breadcrumb?: string;
 };

--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -11,14 +11,13 @@ import {
   GearIcon,
   KeyIcon,
   MagnifyingGlassIcon,
-  MoonIcon,
   PaperclipIcon,
   PencilSimpleIcon,
   PlusIcon,
   PushPinIcon,
   RobotIcon,
   ShareNetworkIcon,
-  SunIcon,
+  SwatchesIcon,
   TrashIcon,
   UploadIcon,
   UsersIcon,
@@ -68,6 +67,7 @@ import { CommandPaletteConversationActions } from "./command-palette-conversatio
 import { CommandPaletteConversationBrowser } from "./command-palette-conversation-browser";
 import { CommandPaletteMainMenu } from "./command-palette-main-menu";
 import { CommandPaletteModelBrowser } from "./command-palette-model-browser";
+import { CommandPaletteThemeMenu } from "./command-palette-theme-menu";
 import type {
   Action,
   ConversationType,
@@ -94,6 +94,9 @@ function getCommandInputPlaceholder(
   }
   if (currentMenu === "conversation-browser") {
     return "Search conversations...";
+  }
+  if (currentMenu === "theme") {
+    return "Search themes...";
   }
   return "Search conversations, switch models, or take actions...";
 }
@@ -123,7 +126,15 @@ export function CommandPalette({
   const navigate = useNavigate();
   const location = useLocation();
   const params = useParams();
-  const { theme, toggleTheme } = useTheme();
+  const {
+    theme,
+    setTheme,
+    colorScheme,
+    setColorScheme,
+    previewScheme,
+    previewMode,
+    endPreview,
+  } = useTheme();
   const { isAuthenticated } = useUserIdentity();
 
   const currentConversationId = params.conversationId;
@@ -527,10 +538,23 @@ export function CommandPalette({
     handleClose();
   }, [navigate, handleClose]);
 
-  const handleToggleTheme = useCallback(() => {
-    toggleTheme();
-    handleClose();
-  }, [toggleTheme, handleClose]);
+  const handleOpenThemeMenu = useCallback(() => {
+    navigateToMenu("theme", undefined, "Theme");
+  }, [navigateToMenu]);
+
+  const handleSelectColorScheme = useCallback(
+    (scheme: Parameters<typeof setColorScheme>[0]) => {
+      setColorScheme(scheme);
+    },
+    [setColorScheme]
+  );
+
+  const handleSelectTheme = useCallback(
+    (newTheme: Parameters<typeof setTheme>[0]) => {
+      setTheme(newTheme);
+    },
+    [setTheme]
+  );
 
   const handleImportConversations = useCallback(() => {
     handleClose();
@@ -705,20 +729,19 @@ export function CommandPalette({
     }
 
     actions.push({
-      id: "toggle-theme",
-      label: theme === "dark" ? "Switch to Light Mode" : "Switch to Dark Mode",
-      icon: theme === "dark" ? SunIcon : MoonIcon,
-      handler: handleToggleTheme,
+      id: "change-theme",
+      label: "Change Theme",
+      icon: SwatchesIcon,
+      handler: handleOpenThemeMenu,
       disabled: false,
     });
 
     return actions;
   }, [
-    theme,
     handleNewConversation,
     handlePrivateMode,
     handleImportConversations,
-    handleToggleTheme,
+    handleOpenThemeMenu,
     navigateToMenu,
     online,
     isAuthenticated,
@@ -1285,6 +1308,20 @@ export function CommandPalette({
                 online={online}
                 onNavigateToConversation={handleNavigateToConversation}
                 onConversationActions={handleConversationActions}
+              />
+            )}
+
+            {/* Theme Menu */}
+            {navigation.currentMenu === "theme" && (
+              <CommandPaletteThemeMenu
+                colorScheme={colorScheme}
+                theme={theme}
+                selectedValue={selectedValue}
+                onSelectColorScheme={handleSelectColorScheme}
+                onSelectTheme={handleSelectTheme}
+                previewScheme={previewScheme}
+                previewMode={previewMode}
+                endPreview={endPreview}
               />
             )}
           </CommandList>

--- a/src/components/navigation/sidebar/sidebar-footer.tsx
+++ b/src/components/navigation/sidebar/sidebar-footer.tsx
@@ -1,7 +1,9 @@
 import {
+  CheckIcon,
   GearIcon,
   MonitorIcon,
   MoonIcon,
+  PaletteIcon,
   PlusIcon,
   SignOutIcon,
   SunIcon,
@@ -16,7 +18,9 @@ import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -31,6 +35,7 @@ import {
 import { useActiveProfile } from "@/hooks/use-active-profile";
 import { useTheme } from "@/hooks/use-theme";
 import { useUserSettings } from "@/hooks/use-user-settings";
+import { COLOR_SCHEME_DEFINITIONS } from "@/lib/color-schemes";
 import { getProfileIconComponent } from "@/lib/profile-icons";
 import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
@@ -174,7 +179,15 @@ const UserMenu = memo(
     shouldAnonymize: boolean;
     navigate: (path: string) => void;
   }) => {
-    const { theme, setTheme } = useTheme();
+    const {
+      theme,
+      setTheme,
+      colorScheme,
+      setColorScheme,
+      previewScheme,
+      previewMode,
+      endPreview,
+    } = useTheme();
 
     const avatar = user?.image ? (
       <img
@@ -227,27 +240,74 @@ const UserMenu = memo(
             Manage Profiles
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuSub>
+          <DropdownMenuSub
+            onOpenChange={open => {
+              if (!open) {
+                endPreview();
+              }
+            }}
+          >
             <DropdownMenuSubTrigger className="gap-2">
-              {(() => {
-                const ThemeIcon =
-                  THEME_OPTIONS.find(t => t.value === theme)?.icon ??
-                  MonitorIcon;
-                return <ThemeIcon className="size-4" />;
-              })()}
-              Theme
+              <PaletteIcon className="size-4" />
+              Appearance
             </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="w-36">
-              {THEME_OPTIONS.map(opt => (
-                <DropdownMenuItem
-                  key={opt.value}
-                  onClick={() => setTheme(opt.value)}
-                  className={cn(theme === opt.value && "bg-muted font-medium")}
-                >
-                  <opt.icon className="size-4" />
-                  {opt.label}
-                </DropdownMenuItem>
-              ))}
+            <DropdownMenuSubContent className="w-44">
+              <DropdownMenuGroup>
+                <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+                  Mode
+                </DropdownMenuLabel>
+                {THEME_OPTIONS.map(opt => (
+                  <DropdownMenuItem
+                    key={opt.value}
+                    onClick={() => setTheme(opt.value)}
+                    onMouseEnter={() => previewMode(opt.value)}
+                    className={cn(
+                      theme === opt.value && "bg-muted font-medium"
+                    )}
+                  >
+                    <opt.icon className="size-4" />
+                    {opt.label}
+                    {theme === opt.value && (
+                      <CheckIcon className="size-3.5 ml-auto" />
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuGroup>
+                <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+                  Color scheme
+                </DropdownMenuLabel>
+                {COLOR_SCHEME_DEFINITIONS.map(scheme => {
+                  const isActive = colorScheme === scheme.id;
+                  const isDark =
+                    document.documentElement.classList.contains("dark");
+                  const preview = isDark
+                    ? scheme.preview.dark
+                    : scheme.preview.light;
+                  return (
+                    <DropdownMenuItem
+                      key={scheme.id}
+                      onClick={() => setColorScheme(scheme.id)}
+                      onMouseEnter={() => previewScheme(scheme.id)}
+                      className={cn(isActive && "bg-muted font-medium")}
+                    >
+                      <div className="flex items-center gap-0.5 shrink-0">
+                        <div
+                          className="size-3 rounded-full"
+                          style={{ backgroundColor: preview.primary }}
+                        />
+                        <div
+                          className="size-3 rounded-full"
+                          style={{ backgroundColor: preview.accent }}
+                        />
+                      </div>
+                      {scheme.name}
+                      {isActive && <CheckIcon className="size-3.5 ml-auto" />}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuGroup>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuSeparator />

--- a/src/components/settings/color-scheme-selector.tsx
+++ b/src/components/settings/color-scheme-selector.tsx
@@ -1,0 +1,154 @@
+import {
+  CheckIcon,
+  CircleHalfIcon,
+  MoonIcon,
+  SunIcon,
+} from "@phosphor-icons/react";
+import { useTheme } from "@/hooks/use-theme";
+import type { ColorScheme } from "@/lib/color-schemes";
+import {
+  COLOR_SCHEME_DEFINITIONS,
+  type ColorSchemeDefinition,
+} from "@/lib/color-schemes";
+import { cn } from "@/lib/utils";
+
+const MODE_OPTIONS = [
+  { value: "light" as const, label: "Light", icon: SunIcon },
+  { value: "dark" as const, label: "Dark", icon: MoonIcon },
+  { value: "system" as const, label: "System", icon: CircleHalfIcon },
+];
+
+function SchemeCard({
+  definition,
+  isActive,
+  isDark,
+  onSelect,
+  onPreview,
+}: {
+  definition: ColorSchemeDefinition;
+  isActive: boolean;
+  isDark: boolean;
+  onSelect: (id: ColorScheme) => void;
+  onPreview: (id: ColorScheme) => void;
+}) {
+  const preview = isDark ? definition.preview.dark : definition.preview.light;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(definition.id)}
+      onMouseEnter={() => onPreview(definition.id)}
+      className={cn(
+        "relative flex flex-col gap-2 rounded-lg border p-3 text-left transition-colors cursor-pointer",
+        "hover:bg-muted/30",
+        isActive && "ring-2 ring-primary border-primary"
+      )}
+    >
+      {isActive && (
+        <div className="absolute top-2 right-2 flex items-center justify-center size-5 rounded-full bg-primary text-primary-foreground">
+          <CheckIcon className="size-3" weight="bold" />
+        </div>
+      )}
+
+      {/* Preview swatches */}
+      <div className="flex gap-1.5">
+        <div
+          className="size-6 rounded-full border border-border/50"
+          style={{ backgroundColor: preview.bg }}
+        />
+        <div
+          className="size-6 rounded-full border border-border/50"
+          style={{ backgroundColor: preview.primary }}
+        />
+        <div
+          className="size-6 rounded-full border border-border/50"
+          style={{ backgroundColor: preview.accent }}
+        />
+      </div>
+
+      <div>
+        <div className="font-medium text-sm">{definition.name}</div>
+        <p className="text-xs text-muted-foreground">
+          {definition.description}
+        </p>
+      </div>
+    </button>
+  );
+}
+
+export function ColorSchemeSelector() {
+  const {
+    colorScheme,
+    setColorScheme,
+    theme,
+    setTheme,
+    previewScheme,
+    previewMode,
+    endPreview,
+  } = useTheme();
+  const isDark =
+    theme === "dark" ||
+    (theme === "system" &&
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+  return (
+    <div className="stack-6">
+      {/* Color scheme */}
+      <div>
+        <div className="font-medium mb-1">Color scheme</div>
+        <p className="text-sm text-muted-foreground mb-3">
+          Choose a color palette for the interface
+        </p>
+        <div
+          className="grid grid-cols-2 gap-3 sm:grid-cols-3"
+          onMouseLeave={endPreview}
+        >
+          {COLOR_SCHEME_DEFINITIONS.map(definition => (
+            <SchemeCard
+              key={definition.id}
+              definition={definition}
+              isActive={colorScheme === definition.id}
+              isDark={isDark}
+              onSelect={setColorScheme}
+              onPreview={previewScheme}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Mode */}
+      <div>
+        <div className="font-medium mb-1">Mode</div>
+        <p className="text-sm text-muted-foreground mb-3">
+          Switch between light and dark mode
+        </p>
+        <div
+          className="inline-flex rounded-lg border p-1 gap-1"
+          onMouseLeave={endPreview}
+        >
+          {MODE_OPTIONS.map(option => {
+            const Icon = option.icon;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setTheme(option.value)}
+                onMouseEnter={() => previewMode(option.value)}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors cursor-pointer",
+                  theme === option.value
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                )}
+              >
+                <Icon className="size-4" />
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -39,19 +39,28 @@ export class ErrorBoundary extends React.Component<
 
   override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error("Error caught by boundary:", error, errorInfo);
-  }
-
-  override componentDidMount() {
-    // Ensure theme is applied from localStorage
+    // Re-apply theme so the error fallback UI uses the correct colors
     this.applyThemeFromLocalStorage();
   }
 
   applyThemeFromLocalStorage = () => {
     try {
-      const storedTheme = getLS<"light" | "dark">(CACHE_KEYS.theme, "light");
+      const storedTheme = getLS<"light" | "dark" | "system">(
+        CACHE_KEYS.theme,
+        "system"
+      );
+
+      let actual: "light" | "dark";
+      if (storedTheme === "light" || storedTheme === "dark") {
+        actual = storedTheme;
+      } else {
+        actual = window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+      }
 
       document.documentElement.classList.remove("light", "dark");
-      document.documentElement.classList.add(storedTheme);
+      document.documentElement.classList.add(actual);
     } catch (error) {
       console.error("Error reading theme from storage:", error);
     }

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,9 +1,4 @@
-import {
-  CheckIcon,
-  MonitorIcon,
-  MoonIcon,
-  SunIcon,
-} from "@phosphor-icons/react";
+import { MonitorIcon, MoonIcon, SunIcon } from "@phosphor-icons/react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -53,7 +48,7 @@ export const ThemeToggle = ({
   variant = "ghost",
   className,
 }: ThemeToggleProps) => {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, previewMode, endPreview } = useTheme();
 
   const iconSize = className?.includes("h-10") ? "size-5" : "size-4";
 
@@ -64,7 +59,13 @@ export const ThemeToggle = ({
   };
 
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      onOpenChange={open => {
+        if (!open) {
+          endPreview();
+        }
+      }}
+    >
       <DropdownMenuTrigger>
         <Button
           className={cn("transition-colors duration-150", className)}
@@ -79,6 +80,7 @@ export const ThemeToggle = ({
         <DropdownMenuRadioGroup value={theme} onValueChange={handleThemeChange}>
           <DropdownMenuRadioItem
             value="light"
+            onMouseEnter={() => previewMode("light")}
             className={cn(
               "pl-2",
               theme === "light" &&
@@ -90,6 +92,7 @@ export const ThemeToggle = ({
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem
             value="dark"
+            onMouseEnter={() => previewMode("dark")}
             className={cn(
               "pl-2",
               theme === "dark" &&
@@ -101,6 +104,7 @@ export const ThemeToggle = ({
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem
             value="system"
+            onMouseEnter={() => previewMode("system")}
             className={cn(
               "pl-2",
               theme === "system" &&

--- a/src/globals.css
+++ b/src/globals.css
@@ -133,33 +133,11 @@
     hsl(0 0% 4%) 0%,
     hsl(0 0% 16%) 100%
   );
-  --gradient-surface: linear-gradient(
-    135deg,
-    hsl(0 0% 100%) 0%,
-    hsl(0 0% 99%) 100%
-  );
-  --gradient-accent: linear-gradient(
-    135deg,
-    hsl(0 0% 20%) 0%,
-    hsl(0 0% 35%) 100%
-  );
   --gradient-tropical: linear-gradient(
     135deg,
     hsl(214.6 60% 45%),
     hsl(214.6 79.1% 62.5%)
   );
-  --gradient-organic: radial-gradient(
-    ellipse 70% 70% at 50% 50%,
-    hsl(0 0% 0% / 0.02) 0%,
-    transparent 70%
-  );
-  --gradient-header-from-logo: linear-gradient(
-    135deg,
-    hsl(0 0% 4%),
-    hsl(0 0% 16%),
-    hsl(0 0% 21%)
-  );
-
   /* Animations */
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
@@ -208,9 +186,7 @@
   --color-ring: hsl(0 0% 60%);
   --color-background: hsl(0 0% 99%);
   --color-foreground: hsl(0 0% 5%);
-  --color-foreground-focus: hsl(0 0% 0%);
   --color-highlight: hsl(0 0% 20%);
-  --color-highlight-foreground: hsl(0 0% 100%);
   --color-card: hsl(0 0% 100%);
   --color-card-foreground: hsl(0 0% 10%);
   --color-popover: hsl(0 0% 100%);
@@ -218,22 +194,17 @@
   --color-sidebar-foreground: hsl(0 0% 5%);
   --color-sidebar-muted: hsl(0 0% 25%);
   --color-sidebar-hover: hsl(0 0% 96%);
-  --color-sidebar-tinted: hsl(0 0% 98%);
-  --color-active-element-tint: hsl(0 0% 97%);
-  --color-active-element-border: hsl(0 0% 85%);
   --color-sidebar: hsl(0 0% 97%);
 
   /* Primary Colors (Are.na Black) */
   --color-primary: hsl(0 0% 10%);
   --color-primary-foreground: hsl(0 0% 100%);
   --color-primary-hover: hsl(0 0% 20%);
-  --color-primary-active: hsl(0 0% 30%);
 
   /* Secondary Colors (Are.na Gray) */
   --color-secondary: hsl(0 0% 97%);
   --color-secondary-foreground: hsl(0 0% 15%);
   --color-secondary-hover: hsl(0 0% 95%);
-  --color-secondary-active: hsl(0 0% 93%);
 
   /* Muted Colors */
   --color-muted: hsl(0 0% 97%);
@@ -261,7 +232,6 @@
   --color-success: hsl(160.1 84.1% 39.4%);
   --color-success-foreground: hsl(0 0% 100%);
   --color-success-hover: hsl(160 85% 35%);
-  --color-success-active: hsl(160 86% 30%);
   --color-success-bg: hsl(162 58% 86%);
   --color-success-border: hsl(162 48% 68%);
 
@@ -269,7 +239,6 @@
   --color-warning: hsl(47.9 95.8% 53.1%);
   --color-warning-foreground: hsl(0 0% 10%);
   --color-warning-hover: hsl(48 96% 48%);
-  --color-warning-active: hsl(48 97% 43%);
   --color-warning-bg: hsl(40 92% 90%);
   --color-warning-border: hsl(40 72% 70%);
 
@@ -277,7 +246,6 @@
   --color-info: hsl(188.7 94.5% 42.7%);
   --color-info-foreground: hsl(0 0% 100%);
   --color-info-hover: hsl(189 95% 48%);
-  --color-info-active: hsl(189 96% 53%);
   --color-info-bg: hsl(205 90% 90%);
   --color-info-border: hsl(205 68% 68%);
 
@@ -285,37 +253,11 @@
   --color-danger: hsl(0 75% 50%);
   --color-danger-foreground: hsl(0 0% 100%);
   --color-danger-hover: hsl(0 80% 55%);
-  --color-danger-active: hsl(0 85% 60%);
   --color-danger-bg: hsl(4 88% 92%);
   --color-danger-border: hsl(4 72% 72%);
 
   /* Surface Colors */
   --color-surface: hsl(0 0% 100%);
-  --color-surface-variant: hsl(0 0% 97%);
-  --color-surface-hover: hsl(0 0% 96.1%);
-  --color-surface-active: hsl(0 0% 95%);
-  --color-surface-primary: hsl(0 0% 99%);
-  --color-surface-secondary: hsl(0 0% 97%);
-
-  /* Coral Color Palette */
-  --color-coral-50: hsl(10 100% 97%);
-  --color-coral-100: hsl(10 80% 92%);
-  --color-coral-200: hsl(10 75% 85%);
-  --color-coral-300: hsl(10 75% 75%);
-  --color-coral-400: hsl(10 75% 68%);
-  --color-coral-500: hsl(10 75% 60%);
-  --color-coral-600: hsl(10 75% 52%);
-  --color-coral-700: hsl(10 75% 45%);
-  --color-coral-800: hsl(10 75% 38%);
-  --color-coral-900: hsl(10 75% 32%);
-  --color-coral-950: hsl(10 75% 20%);
-
-  /* Chart Colors */
-  --color-chart-1: hsl(12 76% 61%);
-  --color-chart-2: hsl(173 58% 39%);
-  --color-chart-3: hsl(197 37% 24%);
-  --color-chart-4: hsl(43 74% 66%);
-  --color-chart-5: hsl(27 87% 67%);
 
   /* Z-Index Utilities */
   --z-index-content: var(--z-content);
@@ -480,9 +422,7 @@
     /* Dark Mode Color Overrides (Are.na-inspired Dark) */
     --color-background: hsl(0 0% 8%);
     --color-foreground: hsl(0 0% 98%);
-    --color-foreground-focus: hsl(0 0% 100%);
     --color-highlight: hsl(0 0% 25%);
-    --color-highlight-foreground: hsl(0 0% 100%);
     --color-card: hsl(0 0% 10%);
     --color-card-foreground: hsl(0 0% 95%);
     --color-popover: hsl(0 0% 8%);
@@ -495,11 +435,9 @@
     --color-primary: hsl(0 0% 95%);
     --color-primary-foreground: hsl(0 0% 8%);
     --color-primary-hover: hsl(0 0% 90%);
-    --color-primary-active: hsl(0 0% 85%);
     --color-secondary: hsl(0 0% 15%);
     --color-secondary-foreground: hsl(0 0% 95%);
     --color-secondary-hover: hsl(0 0% 18%);
-    --color-secondary-active: hsl(0 0% 22%);
     --color-muted: hsl(0 0% 15%);
     --color-muted-foreground: hsl(0 0% 75%);
     --color-accent: hsl(0 0% 18%);
@@ -516,26 +454,19 @@
     --color-danger: hsl(0 72% 45%);
     --color-danger-foreground: hsl(0 0% 100%);
     --color-danger-hover: hsl(0 75% 50%);
-    --color-danger-active: hsl(0 78% 55%);
     /* Success: keep light mode value with white text */
     --color-success: hsl(160.1 84.1% 39.4%);
     --color-success-foreground: hsl(0 0% 100%);
     --color-success-hover: hsl(160 85% 45%);
-    --color-success-active: hsl(160 86% 50%);
     /* Warning: darker text for contrast on bright yellow background */
     --color-warning: hsl(47.9 95.8% 53.1%);
     --color-warning-foreground: hsl(0 0% 10%);
     --color-warning-hover: hsl(48 96% 58%);
-    --color-warning-active: hsl(48 97% 63%);
     /* Info: keep light mode value with white text */
     --color-info: hsl(188.7 94.5% 42.7%);
     --color-info-foreground: hsl(0 0% 100%);
     --color-info-hover: hsl(189 95% 48%);
-    --color-info-active: hsl(189 96% 53%);
     --color-surface: hsl(228 8% 7%);
-    --color-surface-variant: hsl(228 5% 11%);
-    --color-surface-hover: hsl(228 4% 14%);
-    --color-surface-active: hsl(0 0% 16%);
     --color-success-bg: hsl(160 60% 10%);
     --color-warning-bg: hsl(37 80% 15%);
     --color-info-bg: hsl(214 50% 15%);
@@ -561,6 +492,337 @@
   }
 }
 
+/* ==========================================================================
+   Color Schemes
+   Classic = the @theme + .dark fallback above (no selector needed).
+   Each non-classic scheme overrides the core UI variables.
+   Status colors (success/warning/danger/info) stay inherited from @theme.
+   ========================================================================== */
+
+@layer base {
+  /* --- Polly Light --- */
+  [data-color-scheme="polly"] {
+    --color-background: hsl(264 40% 97%);
+    --color-foreground: hsl(264 25% 8%);
+    --color-highlight: hsl(261 70% 38%);
+    --color-border: hsl(264 28% 84%);
+    --color-input: hsl(264 35% 97%);
+    --color-input-hover: hsl(264 32% 95%);
+    --color-input-focus: hsl(264 30% 93%);
+    --color-input-border: hsl(264 24% 76%);
+    --color-ring: hsl(261 85% 45%);
+    --color-card: hsl(264 35% 97%);
+    --color-card-foreground: hsl(264 22% 10%);
+    --color-popover: hsl(264 35% 97%);
+    --color-popover-foreground: hsl(264 22% 10%);
+    --color-sidebar: hsl(264 35% 93%);
+    --color-sidebar-foreground: hsl(264 22% 8%);
+    --color-sidebar-muted: hsl(264 18% 38%);
+    --color-sidebar-hover: hsl(264 32% 89%);
+    --color-primary: hsl(261 85% 45%);
+    --color-primary-foreground: hsl(0 0% 100%);
+    --color-primary-hover: hsl(261 82% 52%);
+    --color-secondary: hsl(264 32% 92%);
+    --color-secondary-foreground: hsl(264 22% 16%);
+    --color-secondary-hover: hsl(264 30% 88%);
+    --color-muted: hsl(264 32% 92%);
+    --color-muted-foreground: hsl(264 16% 40%);
+    --color-accent: hsl(264 32% 92%);
+    --color-accent-foreground: hsl(264 22% 16%);
+    --color-destructive: hsl(0 84% 60%);
+    --color-destructive-foreground: hsl(0 0% 100%);
+    --color-surface: hsl(264 35% 97%);
+  }
+
+  /* --- Polly Dark --- */
+  [data-color-scheme="polly"].dark {
+    --color-background: hsl(264 35% 7%);
+    --color-foreground: hsl(264 25% 95%);
+    --color-highlight: hsl(261 55% 30%);
+    --color-border: hsl(264 22% 20%);
+    --color-input: hsl(264 28% 11%);
+    --color-input-hover: hsl(264 25% 13%);
+    --color-input-focus: hsl(264 22% 16%);
+    --color-input-border: hsl(264 22% 20%);
+    --color-ring: hsl(261 85% 68%);
+    --color-card: hsl(264 30% 10%);
+    --color-card-foreground: hsl(264 22% 92%);
+    --color-popover: hsl(264 30% 8%);
+    --color-popover-foreground: hsl(264 20% 85%);
+    --color-sidebar: hsl(264 30% 8%);
+    --color-sidebar-foreground: hsl(264 20% 88%);
+    --color-sidebar-muted: hsl(264 18% 55%);
+    --color-sidebar-hover: hsl(264 26% 13%);
+    --color-primary: hsl(261 85% 74%);
+    --color-primary-foreground: hsl(264 35% 7%);
+    --color-primary-hover: hsl(261 82% 80%);
+    --color-secondary: hsl(264 26% 14%);
+    --color-secondary-foreground: hsl(264 25% 90%);
+    --color-secondary-hover: hsl(264 24% 18%);
+    --color-muted: hsl(264 22% 14%);
+    --color-muted-foreground: hsl(264 18% 62%);
+    --color-accent: hsl(264 26% 18%);
+    --color-accent-foreground: hsl(264 25% 90%);
+    --color-destructive: hsl(0 72% 45%);
+    --color-destructive-foreground: hsl(0 0% 100%);
+    --color-surface: hsl(264 26% 6%);
+    --color-success-bg: hsl(160 60% 10%);
+    --color-warning-bg: hsl(37 80% 15%);
+    --color-info-bg: hsl(214 50% 15%);
+    --color-danger-bg: hsl(0 60% 12%);
+    --color-success-border: hsl(160 50% 20%);
+    --color-warning-border: hsl(37 60% 25%);
+    --color-info-border: hsl(214 40% 25%);
+    --color-danger-border: hsl(0 50% 20%);
+  }
+
+  /* --- Catppuccin Latte (Light) --- */
+  /* Canonical: base=#eff1f5 mantle=#e6e9ef crust=#dce0e8 text=#4c4f69 subtext1=#5c5f77 */
+  /* surface0=#ccd0da surface1=#bcc0cc surface2=#acb0be mauve=#8839ef blue=#1e66f5 red=#d20f39 */
+  [data-color-scheme="catppuccin"] {
+    --color-background: hsl(220 23% 95%); /* base */
+    --color-foreground: hsl(234 16% 35%); /* text */
+    --color-highlight: hsl(266 85% 58%); /* mauve */
+    --color-border: hsl(223 16% 83%); /* surface0 */
+    --color-input: hsl(220 23% 95%); /* base */
+    --color-input-hover: hsl(220 22% 92%); /* mantle */
+    --color-input-focus: hsl(220 21% 89%); /* crust */
+    --color-input-border: hsl(225 14% 77%); /* surface1 */
+    --color-ring: hsl(220 91% 54%); /* blue — canonical focus color */
+    --color-card: hsl(220 23% 95%); /* base */
+    --color-card-foreground: hsl(234 16% 35%); /* text */
+    --color-popover: hsl(220 23% 95%); /* base */
+    --color-popover-foreground: hsl(234 16% 35%); /* text */
+    --color-sidebar: hsl(220 22% 92%); /* mantle */
+    --color-sidebar-foreground: hsl(234 16% 35%); /* text */
+    --color-sidebar-muted: hsl(233 13% 41%); /* subtext1 */
+    --color-sidebar-hover: hsl(223 16% 83%); /* surface0 — rest→hover pattern */
+    --color-primary: hsl(266 85% 58%); /* mauve */
+    --color-primary-foreground: hsl(220 23% 95%); /* base */
+    --color-primary-hover: hsl(231 97% 72%); /* lavender */
+    --color-secondary: hsl(220 22% 92%); /* mantle */
+    --color-secondary-foreground: hsl(234 16% 35%); /* text */
+    --color-secondary-hover: hsl(223 16% 83%); /* surface0 */
+    --color-muted: hsl(220 22% 92%); /* mantle */
+    --color-muted-foreground: hsl(233 13% 41%); /* subtext1 */
+    --color-accent: hsl(220 22% 92%); /* mantle */
+    --color-accent-foreground: hsl(234 16% 35%); /* text */
+    --color-destructive: hsl(347 87% 44%); /* red */
+    --color-destructive-foreground: hsl(0 0% 100%);
+    --color-surface: hsl(220 23% 95%); /* base */
+  }
+
+  /* --- Catppuccin Mocha (Dark) --- */
+  /* Canonical: base=#1e1e2e mantle=#181825 crust=#11111b text=#cdd6f4 subtext0=#a6adc8 */
+  /* surface0=#313244 surface1=#45475a surface2=#585b70 overlay2=#9399b2 */
+  /* mauve=#cba6f7 blue=#89b4fa lavender=#b4befe red=#f38ba8 */
+  [data-color-scheme="catppuccin"].dark {
+    --color-background: hsl(240 21% 15%); /* base */
+    --color-foreground: hsl(226 64% 88%); /* text */
+    --color-highlight: hsl(267 84% 35%);
+    --color-border: hsl(237 16% 23%); /* surface0 */
+    --color-input: hsl(240 21% 15%); /* base */
+    --color-input-hover: hsl(237 16% 23%); /* surface0 */
+    --color-input-focus: hsl(234 13% 31%); /* surface1 */
+    --color-input-border: hsl(234 13% 31%); /* surface1 */
+    --color-ring: hsl(217 92% 76%); /* blue — canonical focus color */
+    --color-card: hsl(240 21% 15%); /* base */
+    --color-card-foreground: hsl(226 64% 88%); /* text */
+    --color-popover: hsl(240 21% 12%); /* mantle */
+    --color-popover-foreground: hsl(226 64% 88%); /* text */
+    --color-sidebar: hsl(240 21% 12%); /* mantle */
+    --color-sidebar-foreground: hsl(226 64% 88%); /* text */
+    --color-sidebar-muted: hsl(228 24% 72%); /* subtext0 */
+    --color-sidebar-hover: hsl(237 16% 23%); /* surface0 */
+    --color-primary: hsl(267 84% 81%); /* mauve */
+    --color-primary-foreground: hsl(240 23% 9%); /* crust */
+    --color-primary-hover: hsl(232 97% 85%); /* lavender */
+    --color-secondary: hsl(237 16% 23%); /* surface0 */
+    --color-secondary-foreground: hsl(226 64% 88%); /* text */
+    --color-secondary-hover: hsl(234 13% 31%); /* surface1 */
+    --color-muted: hsl(237 16% 23%); /* surface0 */
+    --color-muted-foreground: hsl(228 24% 72%); /* subtext0 */
+    --color-accent: hsl(234 13% 31%); /* surface1 */
+    --color-accent-foreground: hsl(226 64% 88%); /* text */
+    --color-destructive: hsl(343 81% 75%); /* red */
+    --color-destructive-foreground: hsl(240 23% 9%); /* crust */
+    --color-surface: hsl(240 21% 12%); /* mantle */
+    --color-success-bg: hsl(160 60% 10%);
+    --color-warning-bg: hsl(37 80% 15%);
+    --color-info-bg: hsl(214 50% 15%);
+    --color-danger-bg: hsl(0 60% 12%);
+    --color-success-border: hsl(160 50% 20%);
+    --color-warning-border: hsl(37 60% 25%);
+    --color-info-border: hsl(214 40% 25%);
+    --color-danger-border: hsl(0 50% 20%);
+  }
+
+  /* --- Dracula Alucard (Light) --- */
+  /* Canonical: bg=#FFFBEB fg=#1F1F1F comment=#6C664B selection=#CFCFDE */
+  /* UI bg levels: Floating=#EFEDDC(90%) Lighter=#ECE9DF(90%) Light=#DEDCCF(84%) Dark=#CECCC0(78%) Darker=#BCBAB3(72%) */
+  /* pink=#A3144D purple=#644AC9 red=#CB3A2A funcPurple=#815CD6 */
+  [data-color-scheme="dracula"] {
+    --color-background: hsl(48 100% 96%); /* canonical bg */
+    --color-foreground: hsl(0 0% 12%); /* canonical fg */
+    --color-highlight: hsl(336 78% 36%); /* canonical pink */
+    --color-border: hsl(51 13% 78%); /* bg-dark */
+    --color-input: hsl(48 100% 96%); /* bg */
+    --color-input-hover: hsl(46 25% 90%); /* bg-lighter */
+    --color-input-focus: hsl(46 25% 90%); /* bg-lighter */
+    --color-input-border: hsl(51 13% 78%); /* bg-dark */
+    --color-ring: hsl(252 54% 54%); /* canonical purple */
+    --color-card: hsl(54 37% 90%); /* floating */
+    --color-card-foreground: hsl(0 0% 12%); /* fg */
+    --color-popover: hsl(54 37% 90%); /* floating */
+    --color-popover-foreground: hsl(0 0% 12%); /* fg */
+    --color-sidebar: hsl(46 25% 90%); /* bg-lighter */
+    --color-sidebar-foreground: hsl(0 0% 12%); /* fg */
+    --color-sidebar-muted: hsl(49 18% 36%); /* canonical comment */
+    --color-sidebar-hover: hsl(52 19% 84%); /* bg-light */
+    --color-primary: hsl(336 78% 36%); /* canonical pink */
+    --color-primary-foreground: hsl(0 0% 100%);
+    --color-primary-hover: hsl(336 78% 44%);
+    --color-secondary: hsl(46 25% 90%); /* bg-lighter */
+    --color-secondary-foreground: hsl(0 0% 12%); /* fg */
+    --color-secondary-hover: hsl(52 19% 84%); /* bg-light */
+    --color-muted: hsl(46 25% 90%); /* bg-lighter */
+    --color-muted-foreground: hsl(49 18% 36%); /* canonical comment */
+    --color-accent: hsl(46 25% 90%); /* bg-lighter */
+    --color-accent-foreground: hsl(0 0% 12%); /* fg */
+    --color-destructive: hsl(6 66% 48%); /* canonical red */
+    --color-destructive-foreground: hsl(0 0% 100%);
+    --color-surface: hsl(48 100% 96%); /* bg */
+  }
+
+  /* --- Dracula Dark --- */
+  /* Canonical bg levels: Darker=#191A21(11%) Dark=#21222C(15%) Main=#282A36(18%) Light=#343746(24%) Lighter=#424450(29%) */
+  /* fg=#F8F8F2 comment=#6272A4 selection=#44475A pink=#FF79C6 purple=#BD93F9 red=#FF5555 */
+  /* Website text hierarchy: caption=hsl(250 12% 72%) body=hsl(250 12% 78%) */
+  /* Functional: purple=#815CD6 for focus */
+  [data-color-scheme="dracula"].dark {
+    --color-background: hsl(231 15% 18%); /* bg-main */
+    --color-foreground: hsl(60 30% 96%); /* canonical fg */
+    --color-highlight: hsl(232 14% 31%); /* selection */
+    --color-border: hsl(231 10% 29%); /* bg-lighter */
+    --color-input: hsl(231 15% 18%); /* bg-main */
+    --color-input-hover: hsl(230 15% 24%); /* bg-light */
+    --color-input-focus: hsl(230 15% 24%); /* bg-light */
+    --color-input-border: hsl(231 10% 29%); /* bg-lighter */
+    --color-ring: hsl(258 60% 60%); /* functional purple */
+    --color-card: hsl(230 15% 24%); /* bg-light — elevated surface */
+    --color-card-foreground: hsl(60 30% 96%); /* fg */
+    --color-popover: hsl(231 15% 18%); /* bg-main */
+    --color-popover-foreground: hsl(250 12% 84%); /* heading-level text */
+    --color-sidebar: hsl(235 14% 15%); /* bg-dark */
+    --color-sidebar-foreground: hsl(250 12% 90%); /* display-level text */
+    --color-sidebar-muted: hsl(250 12% 72%); /* caption-level text */
+    --color-sidebar-hover: hsl(230 15% 24%); /* bg-light */
+    --color-primary: hsl(326 100% 74%); /* canonical pink */
+    --color-primary-foreground: hsl(233 14% 11%); /* bg-darker */
+    --color-primary-hover: hsl(326 100% 80%);
+    --color-secondary: hsl(230 15% 24%); /* bg-light */
+    --color-secondary-foreground: hsl(250 12% 90%); /* display-level text */
+    --color-secondary-hover: hsl(231 10% 29%); /* bg-lighter */
+    --color-muted: hsl(230 15% 24%); /* bg-light */
+    --color-muted-foreground: hsl(250 12% 72%); /* caption-level text */
+    --color-accent: hsl(231 10% 29%); /* bg-lighter */
+    --color-accent-foreground: hsl(250 12% 84%); /* heading-level text */
+    --color-destructive: hsl(12 72% 54%); /* functional red */
+    --color-destructive-foreground: hsl(233 14% 11%); /* bg-darker */
+    --color-surface: hsl(233 14% 11%); /* bg-darker */
+    --color-success-bg: hsl(135 50% 12%);
+    --color-warning-bg: hsl(65 40% 14%);
+    --color-info-bg: hsl(191 40% 14%);
+    --color-danger-bg: hsl(0 50% 14%);
+    --color-success-border: hsl(135 40% 22%);
+    --color-warning-border: hsl(65 35% 22%);
+    --color-info-border: hsl(191 35% 22%);
+    --color-danger-border: hsl(0 40% 22%);
+  }
+
+  /* --- Nord Snow Storm (Light) --- */
+  /* Canonical: nord0=#2E3440 nord3=#4C566A nord4=#D8DEE9 nord5=#E5E9F0 nord6=#ECEFF4 */
+  /* nord7=#8FBCBB nord8=#88C0D0 nord9=#81A1C1 nord10=#5E81AC nord11=#BF616A */
+  [data-color-scheme="nord"] {
+    --color-background: hsl(218 27% 94%); /* nord6 */
+    --color-foreground: hsl(220 16% 22%); /* nord0 */
+    --color-highlight: hsl(193 43% 67%); /* nord8 */
+    --color-border: hsl(219 28% 88%); /* nord4 */
+    --color-input: hsl(218 27% 94%); /* nord6 */
+    --color-input-hover: hsl(218 27% 92%); /* nord5 */
+    --color-input-focus: hsl(218 27% 92%); /* nord5 */
+    --color-input-border: hsl(219 28% 88%); /* nord4 */
+    --color-ring: hsl(
+      193 43% 67%
+    ); /* nord8 — primary accent per official ports */
+    --color-card: hsl(218 27% 94%); /* nord6 */
+    --color-card-foreground: hsl(220 16% 22%); /* nord0 */
+    --color-popover: hsl(218 27% 94%); /* nord6 */
+    --color-popover-foreground: hsl(220 16% 22%); /* nord0 */
+    --color-sidebar: hsl(218 27% 92%); /* nord5 */
+    --color-sidebar-foreground: hsl(220 16% 22%); /* nord0 */
+    --color-sidebar-muted: hsl(220 16% 36%); /* nord3 */
+    --color-sidebar-hover: hsl(219 28% 88%); /* nord4 */
+    --color-primary: hsl(193 43% 67%); /* nord8 — official primary accent */
+    --color-primary-foreground: hsl(220 16% 22%); /* nord0 */
+    --color-primary-hover: hsl(179 25% 65%); /* nord7 */
+    --color-secondary: hsl(218 27% 92%); /* nord5 */
+    --color-secondary-foreground: hsl(220 16% 22%); /* nord0 */
+    --color-secondary-hover: hsl(219 28% 88%); /* nord4 */
+    --color-muted: hsl(218 27% 92%); /* nord5 */
+    --color-muted-foreground: hsl(220 16% 36%); /* nord3 */
+    --color-accent: hsl(218 27% 92%); /* nord5 */
+    --color-accent-foreground: hsl(220 16% 22%); /* nord0 */
+    --color-destructive: hsl(354 42% 56%); /* nord11 */
+    --color-destructive-foreground: hsl(0 0% 100%);
+    --color-surface: hsl(218 27% 94%); /* nord6 */
+  }
+
+  /* --- Nord Polar Night (Dark) --- */
+  /* Canonical: nord0=#2E3440 nord1=#3B4252 nord2=#434C5E nord3=#4C566A */
+  /* nord4=#D8DEE9 nord8=#88C0D0 nord9=#81A1C1 nord11=#BF616A */
+  [data-color-scheme="nord"].dark {
+    --color-background: hsl(220 16% 22%); /* nord0 */
+    --color-foreground: hsl(219 28% 88%); /* nord4 */
+    --color-highlight: hsl(220 16% 36%); /* nord3 */
+    --color-border: hsl(220 17% 32%); /* nord2 */
+    --color-input: hsl(222 16% 28%); /* nord1 */
+    --color-input-hover: hsl(220 17% 32%); /* nord2 */
+    --color-input-focus: hsl(220 16% 36%); /* nord3 */
+    --color-input-border: hsl(220 17% 32%); /* nord2 */
+    --color-ring: hsl(193 43% 67%); /* nord8 */
+    --color-card: hsl(222 16% 28%); /* nord1 */
+    --color-card-foreground: hsl(219 28% 88%); /* nord4 */
+    --color-popover: hsl(220 16% 22%); /* nord0 */
+    --color-popover-foreground: hsl(219 28% 88%); /* nord4 */
+    --color-sidebar: hsl(220 16% 22%); /* nord0 */
+    --color-sidebar-foreground: hsl(219 28% 88%); /* nord4 */
+    --color-sidebar-muted: hsl(210 34% 63%); /* nord9 */
+    --color-sidebar-hover: hsl(222 16% 28%); /* nord1 */
+    --color-primary: hsl(193 43% 67%); /* nord8 */
+    --color-primary-foreground: hsl(220 16% 22%); /* nord0 */
+    --color-primary-hover: hsl(179 25% 65%); /* nord7 */
+    --color-secondary: hsl(222 16% 28%); /* nord1 */
+    --color-secondary-foreground: hsl(219 28% 88%); /* nord4 */
+    --color-secondary-hover: hsl(220 17% 32%); /* nord2 */
+    --color-muted: hsl(222 16% 28%); /* nord1 — lifted from bg for contrast */
+    --color-muted-foreground: hsl(210 34% 63%); /* nord9 */
+    --color-accent: hsl(220 17% 32%); /* nord2 */
+    --color-accent-foreground: hsl(219 28% 88%); /* nord4 */
+    --color-destructive: hsl(354 42% 56%); /* nord11 */
+    --color-destructive-foreground: hsl(218 27% 92%); /* nord5 */
+    --color-surface: hsl(220 16% 22%); /* nord0 */
+    --color-success-bg: hsl(92 20% 12%);
+    --color-warning-bg: hsl(40 35% 14%);
+    --color-info-bg: hsl(193 25% 14%);
+    --color-danger-bg: hsl(354 25% 14%);
+    --color-success-border: hsl(92 20% 22%);
+    --color-warning-border: hsl(40 30% 22%);
+    --color-info-border: hsl(193 20% 22%);
+    --color-danger-border: hsl(354 20% 22%);
+  }
+}
+
 @layer base {
   * {
     border-color: var(--color-border);
@@ -582,12 +844,12 @@
 
   ::selection {
     background: var(--color-highlight);
-    color: var(--color-highlight-foreground);
+    color: hsl(0 0% 100%);
   }
 
   .dark ::selection {
     background: var(--color-highlight);
-    color: var(--color-highlight-foreground);
+    color: hsl(0 0% 100%);
   }
 }
 

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,78 +1,161 @@
-import { useCallback, useEffect, useState } from "react";
-import { flushSync } from "react-dom";
+import { useSyncExternalStore } from "react";
+import type { ColorScheme } from "../lib/color-schemes";
+import { DEFAULT_COLOR_SCHEME } from "../lib/color-schemes";
 import { CACHE_KEYS, get as getLS, set as setLS } from "../lib/local-storage";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Theme = "light" | "dark" | "system";
+
+function applyModeToDOM(mode: Theme) {
+  const root = document.documentElement;
+  let actual: "light" | "dark";
+  if (mode === "light" || mode === "dark") {
+    actual = mode;
+  } else {
+    actual = window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+  root.classList.remove("light", "dark");
+  root.classList.add(actual);
+}
+
+function applySchemeToDOM(scheme: string) {
+  document.documentElement.setAttribute("data-color-scheme", scheme);
+}
 
 function withDisabledAnimations(fn: () => void) {
   const root = document.documentElement;
   root.classList.add("disable-animations");
-  flushSync(fn);
+  fn();
   requestAnimationFrame(() => {
     root.classList.remove("disable-animations");
   });
 }
 
-type Theme = "light" | "dark" | "system";
+// ---------------------------------------------------------------------------
+// Module-level shared state (single source of truth for all useTheme callers)
+// ---------------------------------------------------------------------------
+
+type ThemeState = {
+  theme: Theme;
+  colorScheme: ColorScheme;
+};
+
+let state: ThemeState = {
+  theme: getLS<Theme>(CACHE_KEYS.theme, "system"),
+  colorScheme: getLS<ColorScheme>(CACHE_KEYS.colorScheme, DEFAULT_COLOR_SCHEME),
+};
+
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) {
+    l();
+  }
+}
+
+function getSnapshot(): ThemeState {
+  return state;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Actions (stable references — safe to use without useCallback)
+// ---------------------------------------------------------------------------
+
+function setTheme(next: Theme) {
+  withDisabledAnimations(() => {
+    state = { ...state, theme: next };
+    setLS<Theme>(CACHE_KEYS.theme, next);
+    applyModeToDOM(next);
+    emit();
+  });
+}
+
+function setColorScheme(next: ColorScheme) {
+  withDisabledAnimations(() => {
+    state = { ...state, colorScheme: next };
+    setLS<ColorScheme>(CACHE_KEYS.colorScheme, next);
+    applySchemeToDOM(next);
+    emit();
+  });
+}
+
+function toggleTheme() {
+  setTheme(state.theme === "light" ? "dark" : "light");
+}
+
+/** Apply a color scheme to the DOM without persisting. */
+function previewScheme(scheme: string) {
+  applySchemeToDOM(scheme);
+}
+
+/** Apply a light/dark mode to the DOM without persisting. */
+function previewMode(mode: string) {
+  applyModeToDOM(mode as Theme);
+}
+
+/** Restore the DOM to match the persisted (committed) state. */
+function endPreview() {
+  applySchemeToDOM(state.colorScheme);
+  applyModeToDOM(state.theme);
+}
+
+// ---------------------------------------------------------------------------
+// System-preference listener (module-level, runs once)
+// ---------------------------------------------------------------------------
+
+if (typeof window !== "undefined") {
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", () => {
+      if (state.theme === "system") {
+        applyModeToDOM("system");
+      }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+/** @internal Re-read localStorage and reset module state. Only for tests. */
+export function __resetThemeState() {
+  state = {
+    theme: getLS<Theme>(CACHE_KEYS.theme, "system"),
+    colorScheme: getLS<ColorScheme>(
+      CACHE_KEYS.colorScheme,
+      DEFAULT_COLOR_SCHEME
+    ),
+  };
+  emit();
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
 
 export function useTheme() {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    const stored = getLS<Theme>(CACHE_KEYS.theme, "system");
-    return stored;
-  });
+  const { theme, colorScheme } = useSyncExternalStore(subscribe, getSnapshot);
 
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (!mounted) {
-      return;
-    }
-
-    const updateTheme = () => {
-      let actualTheme: "light" | "dark";
-      if (theme === "light" || theme === "dark") {
-        actualTheme = theme;
-      } else {
-        const prefersDark = window.matchMedia(
-          "(prefers-color-scheme: dark)"
-        ).matches;
-        actualTheme = prefersDark ? "dark" : "light";
-      }
-
-      const root = document.documentElement;
-      const currentTheme = root.classList.contains("light") ? "light" : "dark";
-      if (currentTheme !== actualTheme) {
-        root.classList.remove("light", "dark");
-        root.classList.add(actualTheme);
-      }
-    };
-
-    updateTheme();
-
-    if (theme === "system") {
-      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-      const handleChange = () => {
-        updateTheme();
-      };
-      mediaQuery.addEventListener("change", handleChange);
-      return () => {
-        mediaQuery.removeEventListener("change", handleChange);
-      };
-    }
-  }, [theme, mounted]);
-
-  const setTheme = useCallback((newTheme: Theme) => {
-    withDisabledAnimations(() => {
-      setThemeState(newTheme);
-      setLS<Theme>(CACHE_KEYS.theme, newTheme);
-    });
-  }, []);
-
-  const toggleTheme = useCallback(() => {
-    setTheme(theme === "light" ? "dark" : "light");
-  }, [theme, setTheme]);
-
-  return { theme, setTheme, toggleTheme, mounted };
+  return {
+    theme,
+    colorScheme,
+    setTheme,
+    setColorScheme,
+    toggleTheme,
+    previewScheme,
+    previewMode,
+    endPreview,
+  };
 }

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -91,8 +91,17 @@ function setColorScheme(next: ColorScheme) {
   });
 }
 
+function resolveMode(): "light" | "dark" {
+  if (state.theme === "light" || state.theme === "dark") {
+    return state.theme;
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
 function toggleTheme() {
-  setTheme(state.theme === "light" ? "dark" : "light");
+  setTheme(resolveMode() === "light" ? "dark" : "light");
 }
 
 /** Apply a color scheme to the DOM without persisting. */

--- a/src/lib/color-schemes.ts
+++ b/src/lib/color-schemes.ts
@@ -1,0 +1,69 @@
+export const COLOR_SCHEMES = [
+  "polly",
+  "catppuccin",
+  "dracula",
+  "nord",
+  "classic",
+] as const;
+
+export type ColorScheme = (typeof COLOR_SCHEMES)[number];
+
+export const DEFAULT_COLOR_SCHEME: ColorScheme = "polly";
+
+export type ColorSchemeDefinition = {
+  id: ColorScheme;
+  name: string;
+  description: string;
+  preview: {
+    light: { bg: string; primary: string; accent: string };
+    dark: { bg: string; primary: string; accent: string };
+  };
+};
+
+export const COLOR_SCHEME_DEFINITIONS: ColorSchemeDefinition[] = [
+  {
+    id: "polly",
+    name: "Polly",
+    description: "Warm lavender with purple accents",
+    preview: {
+      light: { bg: "#f6f2fb", primary: "#5511d4", accent: "#7c3aed" },
+      dark: { bg: "#110d1a", primary: "#b07afc", accent: "#7c3aed" },
+    },
+  },
+  {
+    id: "catppuccin",
+    name: "Catppuccin",
+    description: "Soothing pastels for productivity",
+    preview: {
+      light: { bg: "#eff1f5", primary: "#8839ef", accent: "#ea76cb" },
+      dark: { bg: "#1e1e2e", primary: "#cba6f7", accent: "#f5c2e7" },
+    },
+  },
+  {
+    id: "dracula",
+    name: "Dracula",
+    description: "Dark elegance with vibrant pops",
+    preview: {
+      light: { bg: "#fffbeb", primary: "#a3144d", accent: "#644ac9" },
+      dark: { bg: "#282a36", primary: "#ff79c6", accent: "#bd93f9" },
+    },
+  },
+  {
+    id: "nord",
+    name: "Nord",
+    description: "Arctic-inspired muted tones",
+    preview: {
+      light: { bg: "#eceff4", primary: "#88c0d0", accent: "#81a1c1" },
+      dark: { bg: "#2e3440", primary: "#88c0d0", accent: "#81a1c1" },
+    },
+  },
+  {
+    id: "classic",
+    name: "Classic",
+    description: "Clean grayscale, no distractions",
+    preview: {
+      light: { bg: "#fcfcfc", primary: "#1a1a1a", accent: "#525252" },
+      dark: { bg: "#141414", primary: "#f2f2f2", accent: "#a3a3a3" },
+    },
+  },
+];

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -176,6 +176,17 @@ export {
 } from "./type-guards";
 
 // =============================================================================
+// Color Schemes
+// =============================================================================
+
+export type { ColorScheme, ColorSchemeDefinition } from "./color-schemes";
+export {
+  COLOR_SCHEME_DEFINITIONS,
+  COLOR_SCHEMES,
+  DEFAULT_COLOR_SCHEME,
+} from "./color-schemes";
+
+// =============================================================================
 // Syntax Themes
 // =============================================================================
 

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -23,6 +23,7 @@ export const CACHE_KEYS = {
   anonymousSession: "anonymous-session",
   anonymousUserGraduation: "anonymous-user-graduation",
   anonymousGraduationToken: "anonymous-graduation-token",
+  colorScheme: "color-scheme",
 } as const;
 
 export type CacheKey = (typeof CACHE_KEYS)[keyof typeof CACHE_KEYS];
@@ -40,6 +41,7 @@ const PRIVATE_MODE_BLOCKED_KEYS = new Set<CacheKey>([
 const PERSISTENT_KEYS = new Set<CacheKey>([
   CACHE_KEYS.sidebar,
   CACHE_KEYS.theme,
+  CACHE_KEYS.colorScheme,
   CACHE_KEYS.zenDisplayPreferences,
 ]);
 

--- a/src/pages/settings/general-page.tsx
+++ b/src/pages/settings/general-page.tsx
@@ -11,6 +11,7 @@ import {
 import { useConvex, useMutation } from "convex/react";
 import { useCallback, useState, useTransition } from "react";
 import { useNavigate } from "react-router-dom";
+import { ColorSchemeSelector } from "@/components/settings/color-scheme-selector";
 import { ProfileDeleteDialog } from "@/components/settings/profile-delete-dialog";
 import { ProfileFormDialog } from "@/components/settings/profile-form-dialog";
 import { SettingsPageLayout } from "@/components/settings/ui/settings-page-layout";
@@ -240,6 +241,12 @@ export default function GeneralPage() {
           </aside>
 
           <main className="stack-12">
+            {/* Appearance */}
+            <section>
+              <h2 className="text-lg font-semibold mb-4">Appearance</h2>
+              <ColorSchemeSelector />
+            </section>
+
             {/* Preferences */}
             <section>
               <h2 className="text-lg font-semibold mb-4">Preferences</h2>


### PR DESCRIPTION
## Summary
- Add a complete color scheme system with 5 themes: **Polly** (default), **Catppuccin**, **Dracula**, **Nord**, and **Classic** — each with light and dark mode variants
- Color schemes are selectable from the sidebar appearance menu, command palette, and settings page, with hover-to-preview support
- Fix a bug where `ErrorBoundary.componentDidMount` was nuking the theme set by the blocking init script, causing wrong theme on load until a theme switcher mounted

## Changes
- **`src/lib/color-schemes.ts`** — Color scheme definitions and types
- **`src/globals.css`** — CSS variables for each scheme via `[data-color-scheme]` selectors
- **`index.html`** — Critical inline CSS for all schemes to prevent FOSC
- **`public/theme-init.js`** — Apply color scheme before first paint with allowlist validation
- **`src/hooks/use-theme.ts`** — Rewritten with `useSyncExternalStore` for shared module-level state (fixes stale preview across multiple hook instances)
- **`src/hooks/use-theme.test.tsx`** — Tests for shared state, preview/endPreview, and cross-instance behavior
- **`src/components/ui/error-boundary.tsx`** — Move `applyThemeFromLocalStorage` to `componentDidCatch` only, handle "system" theme
- **`src/components/navigation/command-palette-theme-menu.tsx`** — New theme submenu in command palette
- **`src/components/settings/color-scheme-selector.tsx`** — Settings page color scheme picker
- **`src/components/navigation/sidebar/sidebar-footer.tsx`** — Expanded appearance submenu with mode + scheme sections
- **`src/components/ui/theme-toggle.tsx`** — Preview-on-hover support

## Test plan
- [x] `bun run check` passes (lint, types, build)
- [x] `bun test src/hooks/use-theme.test.tsx` — 5/5 tests pass
- [ ] Verify each color scheme renders correctly in both light and dark mode
- [ ] Verify hover preview in sidebar, command palette, and settings
- [ ] Verify theme persists across page refresh (no flash of wrong scheme)
- [ ] Verify ErrorBoundary no longer nukes theme on mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)