### PR TITLE
Enable tsgo (TypeScript 7) for faster typechecking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@typescript/native-preview": "^7.0.0-dev.20260220.1",
         "@vitejs/plugin-react": "^5.1.2",
         "babel-plugin-react-compiler": "1.0.0",
         "bun-plugin-tailwind": "^0.1.2",
@@ -511,6 +512,22 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260220.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260220.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260220.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260220.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260220.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260220.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260220.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260220.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-trYXlG98/C7Q7pqnPrKo+ksXrWqWVMncCy2x0VftD2llfL99Z//g2mpB9TmzWeKgb4d1659ESvxTowCGnzMccw=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260220.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VZQHVaLYTpa3wfCLcFD5cfnegr4iDtzBxV6yh3tys+HYePi4TXuAqct/dmziW0cpCo/UQ2KqAPGxwVO3YMDYJA=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260220.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-ieGtyz904rlme8YWauDpCqGbnOQQ5dzUyRKU25I7MNIaoZFf0vK5gMh3SLjHC7ayWxjrCa2ezH4ka8UmyWQcPg=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260220.1", "", { "os": "linux", "cpu": "arm" }, "sha512-wMA63N6XLAkO0Ibq1Qz2zkQHF6oLynYh5+q1YayzWxp1FOas0oJUdNgVbiWeisAT4IEI9SmYtVwJJNTm/cwrwg=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260220.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-nlOOABSQUe6ix/KOsZS3ALZ/sg9rhtp6SKtQnXO8X4+2XUlwVYS6nIrAQ5jG4+OsCvcESttNeHhBw817uNrsuA=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260220.1", "", { "os": "linux", "cpu": "x64" }, "sha512-W7R/5ct/BGuPAmJuKFU0ZuLU2nzLA26XfoaoUHHoTLYRMMuY3LBv+7zKSUTlSGjayeWQ5KtDrfrY72LarWAXkQ=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260220.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-FNXTr2lS1QLUB05jWjkBVwrDierNuxKduQq9ayloENJrsC8GfG1sXkfy8R021+ozP/D1LI/CFUn3hkB2vPXTsQ=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260220.1", "", { "os": "win32", "cpu": "x64" }, "sha512-byHRyf4dOuKOADrs43tWyPhmAgqk+XrA/XOsJnGsxUKxPwots+gf9x5kg/IxTbB3QjPsVe/V9QdMl3//sUTCmQ=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 

--- a/convex.json
+++ b/convex.json
@@ -1,4 +1,5 @@
 {
+  "typescriptCompiler": "tsgo",
   "node": {
     "externalPackages": [
       "@node-rs/argon2",

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -17,12 +17,11 @@
     "skipLibCheck": true,
     "noEmit": true,
     "moduleResolution": "bundler",
-    "baseUrl": "..",
     "paths": {
-      "@/*": ["src/*"],
-      "@convex/*": ["convex/*"],
-      "@shared/*": ["shared/*"],
-      "@config/*": ["config/*"]
+      "@/*": ["./../src/*"],
+      "@convex/*": ["./../convex/*"],
+      "@shared/*": ["./../shared/*"],
+      "@config/*": ["./../config/*"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "NODE_ENV=production sh -c \"convex deploy --verbose --typecheck disable && vite build\"",
     "fix": "biome check --write .",
     "check": "biome ci . && react-compiler-healthcheck && vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint:file": "biome check --write",
     "check:file": "biome check",
     "check:json": "biome ci --reporter=json .",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "NODE_ENV=production sh -c \"convex deploy --verbose --typecheck disable && vite build\"",
     "fix": "biome check --write .",
     "check": "biome ci . && react-compiler-healthcheck && vite build",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.tsgo.json",
     "lint:file": "biome check --write",
     "check:file": "biome check",
     "check:json": "biome ci --reporter=json .",
@@ -114,7 +114,10 @@
     "*.{js,jsx,ts,tsx,json,css,md}": [
       "biome check --write --files-ignore-unknown=true --no-errors-on-unmatched"
     ],
-    "*.{ts,tsx}": ["bash -c 'tsc --noEmit'", "react-compiler-healthcheck"],
+    "*.{ts,tsx}": [
+      "bash -c 'tsgo --noEmit -p tsconfig.tsgo.json'",
+      "react-compiler-healthcheck"
+    ],
     "*.{test,spec}.{ts,tsx}": [
       "bash -c 'NODE_ENV=test bun test --pass-with-no-tests'"
     ],

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@typescript/native-preview": "^7.0.0-dev.20260220.1",
     "@vitejs/plugin-react": "^5.1.2",
     "babel-plugin-react-compiler": "1.0.0",
     "bun-plugin-tailwind": "^0.1.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,12 +25,11 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@convex/*": ["convex/*"],
-      "@shared/*": ["shared/*"],
-      "@config/*": ["config/*"]
+      "@/*": ["./src/*"],
+      "@convex/*": ["./convex/*"],
+      "@shared/*": ["./shared/*"],
+      "@config/*": ["./config/*"]
     },
     "types": ["bun-types", "node"]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,11 +25,12 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@convex/*": ["./convex/*"],
-      "@shared/*": ["./shared/*"],
-      "@config/*": ["./config/*"]
+      "@/*": ["src/*"],
+      "@convex/*": ["convex/*"],
+      "@shared/*": ["shared/*"],
+      "@config/*": ["config/*"]
     },
     "types": ["bun-types", "node"]
   },

--- a/tsconfig.tsgo.json
+++ b/tsconfig.tsgo.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": null,
+    "paths": {
+      "@/*": ["./src/*"],
+      "@convex/*": ["./convex/*"],
+      "@shared/*": ["./shared/*"],
+      "@config/*": ["./config/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Enables the TypeScript 7 native preview compiler (`tsgo`) for both Convex and app typechecking
- Adds `tsconfig.tsgo.json` that extends the base tsconfig with tsgo-compatible relative paths (tsgo removed `baseUrl` support, but bun/vite still need it)
- Updates `convex/tsconfig.json` to use relative paths without `baseUrl`
- Updates `typecheck` script and `lint-staged` to use `tsgo` via the tsgo-specific config
- Adds `@typescript/native-preview` as a dev dependency

## Test plan
- [x] `npx convex typecheck` passes with tsgo
- [x] `bun run typecheck` (`tsgo --noEmit -p tsconfig.tsgo.json`) passes
- [x] `bun run check` passes (biome + react-compiler + vite build)
- [x] `bun run test` — 1266 tests pass
- [x] `tsc --noEmit` still works (base tsconfig unchanged for bun/vite compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)