### PR TITLE
fix: use consistent background color across all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,9 +67,9 @@
       html.light:not([data-color-scheme]),
       html:not(.dark):not(.light):not([data-color-scheme]) { color-scheme: light; background-color: hsl(0 0% 99%); color: hsl(0 0% 5%); }
       /* Polly */
-      html.dark[data-color-scheme="polly"] { color-scheme: dark; background-color: hsl(264 35% 7%); color: hsl(264 25% 95%); }
+      html.dark[data-color-scheme="polly"] { color-scheme: dark; background-color: hsl(262 20% 14%); color: hsl(264 25% 95%); }
       html.light[data-color-scheme="polly"],
-      html:not(.dark):not(.light)[data-color-scheme="polly"] { color-scheme: light; background-color: hsl(264 40% 97%); color: hsl(264 25% 8%); }
+      html:not(.dark):not(.light)[data-color-scheme="polly"] { color-scheme: light; background-color: hsl(262 30% 98%); color: hsl(264 25% 8%); }
       /* Catppuccin */
       html.dark[data-color-scheme="catppuccin"] { color-scheme: dark; background-color: hsl(240 21% 15%); color: hsl(226 64% 88%); }
       html.light[data-color-scheme="catppuccin"] { color-scheme: light; background-color: hsl(220 23% 95%); color: hsl(234 16% 35%); }

--- a/src/components/layouts/route-error-boundary.tsx
+++ b/src/components/layouts/route-error-boundary.tsx
@@ -10,7 +10,7 @@ export const RouteErrorBoundary = () => {
   if (isRouteErrorResponse(error)) {
     if (error.status === 404) {
       return (
-        <div className="flex h-full w-full items-center justify-center">
+        <div className="flex min-h-[100dvh] w-full items-center justify-center bg-background">
           <div className="max-w-md text-center">
             <WarningIcon className="mb-4 h-16 w-16 text-destructive" />
             <h1 className="mb-2 text-2xl font-bold">404 - Page Not Found</h1>
@@ -26,7 +26,7 @@ export const RouteErrorBoundary = () => {
     }
 
     return (
-      <div className="flex h-full w-full items-center justify-center">
+      <div className="flex min-h-[100dvh] w-full items-center justify-center bg-background">
         <div className="max-w-md text-center">
           <WarningIcon className="mb-4 h-16 w-16 text-destructive" />
           <h1 className="mb-2 text-2xl font-bold">
@@ -44,7 +44,7 @@ export const RouteErrorBoundary = () => {
   }
 
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    <div className="flex min-h-[100dvh] w-full items-center justify-center bg-background">
       <div className="flex max-w-md flex-col items-center text-center">
         <WarningIcon className="mb-4 h-16 w-16 text-destructive" />
         <h1 className="mb-2 text-2xl font-bold">Something went wrong</h1>

--- a/src/components/layouts/settings-main-layout.tsx
+++ b/src/components/layouts/settings-main-layout.tsx
@@ -5,7 +5,7 @@ import { SettingsHeader } from "@/components/settings/settings-header";
 
 export default function SettingsMainLayout() {
   return (
-    <div className="flex h-[100dvh] flex-col">
+    <div className="flex h-[100dvh] flex-col bg-background">
       <SettingsHeader backLink="/" backText="Back to Chat" />
       <SettingsContainer>
         <Outlet />

--- a/src/components/layouts/settings-standalone-layout.tsx
+++ b/src/components/layouts/settings-standalone-layout.tsx
@@ -5,7 +5,7 @@ import { ROUTES } from "@/lib/routes";
 
 export default function SettingsStandaloneLayout() {
   return (
-    <>
+    <div className="flex min-h-[100dvh] flex-col bg-background">
       <SettingsHeader
         backLink={ROUTES.SETTINGS.PERSONAS}
         backText="Back to Personas"
@@ -13,6 +13,6 @@ export default function SettingsStandaloneLayout() {
       <div className="mx-auto w-full max-w-4xl flex-1 px-6 py-8">
         <Outlet />
       </div>
-    </>
+    </div>
   );
 }

--- a/src/globals.css
+++ b/src/globals.css
@@ -872,6 +872,7 @@
   /* Base UI: Portal isolation to prevent z-index conflicts */
   #root {
     isolation: isolate;
+    min-height: 100dvh;
   }
 
   /* Base UI: iOS 26+ Safari support for backdrops */


### PR DESCRIPTION
## Summary
- Fixed Polly theme's inline background colors in `index.html` to match `--color-background` CSS variables — the mismatch caused a visible two-tone effect
- Added `min-height: 100dvh` to `#root` so the app always fills the viewport
- Added explicit `bg-background` and full viewport height to error boundary, settings, and standalone settings layouts

## Test plan
- [ ] Switch to Polly theme (light + dark) and verify no color seam on settings/error pages
- [ ] Verify other themes (Classic, Catppuccin, Dracula, Nord) still look correct
- [ ] Resize browser to short height on settings page — no second background color should appear
- [ ] Trigger a route error and confirm the error page has a uniform background

🤖 Generated with [Claude Code](https://claude.com/claude-code)