### PR TITLE
fix: gate resolvedId on hasAccess to prevent pre-auth Access Denied

### DIFF
--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -225,17 +225,17 @@ export function CommandPalette({
     currentConversationId ? { slug: currentConversationId } : "skip"
   );
 
+  const currentResolvedId = currentConversation?.hasAccess
+    ? (currentConversation.resolvedId as ConversationId)
+    : undefined;
+
   const { deleteConversation: performDelete } = useDeleteConversation({
-    currentConversationId: currentConversation?.resolvedId as
-      | ConversationId
-      | undefined,
+    currentConversationId: currentResolvedId,
   });
 
   const { archiveConversation: performArchive, unarchiveConversation } =
     useArchiveConversation({
-      currentConversationId: currentConversation?.resolvedId as
-        | ConversationId
-        | undefined,
+      currentConversationId: currentResolvedId,
     });
 
   const managedToast = useToast();
@@ -287,8 +287,10 @@ export function CommandPalette({
     actionConversationSlug ? { slug: actionConversationSlug } : "skip"
   );
 
-  // Get the resolved Convex ID for mutations
-  const actionConversationId = actionConversation?.resolvedId ?? null;
+  // Get the resolved Convex ID for mutations (gate on hasAccess to avoid pre-auth errors)
+  const actionConversationId = actionConversation?.hasAccess
+    ? actionConversation.resolvedId
+    : null;
 
   const resolvedActionContext =
     navigation.selectedConversationId && actionConversation

--- a/src/pages/chat-conversation-page.tsx
+++ b/src/pages/chat-conversation-page.tsx
@@ -96,7 +96,7 @@ export default function ConversationRoute() {
 
   // Query for conversation by slug
   const slugQuery = useQuery(api.conversations.getBySlug, { slug });
-  const resolvedId = slugQuery?.resolvedId ?? null;
+  const resolvedId = slugQuery?.hasAccess ? slugQuery.resolvedId : null;
 
   // Get chat messages and actions
   const {


### PR DESCRIPTION
## Summary
- `getBySlugHandler` returns `resolvedId` even when `hasAccess` is false (before the auth token is available), causing downstream access-controlled queries like `messages.list` to throw `ConvexError("Access denied")`
- Gate `resolvedId` extraction on `hasAccess` in `chat-conversation-page.tsx` and `command-palette.tsx` so queries skip until the user is authenticated
- Once the Convex reactive query re-runs after auth, `hasAccess` becomes true and everything loads normally

## Test plan
- [ ] Navigate to a conversation URL while logged in — messages load as before
- [ ] Hard-refresh on a conversation page — no "Access denied" errors in console during auth hydration
- [ ] Open command palette and use export/delete/archive actions — they work correctly
- [ ] Open a shared conversation link — still accessible (shared access path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)