### PR TITLE
feat: granular data management (export + delete)

### DIFF
--- a/convex/memory.ts
+++ b/convex/memory.ts
@@ -87,6 +87,17 @@ export const getEligibleConversations = internalQuery({
   },
 });
 
+/** List all memories for a user (for export). */
+export const internalListForExport = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("userMemories")
+      .withIndex("by_user", q => q.eq("userId", args.userId))
+      .collect();
+  },
+});
+
 // ============================================================================
 // INTERNAL MUTATIONS (used by extraction action)
 // ============================================================================

--- a/convex/personas.ts
+++ b/convex/personas.ts
@@ -1,11 +1,12 @@
 import { v } from "convex/values";
-import { action, mutation, query } from "./_generated/server";
+import { action, internalQuery, mutation, query } from "./_generated/server";
 import { paginationOptsSchema } from "./lib/pagination";
 import { personaImportSchema } from "./lib/schemas";
 
 // Re-export types used by frontend
 export type { EnrichedPersona } from "./lib/persona/helpers";
 export {
+  clearAllHandler,
   createHandler,
   importPersonasHandler,
   improvePromptHandler,
@@ -28,6 +29,7 @@ export {
 } from "./lib/persona/query_handlers";
 
 import {
+  clearAllHandler,
   createHandler,
   importPersonasHandler,
   improvePromptHandler,
@@ -171,4 +173,19 @@ export const improvePrompt = action({
     prompt: v.string(),
   },
   handler: improvePromptHandler,
+});
+
+export const clearAll = mutation({
+  args: {},
+  handler: clearAllHandler,
+});
+
+export const internalListForExport = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("personas")
+      .withIndex("by_user_active", q => q.eq("userId", args.userId))
+      .collect();
+  },
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -23,6 +23,7 @@ export {
 import { getAuthUserId } from "./lib/auth";
 import { createDefaultConversationFields } from "./lib/shared_utils";
 import {
+  clearAllDataHandler,
   deleteAccountHandler,
   incrementMessageHandler,
   internalDeleteUserDataHandler,
@@ -124,6 +125,11 @@ export const updateProfile = mutation({
 export const deleteAccount = mutation({
   args: {},
   handler: deleteAccountHandler,
+});
+
+export const clearAllData = mutation({
+  args: {},
+  handler: clearAllDataHandler,
 });
 
 /**

--- a/src/components/ui/confirmation-dialog.tsx
+++ b/src/components/ui/confirmation-dialog.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,6 +28,7 @@ interface ConfirmationDialogProps {
   onCancel?: () => void;
   variant?: "default" | "destructive";
   autoFocusConfirm?: boolean;
+  children?: ReactNode;
 }
 
 export const ConfirmationDialog = ({
@@ -40,6 +42,7 @@ export const ConfirmationDialog = ({
   onCancel,
   variant = "default",
   autoFocusConfirm = true,
+  children,
 }: ConfirmationDialogProps) => {
   const [isMobile, setIsMobile] = useState(false);
 
@@ -90,6 +93,7 @@ export const ConfirmationDialog = ({
             <DialogTitle>{title}</DialogTitle>
             <DialogDescription>{description}</DialogDescription>
           </DialogHeader>
+          {children}
           <DialogFooter>
             <Button
               variant="outline"
@@ -121,6 +125,7 @@ export const ConfirmationDialog = ({
           <DrawerBody>
             <div className="stack-lg">
               <p className="text-sm text-muted-foreground">{description}</p>
+              {children}
               <div className="flex justify-end gap-2">
                 <Button
                   variant="outline"


### PR DESCRIPTION
## Summary
- Add per-category deletion options (conversations, memories, personas) to settings danger zone
- Add "delete all data, keep account" option alongside existing "delete account"
- Enhance data export to include `personas.json` and `memories.json` in the ZIP
- Refactor `cascadeDeleteUserData` to share logic with new `clearAllUserDataKeepAccount`

## Test plan
- [ ] Click each delete button in the danger zone, verify confirmation dialog appears with correct text
- [ ] Confirm "Delete all conversations" triggers bulk delete background job
- [ ] Confirm "Delete all memories" clears all memories (batched)
- [ ] Confirm "Delete all personas" clears personas and persona settings
- [ ] Confirm "Delete all data" erases everything but preserves user account and settings
- [ ] Confirm "Delete account" still works as before (full cascade + sign out)
- [ ] Export data and verify ZIP contains `personas.json` and `memories.json`
- [ ] Verify confirmation dialogs show export hint only for "all data" and "account" options

🤖 Generated with [Claude Code](https://claude.com/claude-code)