### PR TITLE
feat: overhaul typography for migraine relief

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,300..700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,100..900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Literata:opsz,wght@7..72,200..900&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/globals.css
+++ b/src/globals.css
@@ -13,21 +13,21 @@
   --container-screen-2xl: 1400px;
 
   /* Font Families */
-  --font-family-sans: Arial, sans-serif;
-  --font-family-serif: "Source Serif 4", "Source Serif Pro", serif;
+  --font-family-sans: "Inter", sans-serif;
+  --font-family-serif: "Literata", serif;
   --font-family-mono:
     "IBM Plex Mono", ui-monospace, SFMono-Regular, "SF Mono", Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
 
   /* Font Sizes - Base */
-  --font-size-xs: 0.75rem;
-  --font-size-sm: 0.875rem;
-  --font-size-base: 1rem;
-  --font-size-lg: 1.125rem;
-  --font-size-xl: 1.25rem;
-  --font-size-2xl: 1.5rem;
-  --font-size-3xl: 1.875rem;
-  --font-size-4xl: 2.25rem;
+  --font-size-xs: 0.875rem;
+  --font-size-sm: 1rem;
+  --font-size-base: 1.125rem;
+  --font-size-lg: 1.25rem;
+  --font-size-xl: 1.375rem;
+  --font-size-2xl: 1.5625rem;
+  --font-size-3xl: 1.9375rem;
+  --font-size-4xl: 2.3125rem;
   --font-size-5xl: 3rem;
   --font-size-6xl: 3.75rem;
   --font-size-7xl: 4.5rem;
@@ -41,13 +41,13 @@
   --font-size-display-xl: 6rem;
 
   /* Body Font Sizes */
-  --font-size-body-sm: 0.875rem;
-  --font-size-body: 1rem;
-  --font-size-body-lg: 1.125rem;
+  --font-size-body-sm: 1rem;
+  --font-size-body: 1.125rem;
+  --font-size-body-lg: 1.25rem;
 
   /* UI Font Sizes */
-  --font-size-caption: 0.75rem;
-  --font-size-overline: 0.625rem;
+  --font-size-caption: 0.875rem;
+  --font-size-overline: 0.75rem;
 
   /* Font Weights */
   --font-weight-thin: 100;
@@ -61,10 +61,10 @@
   --font-weight-black: 900;
 
   /* Letter Spacing */
-  --letter-spacing-tightest: -0.075em;
-  --letter-spacing-tighter: -0.05em;
-  --letter-spacing-tight: -0.025em;
-  --letter-spacing-normal: 0;
+  --letter-spacing-tightest: -0.05em;
+  --letter-spacing-tighter: -0.035em;
+  --letter-spacing-tight: -0.015em;
+  --letter-spacing-normal: 0.005em;
   --letter-spacing-wide: 0.025em;
   --letter-spacing-wider: 0.05em;
   --letter-spacing-widest: 0.1em;
@@ -74,10 +74,10 @@
   --line-height-none: 1;
   --line-height-tight: 1.1;
   --line-height-snug: 1.2;
-  --line-height-normal: 1.4;
-  --line-height-relaxed: 1.5;
-  --line-height-comfortable: 1.6;
-  --line-height-loose: 1.7;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.6;
+  --line-height-comfortable: 1.7;
+  --line-height-loose: 1.8;
   --line-height-3: 0.75rem;
   --line-height-4: 1rem;
   --line-height-5: 1.25rem;
@@ -893,8 +893,8 @@
 }
 
 body {
-  font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
-  line-height: 1.55;
+  font-family: "Inter", sans-serif;
+  line-height: 1.6;
 }
 
 html {
@@ -947,22 +947,22 @@ pre {
 
 /* Stack spacing utilities - semantic variants */
 .stack-xs > * + * {
-  margin-top: 0.25rem;
+  margin-top: 0.375rem;
 }
 .stack-sm > * + * {
-  margin-top: 0.5rem;
+  margin-top: 0.625rem;
 }
 .stack-md > * + * {
-  margin-top: 0.75rem;
-}
-.stack-lg > * + * {
   margin-top: 1rem;
 }
+.stack-lg > * + * {
+  margin-top: 1.25rem;
+}
 .stack-xl > * + * {
-  margin-top: 1.5rem;
+  margin-top: 1.75rem;
 }
 .stack-2xl > * + * {
-  margin-top: 2rem;
+  margin-top: 2.5rem;
 }
 
 /* Stack spacing utilities - numeric variants */
@@ -970,142 +970,142 @@ pre {
   margin-top: 0;
 }
 .stack-1 > * + * {
-  margin-top: 0.25rem;
+  margin-top: 0.3125rem;
 }
 .stack-1\.5 > * + * {
-  margin-top: 0.375rem;
+  margin-top: 0.4375rem;
 }
 .stack-2 > * + * {
-  margin-top: 0.5rem;
-}
-.stack-2\.5 > * + * {
   margin-top: 0.625rem;
 }
-.stack-3 > * + * {
+.stack-2\.5 > * + * {
   margin-top: 0.75rem;
 }
+.stack-3 > * + * {
+  margin-top: 0.875rem;
+}
 .stack-4 > * + * {
-  margin-top: 1rem;
+  margin-top: 1.125rem;
 }
 .stack-5 > * + * {
-  margin-top: 1.25rem;
+  margin-top: 1.375rem;
 }
 .stack-6 > * + * {
-  margin-top: 1.5rem;
+  margin-top: 1.75rem;
 }
 .stack-8 > * + * {
-  margin-top: 2rem;
+  margin-top: 2.25rem;
 }
 .stack-10 > * + * {
-  margin-top: 2.5rem;
+  margin-top: 2.75rem;
 }
 .stack-12 > * + * {
-  margin-top: 3rem;
+  margin-top: 3.5rem;
 }
 
 /* Responsive variants for stack utilities - semantic variants */
 @media (min-width: 640px) {
   .sm\:stack-xs > * + * {
-    margin-top: 0.25rem;
+    margin-top: 0.375rem;
   }
   .sm\:stack-sm > * + * {
-    margin-top: 0.5rem;
+    margin-top: 0.625rem;
   }
   .sm\:stack-md > * + * {
-    margin-top: 0.75rem;
-  }
-  .sm\:stack-lg > * + * {
     margin-top: 1rem;
   }
+  .sm\:stack-lg > * + * {
+    margin-top: 1.25rem;
+  }
   .sm\:stack-xl > * + * {
-    margin-top: 1.5rem;
+    margin-top: 1.75rem;
   }
   .sm\:stack-2xl > * + * {
-    margin-top: 2rem;
+    margin-top: 2.5rem;
   }
 }
 
 @media (min-width: 768px) {
   .md\:stack-xs > * + * {
-    margin-top: 0.25rem;
+    margin-top: 0.375rem;
   }
   .md\:stack-sm > * + * {
-    margin-top: 0.5rem;
+    margin-top: 0.625rem;
   }
   .md\:stack-md > * + * {
-    margin-top: 0.75rem;
-  }
-  .md\:stack-lg > * + * {
     margin-top: 1rem;
   }
+  .md\:stack-lg > * + * {
+    margin-top: 1.25rem;
+  }
   .md\:stack-xl > * + * {
-    margin-top: 1.5rem;
+    margin-top: 1.75rem;
   }
   .md\:stack-2xl > * + * {
-    margin-top: 2rem;
+    margin-top: 2.5rem;
   }
 }
 
 @media (min-width: 1024px) {
   .lg\:stack-xs > * + * {
-    margin-top: 0.25rem;
+    margin-top: 0.375rem;
   }
   .lg\:stack-sm > * + * {
-    margin-top: 0.5rem;
+    margin-top: 0.625rem;
   }
   .lg\:stack-md > * + * {
-    margin-top: 0.75rem;
-  }
-  .lg\:stack-lg > * + * {
     margin-top: 1rem;
   }
+  .lg\:stack-lg > * + * {
+    margin-top: 1.25rem;
+  }
   .lg\:stack-xl > * + * {
-    margin-top: 1.5rem;
+    margin-top: 1.75rem;
   }
   .lg\:stack-2xl > * + * {
-    margin-top: 2rem;
+    margin-top: 2.5rem;
   }
 }
 
 @media (min-width: 1280px) {
   .xl\:stack-xs > * + * {
-    margin-top: 0.25rem;
+    margin-top: 0.375rem;
   }
   .xl\:stack-sm > * + * {
-    margin-top: 0.5rem;
+    margin-top: 0.625rem;
   }
   .xl\:stack-md > * + * {
-    margin-top: 0.75rem;
-  }
-  .xl\:stack-lg > * + * {
     margin-top: 1rem;
   }
+  .xl\:stack-lg > * + * {
+    margin-top: 1.25rem;
+  }
   .xl\:stack-xl > * + * {
-    margin-top: 1.5rem;
+    margin-top: 1.75rem;
   }
   .xl\:stack-2xl > * + * {
-    margin-top: 2rem;
+    margin-top: 2.5rem;
   }
 }
 
 @media (min-width: 1536px) {
   .\32xl\:stack-xs > * + * {
-    margin-top: 0.25rem;
+    margin-top: 0.375rem;
   }
   .\32xl\:stack-sm > * + * {
-    margin-top: 0.5rem;
+    margin-top: 0.625rem;
   }
   .\32xl\:stack-md > * + * {
-    margin-top: 0.75rem;
-  }
-  .\32xl\:stack-lg > * + * {
     margin-top: 1rem;
   }
+  .\32xl\:stack-lg > * + * {
+    margin-top: 1.25rem;
+  }
   .\32xl\:stack-xl > * + * {
-    margin-top: 1.5rem;
+    margin-top: 1.75rem;
   }
   .\32xl\:stack-2xl > * + * {
-    margin-top: 2rem;
+    margin-top: 2.5rem;
   }
 }
 
@@ -1307,41 +1307,41 @@ pre {
 
 /* Density wrappers: compact and spacious (semantic stacks only) */
 .density-compact .stack-xs > * + * {
-  margin-top: 0.125rem;
+  margin-top: 0.1875rem;
 }
 .density-compact .stack-sm > * + * {
-  margin-top: 0.25rem;
+  margin-top: 0.375rem;
 }
 .density-compact .stack-md > * + * {
-  margin-top: 0.5rem;
+  margin-top: 0.625rem;
 }
 .density-compact .stack-lg > * + * {
-  margin-top: 0.75rem;
+  margin-top: 1rem;
 }
 .density-compact .stack-xl > * + * {
-  margin-top: 1rem;
+  margin-top: 1.25rem;
 }
 .density-compact .stack-2xl > * + * {
   margin-top: 1.5rem;
 }
 
 .density-spacious .stack-xs > * + * {
-  margin-top: 0.375rem;
+  margin-top: 0.5rem;
 }
 .density-spacious .stack-sm > * + * {
-  margin-top: 0.75rem;
+  margin-top: 0.875rem;
 }
 .density-spacious .stack-md > * + * {
-  margin-top: 1rem;
+  margin-top: 1.25rem;
 }
 .density-spacious .stack-lg > * + * {
-  margin-top: 1.5rem;
+  margin-top: 1.75rem;
 }
 .density-spacious .stack-xl > * + * {
-  margin-top: 2rem;
+  margin-top: 2.5rem;
 }
 .density-spacious .stack-2xl > * + * {
-  margin-top: 2.5rem;
+  margin-top: 3rem;
 }
 
 /* Duration utilities */
@@ -1425,12 +1425,12 @@ pre {
 
 /* Code block styling */
 .prose pre {
-  padding: 1rem 0.75rem;
+  padding: 1.125rem 0.875rem;
 }
 
 @media (min-width: 640px) {
   .prose pre {
-    padding: 1rem 1.5rem;
+    padding: 1.125rem 1.75rem;
   }
 }
 
@@ -1438,13 +1438,13 @@ pre {
   padding: 0;
   background: transparent;
   color: inherit;
-  font-size: 0.875rem;
-  line-height: 1.7;
+  font-size: 1rem;
+  line-height: 1.8;
 }
 
 @media (min-width: 640px) {
   .prose pre code {
-    font-size: 0.9375rem;
+    font-size: 1.0625rem;
   }
 }
 
@@ -2192,7 +2192,7 @@ pre {
 
 /* Prose Typography Customizations */
 .prose p {
-  line-height: 1.75;
+  line-height: 1.8;
 }
 
 .prose :where(h1, h2, h3, h4, h5, h6) {
@@ -2201,8 +2201,8 @@ pre {
 }
 
 .prose li {
-  margin-top: 0.375rem;
-  margin-bottom: 0.375rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .prose :where(ul, ol) {
@@ -2211,13 +2211,13 @@ pre {
 }
 
 .prose hr {
-  margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
+  margin-top: 1.75rem;
+  margin-bottom: 1.75rem;
 }
 
 .prose a {
   text-decoration-line: underline;
-  text-underline-offset: 2px;
+  text-underline-offset: 3px;
 }
 
 .prose a:hover {
@@ -2226,10 +2226,10 @@ pre {
 
 .prose code {
   border-radius: 0.375rem;
-  padding-left: 0.375rem;
-  padding-right: 0.375rem;
-  padding-top: 0.125rem;
-  padding-bottom: 0.125rem;
+  padding-left: 0.4375rem;
+  padding-right: 0.4375rem;
+  padding-top: 0.1875rem;
+  padding-bottom: 0.1875rem;
 }
 
 .prose blockquote {
@@ -2583,7 +2583,7 @@ pre {
 
 .zen-prose .prose :where(blockquote)::before {
   content: "?";
-  font-family: "Playfair Display", Georgia, serif;
+  font-family: "Literata", Georgia, serif;
   font-size: clamp(
     calc(2.2rem * var(--zen-font-scale, 1)),
     calc((2vw + 1.2rem) * var(--zen-font-scale, 1)),


### PR DESCRIPTION
## Summary

- **Font family swap**: Arial → Inter (variable weight + optical sizing), Source Serif 4 → Literata (optimized for long reading), Playfair Display → Literata in zen blockquotes. IBM Plex Mono unchanged.
- **Font size scale bumped +2px**: xs→14px, sm→16px, base→18px, lg→20px, xl→22px, plus 2xl–4xl, body variants, caption, and overline all shifted up. Display sizes unchanged.
- **Looser spacing everywhere**: line heights +0.1 across the board, letter spacing loosened (normal now 0.005em, tight values less negative), stack spacing bumped at every tier (named, numeric, responsive, density variants), prose element margins/padding increased.

## Test plan

- [ ] `bun run check` passes (lint + types + build)
- [ ] Chat messages render in Inter, feel noticeably softer than Arial
- [ ] Code blocks still use IBM Plex Mono
- [ ] Zen mode uses Literata for serif text and blockquote decorations
- [ ] Text is visibly larger and more spaced out — no cramped areas
- [ ] No layout breakage (buttons, inputs, sidebars, modals still fit)
- [ ] Density compact/spacious modes still produce correct relative spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)