### PR TITLE
fix: resolve tsgo module resolution failures

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -15,7 +15,7 @@ minimumReleaseAge = 86400
 
 [test]
 # Preload runs before any test files; keep it lightweight and self-healing.
-preload = ["test/global-mocks.ts", "test/setup-bun.ts"]
+preload = ["./test/global-mocks.ts", "./test/setup-bun.ts"]
 
 # Randomize spec execution order to ensure tests are independent.
 randomize = true

--- a/src/hooks/use-conversation-import.ts
+++ b/src/hooks/use-conversation-import.ts
@@ -1,4 +1,4 @@
-import { api } from "convex/_generated/api";
+import { api } from "@convex/_generated/api";
 import { useMutation } from "convex/react";
 import { useCallback, useRef, useState } from "react";
 import { useBackgroundJobs } from "@/hooks/use-background-jobs";

--- a/src/hooks/use-conversation-limit.ts
+++ b/src/hooks/use-conversation-limit.ts
@@ -1,6 +1,6 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
 import { useQuery } from "convex/react";
-import { api } from "../../convex/_generated/api";
-import type { Id } from "../../convex/_generated/dataModel";
 
 export function useConversationLimit(conversationId?: Id<"conversations">) {
   const limitStatus = useQuery(

--- a/src/lib/chat/message-utils.ts
+++ b/src/lib/chat/message-utils.ts
@@ -1,7 +1,7 @@
 /**
  * Shared utilities for message handling across components and hooks
  */
-import type { Doc } from "convex/_generated/dataModel";
+import type { Doc } from "@convex/_generated/dataModel";
 import { hasPageArray } from "@/lib/type-guards";
 import type { ChatMessage, ConversationId } from "@/types";
 

--- a/src/pages/settings/new-persona-page.tsx
+++ b/src/pages/settings/new-persona-page.tsx
@@ -1,4 +1,4 @@
-import { api } from "convex/_generated/api";
+import { api } from "@convex/_generated/api";
 import { useMutation } from "convex/react";
 import { useState, useTransition } from "react";
 import { Link, useNavigate } from "react-router-dom";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,12 +25,11 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@convex/*": ["convex/*"],
-      "@shared/*": ["shared/*"],
-      "@config/*": ["config/*"]
+      "@/*": ["./src/*"],
+      "@convex/*": ["./convex/*"],
+      "@shared/*": ["./shared/*"],
+      "@config/*": ["./config/*"]
     },
     "types": ["bun-types", "node"]
   },


### PR DESCRIPTION
## Summary
- Remove deprecated `baseUrl` option and use relative `./` prefixes in tsconfig `paths` to satisfy tsgo's stricter requirements
- Fix 4 source files using bare or relative `convex/_generated` imports to use the `@convex/` alias consistently
- Both `tsc` and `tsgo` now pass cleanly with zero errors

## Test plan
- [x] `bunx tsgo --noEmit` passes with no errors
- [x] `bunx tsc --noEmit` passes with no errors
- [x] `bun run check` (lint + types + build) passes
- [x] Pre-commit hooks (Biome, tsgo, React compiler) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)