### PR TITLE
refactor: consolidate streaming helpers and inline memory retrieval

### DIFF
--- a/convex/lib/conversation/assistant_retry.ts
+++ b/convex/lib/conversation/assistant_retry.ts
@@ -1,7 +1,7 @@
 import type { Doc, Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
-import { executeStreamMessage } from "../../streaming_actions";
+import { buildStreamArgs, executeStreamMessage } from "../../streaming_actions";
 
 export async function handleAssistantRetry(
   ctx: ActionCtx,
@@ -51,23 +51,13 @@ export async function handleAssistantRetry(
     },
   );
 
-  // Direct streaming call — skip scheduler hop (~50-200ms savings)
-  await executeStreamMessage(ctx, {
+  await executeStreamMessage(ctx, buildStreamArgs(streamingArgs, {
     messageId: targetMessage._id,
     conversationId,
-    model: streamingArgs.modelId,
-    provider: streamingArgs.provider,
     personaId: effectivePersonaId,
     reasoningConfig,
-    supportsTools: streamingArgs.supportsTools,
-    supportsImages: streamingArgs.supportsImages,
-    supportsFiles: streamingArgs.supportsFiles,
-    supportsReasoning: streamingArgs.supportsReasoning,
-    supportsTemperature: streamingArgs.supportsTemperature,
-    contextLength: streamingArgs.contextLength,
-    contextEndIndex: streamingArgs.contextEndIndex,
     userId: user._id,
-  });
+  }));
 
   return { assistantMessageId: targetMessage._id };
 }

--- a/convex/lib/conversation/context_building.ts
+++ b/convex/lib/conversation/context_building.ts
@@ -1,6 +1,7 @@
 import type { ActionCtx } from "../../_generated/server";
 import type { Id } from "../../_generated/dataModel";
 import { internal } from "../../_generated/api";
+import { retrieveMemoriesCore } from "../../memory_actions";
 import {
   mergeSystemPrompts,
 } from "./message_handling";
@@ -74,10 +75,10 @@ export const buildContextMessages = async (
               .reverse()
               .find((m: any) => m.role === "user");
             if (!lastUserMsg?.content) return [];
-            return await ctx.runAction(
-              internal.memory_actions.retrieveMemories,
-              { userId, messageContent: lastUserMsg.content },
-            );
+            return await retrieveMemoriesCore(ctx, {
+              userId,
+              messageContent: lastUserMsg.content,
+            });
           } catch (error) {
             console.warn("[buildContextMessagesForStreaming] Memory retrieval failed:", error);
             return [];

--- a/convex/lib/conversation/retry_handlers.ts
+++ b/convex/lib/conversation/retry_handlers.ts
@@ -186,7 +186,6 @@ export async function editMessageHandler(
     },
   );
 
-  // Direct streaming call — skip scheduler hop
   await executeStreamMessage(ctx, {
     messageId: assistantMessageId,
     conversationId: args.conversationId,

--- a/convex/lib/conversation/user_retry.ts
+++ b/convex/lib/conversation/user_retry.ts
@@ -128,16 +128,16 @@ export async function handleUserRetry(
     },
   );
 
-  await executeStreamMessage(ctx, buildStreamArgs(
-    { ...streamingArgs, contextEndIndex: messageIndex },
-    {
+  await executeStreamMessage(ctx, {
+    ...buildStreamArgs(streamingArgs, {
       messageId: assistantMessageId,
       conversationId,
       personaId: effectivePersonaId,
       reasoningConfig,
       userId: user._id,
-    },
-  ));
+    }),
+    contextEndIndex: messageIndex,
+  });
 
   return { assistantMessageId };
 }

--- a/convex/lib/conversation/user_retry.ts
+++ b/convex/lib/conversation/user_retry.ts
@@ -2,7 +2,7 @@ import type { Doc, Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";
 import { api, internal } from "../../_generated/api";
 import { handleMessageDeletion } from "./message_handling";
-import { executeStreamMessage } from "../../streaming_actions";
+import { buildStreamArgs, executeStreamMessage } from "../../streaming_actions";
 import { getUserEffectiveModelWithCapabilities } from "../model_resolution";
 
 export async function handleReplicateUserRetry(
@@ -128,23 +128,16 @@ export async function handleUserRetry(
     },
   );
 
-  // Direct streaming call — skip scheduler hop
-  await executeStreamMessage(ctx, {
-    messageId: assistantMessageId,
-    conversationId,
-    model: streamingArgs.modelId,
-    provider: streamingArgs.provider,
-    personaId: effectivePersonaId,
-    reasoningConfig,
-    supportsTools: streamingArgs.supportsTools,
-    supportsImages: streamingArgs.supportsImages,
-    supportsFiles: streamingArgs.supportsFiles,
-    supportsReasoning: streamingArgs.supportsReasoning,
-    supportsTemperature: streamingArgs.supportsTemperature,
-    contextLength: streamingArgs.contextLength,
-    contextEndIndex: messageIndex,
-    userId: user._id,
-  });
+  await executeStreamMessage(ctx, buildStreamArgs(
+    { ...streamingArgs, contextEndIndex: messageIndex },
+    {
+      messageId: assistantMessageId,
+      conversationId,
+      personaId: effectivePersonaId,
+      reasoningConfig,
+      userId: user._id,
+    },
+  ));
 
   return { assistantMessageId };
 }


### PR DESCRIPTION
## Summary
- Add `ModelStreamingArgs` type and `buildStreamArgs()` helper to eliminate repetitive 12-property spreading across retry/edit action handlers
- Add `toStreamingArgs()` and `scheduleStreamMessage()` helpers in mutation_handlers to deduplicate 4 inline scheduler calls
- Extract `retrieveMemoriesCore()` from `retrieveMemories` internalAction so `context_building.ts` can call it directly, removing a nested action-in-action scheduler hop
- Add tests for `buildStreamArgs` mapping and memory retrieval path

## Test plan
- [x] `bun run check` passes (lint + types + build)
- [x] `bun run test` passes (1331 tests, 0 failures)
- [ ] Manual: send message in new/existing conversation, edit a message, retry a message — all stream correctly
- [ ] Manual: with memory enabled, verify memories still appear in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)