### PR TITLE
fix: increase message action button size and spacing

### DIFF
--- a/src/components/chat/message/action-button.tsx
+++ b/src/components/chat/message/action-button.tsx
@@ -33,7 +33,7 @@ type ActionButtonProps = React.ComponentProps<"button"> & {
 const chipBase = [
   "appearance-none",
   "flex items-center justify-center",
-  "h-6 rounded-md",
+  "h-7 rounded-md",
   "border border-transparent",
   "text-muted-foreground text-xs",
   "transition-all duration-200 ease-out",
@@ -41,8 +41,8 @@ const chipBase = [
 ].join(" ");
 
 const chipSizes: Record<ActionButtonSize, string> = {
-  icon: "w-6",
-  label: "w-auto px-1.5 gap-1",
+  icon: "w-7",
+  label: "w-auto px-2 gap-1",
 };
 
 const chipVariants: Record<ActionButtonVariant, string> = {
@@ -118,7 +118,7 @@ export function ActionButton({
 /** Icon size for mobile drawer items (size-4) */
 export const DRAWER_ICON_SIZE = "size-4";
 
-const iconClass = "size-3.5";
+const iconClass = "size-4";
 
 // ============================================================================
 // Preset action buttons

--- a/src/components/chat/message/image-actions.tsx
+++ b/src/components/chat/message/image-actions.tsx
@@ -141,13 +141,13 @@ export const ImageActions = ({
   // In minimal mode, show only copy prompt + retry
   if (minimal) {
     return (
-      <div className={cn("flex items-center gap-1", className)}>
+      <div className={cn("flex items-center gap-1.5", className)}>
         <ActionButton
           tooltip={prompt ? "Copy prompt to clipboard" : "No prompt available"}
           onClick={handleCopyPrompt}
           disabled={isCopying || !prompt}
         >
-          <CopyIcon className="size-3.5" />
+          <CopyIcon className="size-4" />
         </ActionButton>
 
         {onRetry && (
@@ -162,7 +162,7 @@ export const ImageActions = ({
   }
 
   return (
-    <div className={cn("flex items-center gap-1", className)}>
+    <div className={cn("flex items-center gap-1.5", className)}>
       {/* Show dropdown menu when seed is available, otherwise show simple button */}
       {seed !== undefined ? (
         <DropdownMenu>
@@ -174,7 +174,7 @@ export const ImageActions = ({
                   className="h-7 gap-0.5"
                   disabled={isCopying || (!prompt && seed === undefined)}
                 >
-                  <CopyIcon className="size-3.5" />
+                  <CopyIcon className="size-4" />
                   <CaretDownIcon className="size-3" />
                 </ActionButton>
               </DropdownMenuTrigger>
@@ -206,7 +206,7 @@ export const ImageActions = ({
           onClick={handleCopyPrompt}
           disabled={isCopying || !prompt}
         >
-          <CopyIcon className="size-3.5" />
+          <CopyIcon className="size-4" />
         </ActionButton>
       )}
 
@@ -215,7 +215,7 @@ export const ImageActions = ({
         onClick={handleDownloadImage}
         disabled={isDownloading}
       >
-        <DownloadIcon className="size-3.5" />
+        <DownloadIcon className="size-4" />
       </ActionButton>
 
       {onRetry && (

--- a/src/components/chat/message/image-generation-bubble.tsx
+++ b/src/components/chat/message/image-generation-bubble.tsx
@@ -553,7 +553,7 @@ export const ImageGenerationBubble = ({
                 onClick={onDeleteMessage}
                 disabled={isDeleting}
               >
-                <TrashIcon className="size-3.5" />
+                <TrashIcon className="size-4" />
               </ActionButton>
             )}
           </div>
@@ -595,7 +595,7 @@ export const ImageGenerationBubble = ({
                 onClick={onDeleteMessage}
                 disabled={isDeleting}
               >
-                <TrashIcon className="size-3.5" />
+                <TrashIcon className="size-4" />
               </ActionButton>
             )}
           </div>

--- a/src/components/chat/message/image-retry-popover.tsx
+++ b/src/components/chat/message/image-retry-popover.tsx
@@ -97,7 +97,7 @@ export function ImageRetryPopover({
   );
 
   const triggerContent = (
-    <ArrowCounterClockwiseIcon className="size-3.5" aria-hidden="true" />
+    <ArrowCounterClockwiseIcon className="size-4" aria-hidden="true" />
   );
 
   return (
@@ -244,7 +244,7 @@ function DesktopContent({
         </Button>
         <Button size="sm" onClick={onRetry} disabled={!selectedModel}>
           <ArrowCounterClockwiseIcon
-            className="size-3.5 mr-1.5"
+            className="size-4 mr-1.5"
             aria-hidden="true"
           />
           Retry

--- a/src/components/chat/message/message-actions.tsx
+++ b/src/components/chat/message/message-actions.tsx
@@ -84,12 +84,12 @@ function getTTSIconForDrawer(ttsState: TtsState): React.ReactNode {
 
 function getTTSIconForButton(ttsState: TtsState): React.ReactNode {
   if (ttsState === "loading") {
-    return <Spinner size="sm" className="h-3.5 w-3.5" />;
+    return <Spinner size="sm" className="h-4 w-4" />;
   }
   if (ttsState === "playing") {
-    return <SquareIcon className="size-3.5 text-destructive" weight="fill" />;
+    return <SquareIcon className="size-4 text-destructive" weight="fill" />;
   }
-  return <Volume2Icon animateOnHover className="size-3.5" />;
+  return <Volume2Icon animateOnHover className="size-4" />;
 }
 
 type MessageActionsProps = {
@@ -336,7 +336,7 @@ export const MessageActions = memo(
     }
 
     const containerClassName = cn(
-      "flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100",
+      "flex items-center gap-1.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100",
       "translate-y-0 sm:translate-y-1 sm:group-hover:translate-y-0",
       "transition-all duration-200 ease-out",
       "@media (prefers-reduced-motion: reduce) { transition-duration: 0ms; opacity: 100; transform: none }",
@@ -441,7 +441,7 @@ export const MessageActions = memo(
                     disabled={isEditing}
                     aria-label="More actions"
                   >
-                    <DotsThreeIcon className="size-3.5" aria-hidden="true" />
+                    <DotsThreeIcon className="size-4" aria-hidden="true" />
                   </TooltipTrigger>
                 </DrawerTrigger>
                 <TooltipContent>
@@ -464,7 +464,7 @@ export const MessageActions = memo(
         )}
 
         {/* Desktop: Individual action buttons */}
-        <div className="hidden sm:flex sm:items-center sm:gap-1">
+        <div className="hidden sm:flex sm:items-center sm:gap-1.5">
           {onEditMessage && (
             <ActionButtons.Edit
               disabled={isEditing}
@@ -578,7 +578,7 @@ export const MessageActions = memo(
                 </span>
               )}
               {/* Mobile: Show only icon */}
-              <ChartBarIcon className="size-3.5 sm:hidden" aria-hidden="true" />
+              <ChartBarIcon className="size-4 sm:hidden" aria-hidden="true" />
             </PopoverTrigger>
             <PopoverContent className="w-64 p-3" align="start" side="top">
               <div className="stack-md">
@@ -663,7 +663,7 @@ export const MessageActions = memo(
         {!isUser && model && provider && (
           <ActionButton size="label" className="pointer-events-none">
             {provider !== "replicate" && (
-              <ProviderIcon className="h-3 w-3" provider={provider} />
+              <ProviderIcon className="h-3.5 w-3.5" provider={provider} />
             )}
             <span className="hidden sm:inline">{modelTitle}</span>
           </ActionButton>

--- a/src/components/chat/message/message-error.tsx
+++ b/src/components/chat/message/message-error.tsx
@@ -75,7 +75,7 @@ export function MessageError({
           size="sm"
           onClick={() => onRetry(messageId)}
         >
-          <ArrowCounterClockwiseIcon className="size-3.5" />
+          <ArrowCounterClockwiseIcon className="size-4" />
           Retry message
         </Button>
       );

--- a/src/components/chat/message/retry-model-menu.tsx
+++ b/src/components/chat/message/retry-model-menu.tsx
@@ -718,7 +718,7 @@ export const RetryDropdown = memo(
                   <RefreshCwIcon
                     animateOnHover
                     className={cn(
-                      "size-3.5",
+                      "size-4",
                       isRetrying && "motion-safe:animate-spin-reverse"
                     )}
                     aria-hidden="true"
@@ -862,7 +862,7 @@ export const RetryDropdown = memo(
                   <RefreshCwIcon
                     animateOnHover
                     className={cn(
-                      "size-3.5",
+                      "size-4",
                       isRetrying && "motion-safe:animate-spin-reverse"
                     )}
                     aria-hidden="true"


### PR DESCRIPTION
## Summary
- Increased action button size from 24px to 28px (`h-6 w-6` → `h-7 w-7`) for better click/tap targets
- Bumped icon size from 14px to 16px (`size-3.5` → `size-4`) across all message action components
- Increased gap between action buttons from 4px to 6px (`gap-1` → `gap-1.5`)
- Updated label variant padding (`px-1.5` → `px-2`) for proportional spacing

## Test plan
- [ ] Verify message action buttons render at correct size on desktop hover
- [ ] Verify mobile overflow drawer still works correctly
- [ ] Check image action buttons (copy prompt, download) are consistent
- [ ] Confirm retry dropdown trigger icon size matches other actions
- [ ] Test delete button sizing in image generation bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)