### PR TITLE
chore: upgrade @clerk/clerk-react to 5.61.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@ai-sdk/react": "^3.0.6",
         "@anthropic-ai/sdk": "^0.71.2",
         "@base-ui/react": "^1.0.0",
-        "@clerk/clerk-react": "^5.22.0",
+        "@clerk/clerk-react": "^5.61.1",
         "@llm-ui/code": "^0.13.3",
         "@llm-ui/markdown": "^0.13.3",
         "@llm-ui/react": "^0.13.3",
@@ -182,9 +182,9 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
 
-    "@clerk/clerk-react": ["@clerk/clerk-react@5.60.1", "", { "dependencies": { "@clerk/shared": "^3.45.0", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-Z7LAJKvcieGSFB3Q0f840o8Lh7VauvBjc+aDElIt6OHaJRjWcjhFcRiL2Fvg9YkRG942IZN8RHl7iKUzAU5SIQ=="],
+    "@clerk/clerk-react": ["@clerk/clerk-react@5.61.1", "", { "dependencies": { "@clerk/shared": "^3.47.0", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-FB6Dt6iwNR//UG/Xt61+WJKj6wtxvPtrF4CgO3Vm3GWb6xyFPZUFRrcdE4pZrF1glCVZ1TXEAAvDMFOAM4ybRw=="],
 
-    "@clerk/shared": ["@clerk/shared@3.45.0", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-u4MlyEQy+QnGiQqwwqznplJ59el3k05tgaRyh9O3KSxWa84Br4JCXRuV9yYhA0+7bvgUPE7nLlX2byWmf7QOAA=="],
+    "@clerk/shared": ["@clerk/shared@3.47.0", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-EDWFysptTc58X96MGQIZ3LlcMFKLG+rhIF9kf6n+wnyQDWnfuyA8I8ge7GbjfUXMf00c//A/CGSjg7t/oupUpw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@ai-sdk/react": "^3.0.6",
     "@anthropic-ai/sdk": "^0.71.2",
     "@base-ui/react": "^1.0.0",
-    "@clerk/clerk-react": "^5.22.0",
+    "@clerk/clerk-react": "^5.61.1",
     "@llm-ui/code": "^0.13.3",
     "@llm-ui/markdown": "^0.13.3",
     "@llm-ui/react": "^0.13.3",

--- a/src/globals.css
+++ b/src/globals.css
@@ -176,6 +176,7 @@
   --z-modal: 110;
   --z-select: 115;
   --z-tooltip: 150;
+  --z-banner: 200;
 
   /* Colors - Light Mode Defaults (Are.na-inspired) */
   --color-border: hsl(0 0% 90%);
@@ -308,6 +309,9 @@
   }
   .z-command-palette {
     z-index: var(--z-command-palette);
+  }
+  .z-banner {
+    z-index: var(--z-banner);
   }
   .z-context-menu {
     z-index: var(--z-context-menu);

--- a/src/lib/clerk-recovery.ts
+++ b/src/lib/clerk-recovery.ts
@@ -1,16 +1,11 @@
 /**
- * Auto-recovery for stale Clerk sessions.
+ * Clerk session cookie utilities.
  *
- * When a Clerk session expires or becomes invalid (e.g., after a long dev
- * server downtime, or on a mobile device left idle), the Clerk SDK enters
- * a retry loop hitting 429 (rate-limited) then 422 (session invalid) on its
- * token refresh endpoint. This utility detects that pattern and recovers by
- * clearing stale session cookies and reloading the page once.
+ * Used to clear stale Clerk cookies when session recovery is needed,
+ * e.g. after a long idle period or when the auth page detects a stuck state.
+ * Service-level health (degraded/failed) is handled by ClerkDegraded and
+ * ClerkFailed components in the provider tree.
  */
-
-const RECOVERY_FLAG = "polly:clerk-session-recovered";
-const FAILURE_THRESHOLD = 3;
-const FAILURE_WINDOW_MS = 10_000;
 
 export function clearClerkCookies() {
   for (const cookie of document.cookie.split(";")) {
@@ -25,63 +20,4 @@ export function clearClerkCookies() {
       document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=${window.location.hostname}`;
     }
   }
-}
-
-/**
- * Install a fetch interceptor that monitors Clerk token-refresh responses.
- * After {@link FAILURE_THRESHOLD} 429/422 responses within
- * {@link FAILURE_WINDOW_MS}ms, clears stale cookies and reloads once.
- *
- * Call this once at app bootstrap, before ClerkProvider mounts.
- */
-export function installClerkSessionRecovery() {
-  // Skip if we just recovered — prevents infinite reload loops
-  if (sessionStorage.getItem(RECOVERY_FLAG)) {
-    sessionStorage.removeItem(RECOVERY_FLAG);
-    return;
-  }
-
-  const originalFetch = window.fetch.bind(window);
-  let failures = 0;
-  let windowStart = 0;
-
-  // biome-ignore lint/suspicious/noExplicitAny: patching global fetch requires escaping Bun's extended type
-  (window as any).fetch = async (
-    input: RequestInfo | URL,
-    init?: RequestInit
-  ): Promise<Response> => {
-    const response = await originalFetch(input, init);
-
-    const url = typeof input === "string" ? input : (input as Request)?.url;
-
-    // Only trigger on 422 (session invalid), not 429 (rate limited).
-    // A 429 is transient and Clerk's SDK handles retry-after internally.
-    // A 422 means the session is genuinely dead and needs clearing.
-    if (
-      url?.includes("clerk.") &&
-      url.includes("/tokens") &&
-      response.status === 422
-    ) {
-      const now = Date.now();
-      if (now - windowStart > FAILURE_WINDOW_MS) {
-        failures = 1;
-        windowStart = now;
-      } else {
-        failures++;
-      }
-
-      if (failures >= FAILURE_THRESHOLD) {
-        console.warn(
-          "[Auth] Stale Clerk session detected (%d failures in %dms). Clearing and reloading.",
-          failures,
-          now - windowStart
-        );
-        clearClerkCookies();
-        sessionStorage.setItem(RECOVERY_FLAG, "1");
-        window.location.reload();
-      }
-    }
-
-    return response;
-  };
 }

--- a/src/pages/settings/general-page.tsx
+++ b/src/pages/settings/general-page.tsx
@@ -1,4 +1,4 @@
-import { useClerk } from "@clerk/clerk-react";
+import { useAuth } from "@clerk/clerk-react";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import {
@@ -112,7 +112,7 @@ export default function GeneralPage() {
   const backgroundJobs = useBackgroundJobs();
   const managedToast = useToast();
   const convex = useConvex();
-  const { signOut } = useClerk();
+  const { signOut } = useAuth();
   const navigate = useNavigate();
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget>(null);
   const [isExportingData, startExportTransition] = useTransition();

--- a/src/pages/sign-out-page.tsx
+++ b/src/pages/sign-out-page.tsx
@@ -1,11 +1,11 @@
-import { useClerk } from "@clerk/clerk-react";
+import { useAuth } from "@clerk/clerk-react";
 import { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { clearUserData } from "@/lib/local-storage";
 import { resetChatInputStoreApi } from "@/stores/chat-input-store";
 
 export default function SignOutPage() {
-  const { signOut } = useClerk();
+  const { signOut } = useAuth();
   const navigate = useNavigate();
 
   const handleSignOut = useCallback(async () => {


### PR DESCRIPTION
## Summary
- Upgrades `@clerk/clerk-react` from 5.22.0 → 5.61.1 (+ `@clerk/shared` 3.45.0 → 3.47.0)
- Adopts new `ClerkDegraded` / `ClerkFailed` components to show non-blocking service status banners
- Replaces the `fetch` monkey-patch session recovery with a reactive `useEffect` that detects stale sessions via `wasSignedInRef`
- Removes the legacy `@convex-dev/auth` migration code (expired 2025-03-01) and the `installClerkSessionRecovery` interceptor
- Switches `useClerk` → `useAuth` for `signOut` in settings and sign-out pages (lighter hook)
- Adds `signUpUrl`, `signInFallbackRedirectUrl`, and `signUpFallbackRedirectUrl` to `ClerkProvider`
- Tightens the email-merge guard: gates on `identity.emailVerified`, and only blocks merge when the existing user already has a *different* Clerk `user_` ID — allowing merges for old-auth users and unlinked accounts while preventing cross-Clerk-user hijacking

## Test plan
- [ ] Sign in with existing Clerk account — verify session works normally
- [ ] Sign in with an account that was migrated from old auth — verify it merges correctly (not a duplicate)
- [ ] Sign out and back in — verify no stale session loops
- [ ] Simulate Clerk degraded/failed state — verify banners appear
- [ ] Verify anonymous auth still works when not signed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)