### PR TITLE
feat: add canvas image gallery

### DIFF
--- a/config/models/image-models.ts
+++ b/config/models/image-models.ts
@@ -28,6 +28,7 @@ export const builtInImageModels: ImageModelConfig[] = [
     modelId: "prunaai/flux-fast",
     provider: "replicate",
     free: true,
+    isActive: false,
   },
   // Add more built-in image models here
   // Example:

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -61,6 +61,7 @@ import type * as conversation_search from "../conversation_search.js";
 import type * as conversations from "../conversations.js";
 import type * as crons from "../crons.js";
 import type * as fileStorage from "../fileStorage.js";
+import type * as generations from "../generations.js";
 import type * as http from "../http.js";
 import type * as imageModels from "../imageModels.js";
 import type * as internal_ from "../internal.js";
@@ -215,6 +216,7 @@ declare const fullApi: ApiFromModules<{
   conversations: typeof conversations;
   crons: typeof crons;
   fileStorage: typeof fileStorage;
+  generations: typeof generations;
   http: typeof http;
   imageModels: typeof imageModels;
   internal: typeof internal_;

--- a/convex/generations.ts
+++ b/convex/generations.ts
@@ -1,0 +1,839 @@
+import { v } from "convex/values";
+import Replicate from "replicate";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import {
+  action,
+  internalAction,
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from "./_generated/server";
+import { getApiKey } from "./ai/encryption";
+import { getUserFriendlyErrorMessage } from "./ai/error_handlers";
+import { getAuthUserId } from "./lib/auth";
+import { scheduleRunAfter } from "./lib/scheduler";
+
+// ============================================================================
+// Queries
+// ============================================================================
+
+export const listGenerations = query({
+  args: {
+    limit: v.optional(v.number()),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      return { generations: [], continueCursor: null };
+    }
+
+    const limit = args.limit ?? 50;
+
+    const results = await ctx.db
+      .query("generations")
+      .withIndex("by_user_created", q => q.eq("userId", userId))
+      .order("desc")
+      .take(limit + 1);
+
+    const hasMore = results.length > limit;
+    const page = hasMore ? results.slice(0, limit) : results;
+
+    // Resolve storage URLs for images
+    const generations = await Promise.all(
+      page.map(async gen => {
+        let imageUrls: string[] = [];
+        if (gen.storageIds) {
+          const urls = await Promise.all(
+            gen.storageIds.map(id => ctx.storage.getUrl(id))
+          );
+          imageUrls = urls.filter((u): u is string => u !== null);
+        }
+        return { ...gen, imageUrls };
+      })
+    );
+
+    return {
+      generations,
+      continueCursor: hasMore ? page[page.length - 1]?._id : null,
+    };
+  },
+});
+
+export const getGeneration = query({
+  args: { id: v.id("generations") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      return null;
+    }
+
+    const gen = await ctx.db.get(args.id);
+    if (!gen || gen.userId !== userId) {
+      return null;
+    }
+
+    let imageUrls: string[] = [];
+    if (gen.storageIds) {
+      const urls = await Promise.all(
+        gen.storageIds.map(id => ctx.storage.getUrl(id))
+      );
+      imageUrls = urls.filter((u): u is string => u !== null);
+    }
+    return { ...gen, imageUrls };
+  },
+});
+
+// Internal query for webhook/action lookups
+export const getByReplicateId = internalQuery({
+  args: { replicateId: v.string() },
+  handler: (ctx, args) => {
+    return ctx.db
+      .query("generations")
+      .withIndex("by_replicate_id", q => q.eq("replicateId", args.replicateId))
+      .first();
+  },
+});
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+export const createGeneration = mutation({
+  args: {
+    prompt: v.string(),
+    model: v.string(),
+    provider: v.string(),
+    params: v.optional(
+      v.object({
+        aspectRatio: v.optional(v.string()),
+        width: v.optional(v.number()),
+        height: v.optional(v.number()),
+        steps: v.optional(v.number()),
+        guidanceScale: v.optional(v.number()),
+        seed: v.optional(v.number()),
+        negativePrompt: v.optional(v.string()),
+        count: v.optional(v.number()),
+        quality: v.optional(v.number()),
+      })
+    ),
+    batchId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    return ctx.db.insert("generations", {
+      userId,
+      prompt: args.prompt,
+      model: args.model,
+      provider: args.provider,
+      status: "pending",
+      params: args.params,
+      batchId: args.batchId,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+// Internal mutations for actions to update generation state
+export const updateGenerationStatus = internalMutation({
+  args: {
+    id: v.id("generations"),
+    status: v.string(),
+    replicateId: v.optional(v.string()),
+    error: v.optional(v.string()),
+    duration: v.optional(v.number()),
+    completedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const updates: Record<string, unknown> = { status: args.status };
+    if (args.replicateId !== undefined) {
+      updates.replicateId = args.replicateId;
+    }
+    if (args.error !== undefined) {
+      updates.error = args.error;
+    }
+    if (args.duration !== undefined) {
+      updates.duration = args.duration;
+    }
+    if (args.completedAt !== undefined) {
+      updates.completedAt = args.completedAt;
+    }
+    await ctx.db.patch(args.id, updates);
+  },
+});
+
+export const storeGenerationImages = internalMutation({
+  args: {
+    id: v.id("generations"),
+    storageIds: v.array(v.id("_storage")),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.id, { storageIds: args.storageIds });
+  },
+});
+
+export const deleteGeneration = mutation({
+  args: { id: v.id("generations") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const gen = await ctx.db.get(args.id);
+    if (!gen || gen.userId !== userId) {
+      throw new Error("Not found");
+    }
+
+    // Delete stored files
+    if (gen.storageIds) {
+      for (const storageId of gen.storageIds) {
+        await ctx.storage.delete(storageId);
+      }
+    }
+    await ctx.db.delete(args.id);
+  },
+});
+
+export const retryGeneration = mutation({
+  args: { id: v.id("generations") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const gen = await ctx.db.get(args.id);
+    if (!gen || gen.userId !== userId) {
+      throw new Error("Not found");
+    }
+
+    // Reset status
+    await ctx.db.patch(args.id, {
+      status: "pending",
+      error: undefined,
+      replicateId: undefined,
+      completedAt: undefined,
+      duration: undefined,
+    });
+
+    return args.id;
+  },
+});
+
+// ============================================================================
+// Actions
+// ============================================================================
+
+// Helper: convert aspect ratio to width/height (reused from replicate.ts)
+function convertAspectRatioToDimensions(aspectRatio: string): {
+  width: number;
+  height: number;
+} {
+  const baseSize = 1024;
+  const roundToMultipleOf8 = (value: number): number =>
+    Math.round(value / 8) * 8;
+
+  switch (aspectRatio) {
+    case "1:1":
+      return { width: baseSize, height: baseSize };
+    case "16:9":
+      return {
+        width: roundToMultipleOf8(baseSize * (16 / 9)),
+        height: baseSize,
+      };
+    case "9:16":
+      return {
+        width: baseSize,
+        height: roundToMultipleOf8(baseSize * (16 / 9)),
+      };
+    case "4:3":
+      return {
+        width: roundToMultipleOf8(baseSize * (4 / 3)),
+        height: baseSize,
+      };
+    case "3:4":
+      return {
+        width: baseSize,
+        height: roundToMultipleOf8(baseSize * (4 / 3)),
+      };
+    default: {
+      const [widthRatio, heightRatio] = aspectRatio.split(":").map(Number);
+      if (widthRatio && heightRatio) {
+        const ratio = widthRatio / heightRatio;
+        if (ratio > 1) {
+          return {
+            width: roundToMultipleOf8(baseSize * ratio),
+            height: baseSize,
+          };
+        }
+        return {
+          width: baseSize,
+          height: roundToMultipleOf8(baseSize / ratio),
+        };
+      }
+      return { width: baseSize, height: baseSize };
+    }
+  }
+}
+
+// Helper: detect aspect ratio support from OpenAPI schema
+function detectAspectRatioSupportFromSchema(
+  // biome-ignore lint/suspicious/noExplicitAny: Replicate model data has dynamic schema structure
+  modelData: any
+): "aspect_ratio" | "dimensions" | "none" {
+  try {
+    const inputProps =
+      modelData?.latest_version?.openapi_schema?.components?.schemas?.Input
+        ?.properties;
+    if (!inputProps || typeof inputProps !== "object") {
+      return "none";
+    }
+    if (inputProps.aspect_ratio) {
+      return "aspect_ratio";
+    }
+    if (inputProps.width || inputProps.height) {
+      return "dimensions";
+    }
+    return "none";
+  } catch {
+    return "none";
+  }
+}
+
+export const startCanvasBatch = action({
+  args: {
+    prompt: v.string(),
+    modelIds: v.array(v.string()),
+    params: v.optional(
+      v.object({
+        aspectRatio: v.optional(v.string()),
+        width: v.optional(v.number()),
+        height: v.optional(v.number()),
+        steps: v.optional(v.number()),
+        guidanceScale: v.optional(v.number()),
+        seed: v.optional(v.number()),
+        negativePrompt: v.optional(v.string()),
+        count: v.optional(v.number()),
+        quality: v.optional(v.number()),
+      })
+    ),
+    batchId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    // Create generation rows for each model
+    const generationIds: Id<"generations">[] = [];
+    for (const modelId of args.modelIds) {
+      const id = await ctx.runMutation(
+        internal.generations.internalCreateGeneration,
+        {
+          userId,
+          prompt: args.prompt,
+          model: modelId,
+          provider: "replicate",
+          params: args.params,
+          batchId: args.batchId,
+        }
+      );
+      generationIds.push(id);
+    }
+
+    // Schedule generation for each
+    for (const genId of generationIds) {
+      await scheduleRunAfter(ctx, 0, internal.generations.runCanvasGeneration, {
+        generationId: genId,
+        userId,
+      });
+    }
+
+    return { generationIds, batchId: args.batchId };
+  },
+});
+
+// Internal mutation for actions to create generation rows
+export const internalCreateGeneration = internalMutation({
+  args: {
+    userId: v.id("users"),
+    prompt: v.string(),
+    model: v.string(),
+    provider: v.string(),
+    params: v.optional(
+      v.object({
+        aspectRatio: v.optional(v.string()),
+        width: v.optional(v.number()),
+        height: v.optional(v.number()),
+        steps: v.optional(v.number()),
+        guidanceScale: v.optional(v.number()),
+        seed: v.optional(v.number()),
+        negativePrompt: v.optional(v.string()),
+        count: v.optional(v.number()),
+        quality: v.optional(v.number()),
+      })
+    ),
+    batchId: v.optional(v.string()),
+  },
+  handler: (ctx, args) => {
+    return ctx.db.insert("generations", {
+      userId: args.userId,
+      prompt: args.prompt,
+      model: args.model,
+      provider: args.provider,
+      status: "pending",
+      params: args.params,
+      batchId: args.batchId,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const runCanvasGeneration = internalAction({
+  args: {
+    generationId: v.id("generations"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    try {
+      // Get the generation record
+      const gen = await ctx.runQuery(
+        internal.generations.internalGetGeneration,
+        { id: args.generationId }
+      );
+      if (!gen) {
+        throw new Error("Generation not found");
+      }
+
+      // Get user's Replicate API key (no free model fallback for canvas)
+      const apiKey = await getApiKey(
+        ctx,
+        "replicate",
+        undefined,
+        undefined,
+        args.userId
+      );
+
+      const replicate = new Replicate({ auth: apiKey });
+
+      // Generate random seed if not provided
+      const seed = gen.params?.seed ?? Math.floor(Math.random() * 2147483647);
+
+      // Resolve model and detect schema
+      const [owner, name] = gen.model.split("/");
+      if (!(owner && name)) {
+        throw new Error("Model must be specified as 'owner/name'");
+      }
+
+      const modelData = await replicate.models.get(owner, name);
+      const latestVersion = modelData.latest_version?.id;
+      if (!latestVersion) {
+        throw new Error(`No version available for model: ${gen.model}`);
+      }
+
+      const aspectRatioMode = detectAspectRatioSupportFromSchema(modelData);
+
+      // Get schema properties for parameter mapping
+      // biome-ignore lint/suspicious/noExplicitAny: Replicate model data has dynamic OpenAPI schema
+      const modelDataAny = modelData as any;
+      const inputProps =
+        modelDataAny?.latest_version?.openapi_schema?.components?.schemas?.Input
+          ?.properties;
+      const schemaHasParam = (paramNames: string[]): string | null => {
+        if (!inputProps || typeof inputProps !== "object") {
+          return null;
+        }
+        for (const n of paramNames) {
+          if (n in inputProps) {
+            return n;
+          }
+        }
+        return null;
+      };
+
+      // Build input
+      const input: Record<string, unknown> = { prompt: gen.prompt };
+
+      // Aspect ratio / dimensions
+      if (gen.params?.aspectRatio) {
+        if (aspectRatioMode === "aspect_ratio") {
+          input.aspect_ratio = gen.params.aspectRatio;
+        } else if (aspectRatioMode === "dimensions") {
+          const dims = convertAspectRatioToDimensions(gen.params.aspectRatio);
+          input.width = dims.width;
+          input.height = dims.height;
+        } else {
+          input.aspect_ratio = gen.params.aspectRatio;
+        }
+      }
+
+      if (gen.params?.width && !gen.params?.aspectRatio) {
+        input.width = gen.params.width;
+      }
+      if (gen.params?.height && !gen.params?.aspectRatio) {
+        input.height = gen.params.height;
+      }
+
+      // Steps
+      if (gen.params?.steps) {
+        const stepsParam = schemaHasParam([
+          "num_inference_steps",
+          "steps",
+          "num_steps",
+          "inference_steps",
+          "sampling_steps",
+        ]);
+        if (stepsParam) {
+          input[stepsParam] = gen.params.steps;
+        }
+      }
+
+      // Guidance
+      if (gen.params?.guidanceScale) {
+        const guidanceParam = schemaHasParam([
+          "guidance_scale",
+          "guidance",
+          "cfg_scale",
+          "classifier_free_guidance",
+        ]);
+        if (guidanceParam) {
+          input[guidanceParam] = gen.params.guidanceScale;
+        }
+      }
+
+      input.seed = seed;
+
+      // Negative prompt
+      if (gen.params?.negativePrompt?.trim()) {
+        const negParam = schemaHasParam([
+          "negative_prompt",
+          "negative",
+          "neg_prompt",
+        ]);
+        if (negParam) {
+          input[negParam] = gen.params.negativePrompt;
+        }
+      }
+
+      // Count
+      if (gen.params?.count && gen.params.count >= 1 && gen.params.count <= 4) {
+        const countParam = schemaHasParam([
+          "num_outputs",
+          "batch_size",
+          "num_images",
+        ]);
+        if (countParam) {
+          input[countParam] = gen.params.count;
+        }
+      }
+
+      // Quality
+      if (gen.params?.quality) {
+        const qualityParam = schemaHasParam(["quality"]);
+        if (qualityParam) {
+          input[qualityParam] = gen.params.quality;
+        }
+      }
+
+      // Safety checker
+      if (inputProps && "disable_safety_checker" in inputProps) {
+        input.disable_safety_checker = true;
+      }
+
+      // Create prediction
+      const prediction = await replicate.predictions.create({
+        version: latestVersion,
+        input,
+        webhook: process.env.CONVEX_SITE_URL
+          ? `${process.env.CONVEX_SITE_URL}/webhooks/replicate`
+          : undefined,
+        webhook_events_filter: ["start", "completed"],
+      });
+
+      // Update generation with replicate ID
+      await ctx.runMutation(internal.generations.updateGenerationStatus, {
+        id: args.generationId,
+        status: prediction.status,
+        replicateId: prediction.id,
+      });
+
+      // Update params with actual seed used
+      if (seed !== gen.params?.seed) {
+        await ctx.runMutation(internal.generations.patchGenerationParams, {
+          id: args.generationId,
+          seed,
+        });
+      }
+
+      // Start polling
+      await scheduleRunAfter(
+        ctx,
+        2000,
+        internal.generations.pollCanvasGeneration,
+        {
+          generationId: args.generationId,
+          predictionId: prediction.id,
+          userId: args.userId,
+          maxAttempts: 60,
+          attempt: 1,
+        }
+      );
+    } catch (error) {
+      const friendlyError = getUserFriendlyErrorMessage(error);
+      await ctx.runMutation(internal.generations.updateGenerationStatus, {
+        id: args.generationId,
+        status: "failed",
+        error: friendlyError,
+      });
+    }
+  },
+});
+
+// Patch seed onto generation params after creation
+export const patchGenerationParams = internalMutation({
+  args: {
+    id: v.id("generations"),
+    seed: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const gen = await ctx.db.get(args.id);
+    if (!gen) {
+      return;
+    }
+    await ctx.db.patch(args.id, {
+      params: { ...gen.params, seed: args.seed },
+    });
+  },
+});
+
+// Internal query for actions
+export const internalGetGeneration = internalQuery({
+  args: { id: v.id("generations") },
+  handler: (ctx, args) => {
+    return ctx.db.get(args.id);
+  },
+});
+
+export const pollCanvasGeneration = internalAction({
+  args: {
+    generationId: v.id("generations"),
+    predictionId: v.string(),
+    userId: v.id("users"),
+    maxAttempts: v.number(),
+    attempt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    if (args.attempt > args.maxAttempts) {
+      await ctx.runMutation(internal.generations.updateGenerationStatus, {
+        id: args.generationId,
+        status: "failed",
+        error: getUserFriendlyErrorMessage(new Error("Generation timed out")),
+      });
+      return;
+    }
+
+    try {
+      // Check if already completed (e.g., by webhook)
+      const gen = await ctx.runQuery(
+        internal.generations.internalGetGeneration,
+        { id: args.generationId }
+      );
+      if (!gen) {
+        return;
+      }
+      if (
+        gen.status === "succeeded" ||
+        gen.status === "failed" ||
+        gen.status === "canceled"
+      ) {
+        return;
+      }
+      // Check if a retry replaced this prediction
+      if (gen.replicateId !== args.predictionId) {
+        return;
+      }
+
+      // Get API key
+      const apiKey = await getApiKey(
+        ctx,
+        "replicate",
+        undefined,
+        undefined,
+        args.userId
+      );
+      const replicate = new Replicate({ auth: apiKey });
+      const prediction = await replicate.predictions.get(args.predictionId);
+
+      if (prediction.status === "succeeded") {
+        await ctx.runMutation(internal.generations.updateGenerationStatus, {
+          id: args.generationId,
+          status: "succeeded",
+          duration: prediction.metrics?.predict_time,
+          completedAt: Date.now(),
+        });
+
+        // Store images
+        if (prediction.output) {
+          const imageUrls = Array.isArray(prediction.output)
+            ? prediction.output
+            : [prediction.output];
+          if (imageUrls.length > 0) {
+            await scheduleRunAfter(
+              ctx,
+              0,
+              internal.generations.storeCanvasImages,
+              {
+                generationId: args.generationId,
+                imageUrls,
+              }
+            );
+          }
+        }
+        return;
+      }
+
+      if (prediction.status === "failed") {
+        const errorMessage = prediction.error
+          ? getUserFriendlyErrorMessage(new Error(String(prediction.error)))
+          : "Generation failed";
+        await ctx.runMutation(internal.generations.updateGenerationStatus, {
+          id: args.generationId,
+          status: "failed",
+          error: errorMessage,
+        });
+        return;
+      }
+
+      if (prediction.status === "canceled") {
+        await ctx.runMutation(internal.generations.updateGenerationStatus, {
+          id: args.generationId,
+          status: "canceled",
+        });
+        return;
+      }
+
+      // Continue polling
+      const nextDelay = args.attempt <= 3 ? 2000 : 5000;
+      await scheduleRunAfter(
+        ctx,
+        nextDelay,
+        internal.generations.pollCanvasGeneration,
+        { ...args, attempt: args.attempt + 1 }
+      );
+    } catch {
+      if (args.attempt < args.maxAttempts) {
+        const retryDelay = Math.min(10000, 2000 * 2 ** (args.attempt - 1));
+        await scheduleRunAfter(
+          ctx,
+          retryDelay,
+          internal.generations.pollCanvasGeneration,
+          { ...args, attempt: args.attempt + 1 }
+        );
+      } else {
+        await ctx.runMutation(internal.generations.updateGenerationStatus, {
+          id: args.generationId,
+          status: "failed",
+          error: getUserFriendlyErrorMessage(
+            new Error("Failed to check generation status")
+          ),
+        });
+      }
+    }
+  },
+});
+
+export const storeCanvasImages = internalAction({
+  args: {
+    generationId: v.id("generations"),
+    imageUrls: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    // Check if already stored
+    const gen = await ctx.runQuery(internal.generations.internalGetGeneration, {
+      id: args.generationId,
+    });
+    if (gen?.storageIds && gen.storageIds.length > 0) {
+      return;
+    }
+
+    const storageIds: Id<"_storage">[] = [];
+
+    for (const imageUrl of args.imageUrls) {
+      try {
+        const response = await fetch(imageUrl);
+        if (!response.ok) {
+          continue;
+        }
+
+        const imageBuffer = await response.arrayBuffer();
+        const contentType =
+          response.headers.get("content-type") || "image/jpeg";
+        const blob = new globalThis.Blob([imageBuffer], { type: contentType });
+        const storageId = await ctx.storage.store(blob);
+        storageIds.push(storageId);
+      } catch (err) {
+        console.error("Failed to store canvas image", {
+          generationId: args.generationId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    if (storageIds.length > 0) {
+      await ctx.runMutation(internal.generations.storeGenerationImages, {
+        id: args.generationId,
+        storageIds,
+      });
+    }
+  },
+});
+
+// Webhook handler for canvas generations
+export const handleCanvasWebhook = internalAction({
+  args: {
+    predictionId: v.string(),
+    status: v.string(),
+    output: v.optional(v.any()),
+    error: v.optional(v.string()),
+    metadata: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const gen = await ctx.runQuery(internal.generations.getByReplicateId, {
+      replicateId: args.predictionId,
+    });
+    if (!gen) {
+      return;
+    }
+
+    await ctx.runMutation(internal.generations.updateGenerationStatus, {
+      id: gen._id,
+      status: args.status,
+      error: args.error,
+      duration: args.metadata?.predict_time,
+      completedAt:
+        args.status === "succeeded" || args.status === "failed"
+          ? Date.now()
+          : undefined,
+    });
+
+    if (args.status === "succeeded" && args.output) {
+      const imageUrls = Array.isArray(args.output)
+        ? args.output
+        : [args.output];
+      if (imageUrls.length > 0) {
+        await scheduleRunAfter(ctx, 0, internal.generations.storeCanvasImages, {
+          generationId: gen._id,
+          imageUrls,
+        });
+      }
+    }
+  },
+});

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -1016,6 +1016,40 @@ export const userFileSchema = v.object({
   generatedImagePrompt: v.optional(v.string()), // Prompt used for generation
 });
 
+// Standalone generation schema (canvas mode, decoupled from chat)
+export const generationSchema = v.object({
+  userId: v.id("users"),
+  prompt: v.string(),
+  model: v.string(), // "owner/name" format
+  provider: v.string(), // "replicate"
+  status: v.union(
+    v.literal("pending"),
+    v.literal("starting"),
+    v.literal("processing"),
+    v.literal("succeeded"),
+    v.literal("failed"),
+    v.literal("canceled"),
+  ),
+  replicateId: v.optional(v.string()),
+  storageIds: v.optional(v.array(v.id("_storage"))),
+  error: v.optional(v.string()),
+  params: v.optional(v.object({
+    aspectRatio: v.optional(v.string()),
+    width: v.optional(v.number()),
+    height: v.optional(v.number()),
+    steps: v.optional(v.number()),
+    guidanceScale: v.optional(v.number()),
+    seed: v.optional(v.number()),
+    negativePrompt: v.optional(v.string()),
+    count: v.optional(v.number()),
+    quality: v.optional(v.number()),
+  })),
+  duration: v.optional(v.number()),
+  batchId: v.optional(v.string()), // Groups multi-model generations
+  createdAt: v.number(),
+  completedAt: v.optional(v.number()),
+});
+
 // ============================================================================
 // TYPE ALIASES USING INFER
 // ============================================================================
@@ -1039,3 +1073,4 @@ export type CreateConversationArgs = Infer<typeof conversationCreationSchema>;
 export type CreatePersonaArgs = Infer<typeof personaImportSchema>;
 export type UpdateUserSettingsArgs = Infer<typeof userSettingsUpdateSchema>;
 export type CreateUserModelArgs = Infer<typeof userModelSchema>;
+export type GenerationDoc = Infer<typeof generationSchema>;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4,6 +4,7 @@ import {
   builtInImageModelSchema,
   builtInModelSchema,
   conversationSchema,
+  generationSchema,
   imageModelDefinitionSchema,
   messageFavoriteSchema,
   messageSchema,
@@ -161,6 +162,12 @@ export default defineSchema({
       dimensions: 1536,
       filterFields: ["userId"],
     }),
+
+  generations: defineTable(generationSchema)
+    .index("by_user_created", ["userId", "createdAt"])
+    .index("by_user_status", ["userId", "status", "createdAt"])
+    .index("by_replicate_id", ["replicateId"])
+    .index("by_batch", ["batchId", "createdAt"]),
 
   userFiles: defineTable(userFileSchema)
     .index("by_user_created", ["userId", "createdAt"])

--- a/src/components/canvas/canvas-generation-form.tsx
+++ b/src/components/canvas/canvas-generation-form.tsx
@@ -1,0 +1,430 @@
+import { api } from "@convex/_generated/api";
+import {
+  CaretDownIcon,
+  MagnifyingGlassIcon,
+  SparkleIcon,
+} from "@phosphor-icons/react";
+import { useAction } from "convex/react";
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useEnabledImageModels } from "@/hooks/use-enabled-image-models";
+import { cn } from "@/lib/utils";
+import { useCanvasStore } from "@/stores/canvas-store";
+
+const ASPECT_RATIOS = [
+  { value: "1:1", w: 20, h: 20 },
+  { value: "16:9", w: 24, h: 14 },
+  { value: "9:16", w: 14, h: 24 },
+  { value: "4:3", w: 22, h: 17 },
+  { value: "3:4", w: 17, h: 22 },
+];
+
+const RESOLUTION_PRESETS: {
+  label: string;
+  description: string;
+  value: number;
+}[] = [
+  { label: "Standard", description: "1K resolution", value: 25 },
+  { label: "High", description: "2K resolution", value: 50 },
+  { label: "Ultra", description: "4K resolution", value: 100 },
+];
+
+// biome-ignore lint/suspicious/noExplicitAny: image model shape from dynamic query
+type ImageModel = any;
+
+function extractOwner(modelId: string): string | null {
+  const slashIndex = modelId.indexOf("/");
+  if (slashIndex > 0) {
+    return modelId.slice(0, slashIndex);
+  }
+  return null;
+}
+
+export function CanvasGenerationForm() {
+  const prompt = useCanvasStore(s => s.prompt);
+  const setPrompt = useCanvasStore(s => s.setPrompt);
+  const selectedModelIds = useCanvasStore(s => s.selectedModelIds);
+  const toggleModel = useCanvasStore(s => s.toggleModel);
+  const aspectRatio = useCanvasStore(s => s.aspectRatio);
+  const setAspectRatio = useCanvasStore(s => s.setAspectRatio);
+  const advancedParams = useCanvasStore(s => s.advancedParams);
+  const setAdvancedParams = useCanvasStore(s => s.setAdvancedParams);
+
+  const availableModels = useEnabledImageModels();
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Filter out built-in free models (which are now disabled)
+  // biome-ignore lint/suspicious/noExplicitAny: image model shape from dynamic query
+  const models = availableModels?.filter((m: any) => !(m.isBuiltIn && m.free));
+
+  const filteredModels = models?.filter((model: ImageModel) => {
+    if (!searchQuery.trim()) {
+      return true;
+    }
+    const q = searchQuery.toLowerCase();
+    return (
+      model.name?.toLowerCase().includes(q) ||
+      model.modelId?.toLowerCase().includes(q)
+    );
+  });
+
+  const showSearch = models && models.length >= 5;
+
+  const activeQuality = advancedParams.quality ?? 25;
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      document.getElementById("canvas-generate-btn")?.click();
+    }
+  }, []);
+
+  return (
+    <div className="stack-md pb-2">
+      {/* Prompt */}
+      <div className="stack-xs">
+        <label
+          htmlFor="canvas-prompt"
+          className="text-xs font-medium text-sidebar-muted"
+        >
+          Prompt
+        </label>
+        <textarea
+          id="canvas-prompt"
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Describe the image you want to generate..."
+          className="min-h-[100px] w-full resize-y rounded-lg border border-border/50 bg-sidebar-hover p-3 text-sm text-sidebar-foreground placeholder:text-sidebar-muted/50 focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/20"
+          rows={4}
+        />
+      </div>
+
+      {/* Model selection */}
+      <div className="stack-xs">
+        <span className="text-xs font-medium text-sidebar-muted">
+          Models
+          {selectedModelIds.length > 0 && (
+            <span className="ml-1 text-sidebar-foreground/70">
+              · {selectedModelIds.length} selected
+            </span>
+          )}
+        </span>
+        {!models || models.length === 0 ? (
+          <p className="text-xs text-sidebar-muted/70">
+            No image models available. Add models in{" "}
+            <a href="/settings/models/image" className="text-primary underline">
+              Settings
+            </a>
+            .
+          </p>
+        ) : (
+          <div className="stack-xs">
+            {showSearch && (
+              <div className="relative">
+                <MagnifyingGlassIcon className="absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-sidebar-muted/60" />
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={e => setSearchQuery(e.target.value)}
+                  placeholder="Search models..."
+                  className="w-full rounded-md border border-border/40 bg-sidebar-hover py-1.5 pl-7 pr-2.5 text-xs text-sidebar-foreground placeholder:text-sidebar-muted/50 focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/20"
+                />
+              </div>
+            )}
+            <div className="max-h-[200px] overflow-y-auto scrollbar-thin">
+              {/* biome-ignore lint/suspicious/noExplicitAny: image model shape from dynamic query */}
+              {filteredModels?.map((model: any) => {
+                const isSelected = selectedModelIds.includes(model.modelId);
+                const owner = extractOwner(model.modelId);
+                return (
+                  <button
+                    key={model.modelId || model._id}
+                    type="button"
+                    className={cn(
+                      "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm transition-colors",
+                      isSelected
+                        ? "bg-primary/10"
+                        : "text-sidebar-foreground hover:bg-sidebar-hover"
+                    )}
+                    onClick={() => toggleModel(model.modelId)}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm text-sidebar-foreground">
+                        {model.name}
+                      </div>
+                      {(() => {
+                        const subtitle = model.description || owner;
+                        if (!subtitle) {
+                          return null;
+                        }
+                        return (
+                          <div className="truncate text-[11px] text-sidebar-muted/70">
+                            {subtitle}
+                          </div>
+                        );
+                      })()}
+                    </div>
+                    <div
+                      className={cn(
+                        "flex size-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
+                        isSelected
+                          ? "border-primary bg-primary"
+                          : "border-sidebar-muted/40"
+                      )}
+                    >
+                      {isSelected && (
+                        <div className="size-2 rounded-full bg-primary-foreground" />
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+              {filteredModels?.length === 0 && searchQuery.trim() && (
+                <p className="px-2.5 py-1.5 text-xs text-sidebar-muted/70">
+                  No models match "{searchQuery}"
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Aspect ratio */}
+      <div className="stack-xs">
+        <span className="text-xs font-medium text-sidebar-muted">
+          Aspect Ratio
+        </span>
+        <div className="flex gap-1.5">
+          {ASPECT_RATIOS.map(ar => {
+            const active = aspectRatio === ar.value;
+            return (
+              <button
+                key={ar.value}
+                type="button"
+                className={cn(
+                  "flex flex-1 flex-col items-center gap-1.5 rounded-lg py-2.5 transition-colors",
+                  active
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-sidebar-hover text-sidebar-muted hover:text-sidebar-foreground"
+                )}
+                onClick={() => setAspectRatio(ar.value)}
+              >
+                <div className="flex h-6 items-center justify-center">
+                  <div
+                    className={cn(
+                      "rounded-[3px] border-[1.5px]",
+                      active
+                        ? "border-primary-foreground"
+                        : "border-sidebar-muted/50"
+                    )}
+                    style={{ width: ar.w, height: ar.h }}
+                  />
+                </div>
+                <span className="text-[10px] font-medium tabular-nums">
+                  {ar.value}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Resolution */}
+      <div className="stack-xs">
+        <span className="text-xs font-medium text-sidebar-muted">
+          Resolution
+        </span>
+        <div className="flex gap-1.5">
+          {RESOLUTION_PRESETS.map(preset => (
+            <button
+              key={preset.value}
+              type="button"
+              className={cn(
+                "flex-1 rounded-lg px-3 py-1.5 text-center transition-colors",
+                activeQuality === preset.value
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-sidebar-hover text-sidebar-muted hover:text-sidebar-foreground"
+              )}
+              onClick={() => setAdvancedParams({ quality: preset.value })}
+            >
+              <div className="text-xs font-medium">{preset.label}</div>
+              <div className="text-[10px] opacity-70">{preset.description}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Advanced settings toggle */}
+      <button
+        type="button"
+        className="flex items-center gap-1.5 text-xs text-sidebar-muted transition-colors hover:text-sidebar-foreground"
+        onClick={() => setShowAdvanced(!showAdvanced)}
+      >
+        <CaretDownIcon
+          className={cn(
+            "size-3 transition-transform",
+            showAdvanced && "rotate-180"
+          )}
+        />
+        Advanced Settings
+      </button>
+
+      {showAdvanced && (
+        <div className="stack-sm rounded-lg border border-border/40 p-3">
+          {/* Steps */}
+          <div className="stack-xs">
+            <label
+              htmlFor="canvas-steps"
+              className="text-xs text-sidebar-muted"
+            >
+              Steps
+            </label>
+            <input
+              id="canvas-steps"
+              type="number"
+              min={1}
+              max={100}
+              value={advancedParams.steps ?? ""}
+              onChange={e =>
+                setAdvancedParams({
+                  steps: e.target.value ? Number(e.target.value) : undefined,
+                })
+              }
+              placeholder="Auto"
+              className="w-full rounded-md border border-border/50 bg-sidebar-hover px-2.5 py-1.5 text-sm text-sidebar-foreground"
+            />
+          </div>
+
+          {/* Guidance */}
+          <div className="stack-xs">
+            <label
+              htmlFor="canvas-guidance"
+              className="text-xs text-sidebar-muted"
+            >
+              Guidance Scale
+            </label>
+            <input
+              id="canvas-guidance"
+              type="number"
+              min={0}
+              max={30}
+              step={0.5}
+              value={advancedParams.guidanceScale ?? ""}
+              onChange={e =>
+                setAdvancedParams({
+                  guidanceScale: e.target.value
+                    ? Number(e.target.value)
+                    : undefined,
+                })
+              }
+              placeholder="Auto"
+              className="w-full rounded-md border border-border/50 bg-sidebar-hover px-2.5 py-1.5 text-sm text-sidebar-foreground"
+            />
+          </div>
+
+          {/* Seed */}
+          <div className="stack-xs">
+            <label htmlFor="canvas-seed" className="text-xs text-sidebar-muted">
+              Seed
+            </label>
+            <input
+              id="canvas-seed"
+              type="number"
+              min={0}
+              value={advancedParams.seed ?? ""}
+              onChange={e =>
+                setAdvancedParams({
+                  seed: e.target.value ? Number(e.target.value) : undefined,
+                })
+              }
+              placeholder="Random"
+              className="w-full rounded-md border border-border/50 bg-sidebar-hover px-2.5 py-1.5 text-sm text-sidebar-foreground"
+            />
+          </div>
+
+          {/* Negative prompt */}
+          <div className="stack-xs">
+            <label
+              htmlFor="canvas-neg-prompt"
+              className="text-xs text-sidebar-muted"
+            >
+              Negative Prompt
+            </label>
+            <textarea
+              id="canvas-neg-prompt"
+              value={advancedParams.negativePrompt ?? ""}
+              onChange={e =>
+                setAdvancedParams({
+                  negativePrompt: e.target.value || undefined,
+                })
+              }
+              placeholder="Things to avoid..."
+              className="w-full resize-y rounded-md border border-border/50 bg-sidebar-hover px-2.5 py-1.5 text-sm text-sidebar-foreground"
+              rows={2}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CanvasGenerateButton() {
+  const prompt = useCanvasStore(s => s.prompt);
+  const selectedModelIds = useCanvasStore(s => s.selectedModelIds);
+  const aspectRatio = useCanvasStore(s => s.aspectRatio);
+  const advancedParams = useCanvasStore(s => s.advancedParams);
+  const resetForm = useCanvasStore(s => s.resetForm);
+
+  const startBatch = useAction(api.generations.startCanvasBatch);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const canGenerate =
+    prompt.trim().length > 0 && selectedModelIds.length > 0 && !isGenerating;
+
+  const handleGenerate = useCallback(async () => {
+    if (!canGenerate) {
+      return;
+    }
+    setIsGenerating(true);
+    try {
+      const batchId = crypto.randomUUID();
+      await startBatch({
+        prompt: prompt.trim(),
+        modelIds: selectedModelIds,
+        params: {
+          aspectRatio,
+          ...advancedParams,
+        },
+        batchId,
+      });
+      resetForm();
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [
+    canGenerate,
+    prompt,
+    selectedModelIds,
+    aspectRatio,
+    advancedParams,
+    startBatch,
+    resetForm,
+  ]);
+
+  return (
+    <Button
+      id="canvas-generate-btn"
+      className="w-full gap-2"
+      disabled={!canGenerate}
+      onClick={handleGenerate}
+    >
+      <SparkleIcon className="size-4" />
+      {isGenerating
+        ? "Generating..."
+        : `Generate${selectedModelIds.length > 1 ? ` · ${selectedModelIds.length} models` : ""}`}
+    </Button>
+  );
+}

--- a/src/components/canvas/canvas-grid-card.tsx
+++ b/src/components/canvas/canvas-grid-card.tsx
@@ -1,0 +1,168 @@
+import { api } from "@convex/_generated/api";
+import { ArrowClockwiseIcon } from "@phosphor-icons/react";
+import { useMutation } from "convex/react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import type { CanvasImage } from "@/types";
+
+type CanvasGridCardProps = {
+  image: CanvasImage;
+  onClick?: () => void;
+};
+
+export function CanvasGridCard({ image, onClick }: CanvasGridCardProps) {
+  // Pending/processing states
+  if (
+    image.status === "pending" ||
+    image.status === "starting" ||
+    image.status === "processing"
+  ) {
+    return <PendingCard image={image} />;
+  }
+
+  // Failed state
+  if (image.status === "failed" || image.status === "canceled") {
+    return <FailedCard image={image} />;
+  }
+
+  // Succeeded state
+  return <SucceededCard image={image} onClick={onClick} />;
+}
+
+function PendingCard({ image }: { image: CanvasImage }) {
+  return (
+    <div className="relative overflow-hidden rounded-lg border border-border/40 bg-muted/30">
+      <div
+        className="animate-pulse bg-muted/50"
+        style={{ aspectRatio: formatAspectRatio(image.aspectRatio) }}
+      />
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4">
+        <Spinner />
+        <span className="text-xs font-medium text-muted-foreground">
+          {formatModelName(image.model)}
+        </span>
+        {image.prompt && (
+          <p className="line-clamp-2 text-center text-xs text-muted-foreground/70">
+            {image.prompt}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FailedCard({ image }: { image: CanvasImage }) {
+  const retryGeneration = useMutation(api.generations.retryGeneration);
+  const [isRetrying, setIsRetrying] = useState(false);
+
+  const handleRetry = async () => {
+    if (!image.generationId) {
+      return;
+    }
+    setIsRetrying(true);
+    try {
+      await retryGeneration({ id: image.generationId });
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  return (
+    <div className="relative overflow-hidden rounded-lg border border-destructive/30 bg-destructive/5">
+      <div style={{ aspectRatio: formatAspectRatio(image.aspectRatio) }} />
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
+        <span className="text-xs font-medium text-destructive">
+          {image.status === "canceled" ? "Canceled" : "Failed"}
+        </span>
+        {image.model && (
+          <span className="text-xs text-muted-foreground">
+            {formatModelName(image.model)}
+          </span>
+        )}
+        {image.generationId && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRetry}
+            disabled={isRetrying}
+            className="gap-1.5"
+          >
+            <ArrowClockwiseIcon className="size-3.5" />
+            Retry
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SucceededCard({
+  image,
+  onClick,
+}: {
+  image: CanvasImage;
+  onClick?: () => void;
+}) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <div
+      className="group relative overflow-hidden rounded-lg border border-border/40 bg-muted/30 transition-shadow hover:shadow-md cursor-zoom-in"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onClick={onClick}
+      onKeyDown={e => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
+      tabIndex={0}
+      role="button"
+    >
+      <img
+        src={image.imageUrl}
+        alt={image.prompt || "Generated image"}
+        className="block w-full"
+        loading="lazy"
+      />
+      {/* Hover overlay */}
+      {isHovered && (
+        <div className="absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/70 via-black/20 to-transparent p-3">
+          {image.prompt && (
+            <p className="line-clamp-3 text-xs text-white/90">{image.prompt}</p>
+          )}
+          <div className="mt-1.5 flex items-center gap-2 text-[10px] text-white/60">
+            {image.model && <span>{formatModelName(image.model)}</span>}
+            {image.seed !== undefined && <span>Seed: {image.seed}</span>}
+            {image.duration !== undefined && (
+              <span>{image.duration.toFixed(1)}s</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Converts "16:9" → "16/9" for CSS aspect-ratio, defaults to "1/1". */
+function formatAspectRatio(ratio?: string): string {
+  if (!ratio) {
+    return "1/1";
+  }
+  const [w, h] = ratio.split(":").map(Number);
+  if (w && h) {
+    return `${w}/${h}`;
+  }
+  return "1/1";
+}
+
+function formatModelName(model?: string): string {
+  if (!model) {
+    return "";
+  }
+  // "owner/name" → "name"
+  const parts = model.split("/");
+  return parts[parts.length - 1] || model;
+}

--- a/src/components/canvas/canvas-image-viewer.tsx
+++ b/src/components/canvas/canvas-image-viewer.tsx
@@ -1,0 +1,212 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { CaretLeftIcon, CaretRightIcon, XIcon } from "@phosphor-icons/react";
+import { useCallback, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import type { CanvasImage } from "@/types";
+
+type CanvasImageViewerProps = {
+  images: CanvasImage[];
+  currentIndex: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onIndexChange: (index: number) => void;
+};
+
+export function CanvasImageViewer({
+  images,
+  currentIndex,
+  open,
+  onOpenChange,
+  onIndexChange,
+}: CanvasImageViewerProps) {
+  const image = images[currentIndex];
+
+  const goToPrevious = useCallback(() => {
+    if (images.length === 0) {
+      return;
+    }
+    onIndexChange(currentIndex > 0 ? currentIndex - 1 : images.length - 1);
+  }, [currentIndex, images.length, onIndexChange]);
+
+  const goToNext = useCallback(() => {
+    if (images.length === 0) {
+      return;
+    }
+    onIndexChange(currentIndex < images.length - 1 ? currentIndex + 1 : 0);
+  }, [currentIndex, images.length, onIndexChange]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      switch (event.key) {
+        case "ArrowLeft": {
+          event.preventDefault();
+          goToPrevious();
+          break;
+        }
+        case "ArrowRight": {
+          event.preventDefault();
+          goToNext();
+          break;
+        }
+        case "Escape": {
+          event.preventDefault();
+          onOpenChange(false);
+          break;
+        }
+        case "Home": {
+          event.preventDefault();
+          onIndexChange(0);
+          break;
+        }
+        case "End": {
+          event.preventDefault();
+          onIndexChange(images.length - 1);
+          break;
+        }
+        default:
+          break;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () =>
+      document.removeEventListener("keydown", handleKeyDown, { capture: true });
+  }, [
+    open,
+    goToPrevious,
+    goToNext,
+    onOpenChange,
+    onIndexChange,
+    images.length,
+  ]);
+
+  if (!image) {
+    return null;
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        {/* Backdrop */}
+        <Dialog.Backdrop
+          className="fixed inset-0 z-modal bg-background/95 backdrop-blur-lg
+                     data-[state=open]:animate-in data-[state=closed]:animate-out
+                     data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
+                     data-[open]:animate-in data-[closed]:animate-out
+                     data-[closed]:fade-out-0 data-[open]:fade-in-0
+                     [animation-duration:200ms]"
+        />
+
+        {/* Full-screen popup container */}
+        <Dialog.Popup
+          className="fixed inset-0 z-modal flex items-center justify-center focus:outline-none"
+          aria-label={`Image viewer: ${image.prompt || "Generated image"}`}
+        >
+          {/* Close button */}
+          <Button
+            variant="ghost"
+            size="lg"
+            onClick={e => {
+              e.stopPropagation();
+              onOpenChange(false);
+            }}
+            className="absolute right-4 top-4 z-20 h-10 w-10 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md hover:bg-card transition-colors duration-200"
+            aria-label="Close"
+          >
+            <XIcon className="size-5" />
+          </Button>
+
+          {/* Navigation buttons */}
+          {images.length > 1 && (
+            <>
+              <Button
+                variant="ghost"
+                size="lg"
+                onClick={e => {
+                  e.stopPropagation();
+                  goToPrevious();
+                }}
+                className="absolute left-4 top-1/2 -translate-y-1/2 z-10 h-12 w-12 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md hover:bg-card transition-colors duration-200"
+                aria-label="Previous image"
+              >
+                <CaretLeftIcon className="size-6" />
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="lg"
+                onClick={e => {
+                  e.stopPropagation();
+                  goToNext();
+                }}
+                className="absolute right-4 top-1/2 -translate-y-1/2 z-10 h-12 w-12 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md hover:bg-card transition-colors duration-200"
+                aria-label="Next image"
+              >
+                <CaretRightIcon className="size-6" />
+              </Button>
+            </>
+          )}
+
+          {/* Counter pill */}
+          {images.length > 1 && (
+            <div className="absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-card/90 px-3 py-1.5 text-xs font-medium tabular-nums text-muted-foreground shadow-lg backdrop-blur-md dark:ring-1 dark:ring-white/[0.06]">
+              {currentIndex + 1} / {images.length}
+            </div>
+          )}
+
+          {/* Image + clickable backdrop area */}
+          <div
+            className="flex h-full w-full items-center justify-center p-8"
+            onClick={() => onOpenChange(false)}
+            onKeyDown={e => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onOpenChange(false);
+              }
+            }}
+          >
+            <div className="flex h-full w-full max-w-7xl flex-col items-center justify-center gap-4 pointer-events-none transition-all duration-300 ease-out animate-in fade-in-0 zoom-in-95">
+              {/* Image */}
+              <img
+                key={image.id}
+                src={image.imageUrl}
+                alt={image.prompt || "Generated image"}
+                className="max-h-[calc(100%-4rem)] max-w-full object-contain pointer-events-auto rounded-lg drop-shadow-2xl"
+                draggable={false}
+                onClick={e => e.stopPropagation()}
+                onKeyDown={e => e.stopPropagation()}
+                tabIndex={-1}
+              />
+
+              {/* Info bar */}
+              <div className="pointer-events-auto flex max-w-2xl items-center gap-3 rounded-full bg-card/90 px-4 py-2 shadow-lg backdrop-blur-md dark:ring-1 dark:ring-white/[0.06]">
+                {image.prompt && (
+                  <p className="line-clamp-1 text-xs text-foreground/80">
+                    {image.prompt}
+                  </p>
+                )}
+                <div className="flex shrink-0 items-center gap-2 text-[10px] text-muted-foreground">
+                  {image.model && <span>{formatModelName(image.model)}</span>}
+                  {image.seed !== undefined && <span>Seed: {image.seed}</span>}
+                  {image.duration !== undefined && (
+                    <span>{image.duration.toFixed(1)}s</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function formatModelName(model: string): string {
+  const parts = model.split("/");
+  return parts[parts.length - 1] || model;
+}

--- a/src/components/canvas/canvas-masonry-grid.tsx
+++ b/src/components/canvas/canvas-masonry-grid.tsx
@@ -1,0 +1,167 @@
+import { api } from "@convex/_generated/api";
+import { useQuery } from "convex/react";
+import { useRef, useState } from "react";
+import { useBreakpointColumns } from "@/hooks/use-breakpoint-columns";
+import type { CanvasFilterMode } from "@/stores/canvas-store";
+import type { CanvasImage } from "@/types";
+import { CanvasGridCard } from "./canvas-grid-card";
+import { CanvasImageViewer } from "./canvas-image-viewer";
+
+type CanvasMasonryGridProps = {
+  filterMode: CanvasFilterMode;
+};
+
+export function CanvasMasonryGrid({ filterMode }: CanvasMasonryGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const columnCount = useBreakpointColumns(containerRef);
+
+  // Canvas generations
+  const canvasData = useQuery(
+    api.generations.listGenerations,
+    filterMode !== "conversations" ? {} : "skip"
+  );
+
+  // Conversation images
+  const conversationImages = useQuery(
+    api.fileStorage.listGeneratedImages,
+    filterMode !== "canvas" ? {} : "skip"
+  );
+
+  // Merge and normalize both sources
+  const allImages: CanvasImage[] = [];
+
+  if (filterMode !== "conversations" && canvasData?.generations) {
+    for (const gen of canvasData.generations) {
+      if (gen.status === "succeeded" && gen.imageUrls.length > 0) {
+        // Create one CanvasImage per output image
+        for (const url of gen.imageUrls) {
+          allImages.push({
+            id: `canvas-${gen._id}-${url}`,
+            source: "canvas",
+            imageUrl: url,
+            prompt: gen.prompt,
+            model: gen.model,
+            status: gen.status,
+            seed: gen.params?.seed,
+            duration: gen.duration,
+            createdAt: gen.createdAt,
+            aspectRatio: gen.params?.aspectRatio,
+            generationId: gen._id,
+            batchId: gen.batchId,
+          });
+        }
+      } else {
+        // Pending/failed — show as placeholder
+        allImages.push({
+          id: `canvas-${gen._id}`,
+          source: "canvas",
+          imageUrl: "",
+          prompt: gen.prompt,
+          model: gen.model,
+          status: gen.status,
+          seed: gen.params?.seed,
+          duration: gen.duration,
+          createdAt: gen.createdAt,
+          aspectRatio: gen.params?.aspectRatio,
+          generationId: gen._id,
+          batchId: gen.batchId,
+        });
+      }
+    }
+  }
+
+  if (filterMode !== "canvas" && conversationImages) {
+    for (const file of conversationImages) {
+      if (file.url) {
+        allImages.push({
+          id: `conv-${file._id}`,
+          source: "conversation",
+          imageUrl: file.url,
+          prompt: file.generatedImagePrompt,
+          model: file.generatedImageModel,
+          status: "succeeded",
+          createdAt: file.createdAt,
+          messageId: file.messageId,
+          conversationId: file.conversationId,
+        });
+      }
+    }
+  }
+
+  // Sort by createdAt desc
+  allImages.sort((a, b) => b.createdAt - a.createdAt);
+
+  // Viewer state
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const [viewerIndex, setViewerIndex] = useState(0);
+
+  // Only succeeded images with URLs are viewable
+  const succeededImages = allImages.filter(
+    img => img.status === "succeeded" && img.imageUrl
+  );
+
+  const handleImageClick = (image: CanvasImage) => {
+    const idx = succeededImages.findIndex(img => img.id === image.id);
+    if (idx >= 0) {
+      setViewerIndex(idx);
+      setViewerOpen(true);
+    }
+  };
+
+  if (allImages.length === 0) {
+    return (
+      <div
+        ref={containerRef}
+        className="flex h-full items-center justify-center text-muted-foreground"
+      >
+        <p className="text-sm">
+          {filterMode === "conversations"
+            ? "No conversation images yet."
+            : "No images yet. Generate your first image!"}
+        </p>
+      </div>
+    );
+  }
+
+  // Distribute items row-major across columns so newest items
+  // land top-left and read left-to-right, row by row.
+  const columns: CanvasImage[][] = Array.from(
+    { length: columnCount },
+    () => []
+  );
+  for (let i = 0; i < allImages.length; i++) {
+    const image = allImages[i];
+    if (image) {
+      columns[i % columnCount]?.push(image);
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="flex items-start gap-4">
+      {columns.map((col, colIdx) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: stable column layout, index is the only meaningful key
+        <div key={colIdx} className="flex flex-1 flex-col gap-4">
+          {col.map(image => (
+            <CanvasGridCard
+              key={image.id}
+              image={image}
+              onClick={
+                image.status === "succeeded" && image.imageUrl
+                  ? () => handleImageClick(image)
+                  : undefined
+              }
+            />
+          ))}
+        </div>
+      ))}
+
+      <CanvasImageViewer
+        images={succeededImages}
+        currentIndex={viewerIndex}
+        open={viewerOpen}
+        onOpenChange={setViewerOpen}
+        onIndexChange={setViewerIndex}
+      />
+    </div>
+  );
+}

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -1,4 +1,5 @@
 import { api } from "@convex/_generated/api";
+import { ImagesSquareIcon } from "@phosphor-icons/react";
 import { useQuery } from "convex/react";
 import {
   AnimatePresence,
@@ -470,6 +471,23 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
                       </Button>
                     </Link>
                   )}
+
+                  <Link to={ROUTES.CANVAS}>
+                    <Button
+                      size="icon-sm"
+                      title="Canvas"
+                      variant="ghost"
+                      className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover h-8 w-8"
+                    >
+                      <ImagesSquareIcon
+                        className={cn(
+                          "size-4.5",
+                          location.pathname === ROUTES.CANVAS &&
+                            "[&_path]:fill-current"
+                        )}
+                      />
+                    </Button>
+                  </Link>
 
                   <Link to={ROUTES.HOME}>
                     <Button

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -54,6 +54,7 @@ export { useSpeechInputContext } from "./use-speech-input-context";
 // Model Hooks
 // =============================================================================
 
+export { useBreakpointColumns } from "./use-breakpoint-columns";
 export { useConversationModelOverride } from "./use-conversation-model-override";
 export { useEnabledImageModels } from "./use-enabled-image-models";
 export { useLastGeneratedImageSeed } from "./use-last-generated-image-seed";

--- a/src/hooks/use-breakpoint-columns.ts
+++ b/src/hooks/use-breakpoint-columns.ts
@@ -1,0 +1,42 @@
+import { type RefObject, useEffect, useState } from "react";
+
+const BREAKPOINTS = [
+  { minWidth: 1280, columns: 4 }, // xl
+  { minWidth: 1024, columns: 3 }, // lg
+  { minWidth: 640, columns: 2 }, // sm
+];
+const DEFAULT_COLUMNS = 1;
+
+/**
+ * Returns a responsive column count based on the observed width
+ * of a container element, matching Tailwind's sm/lg/xl breakpoints.
+ */
+export function useBreakpointColumns(
+  ref: RefObject<HTMLElement | null>
+): number {
+  const [columns, setColumns] = useState(DEFAULT_COLUMNS);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    const observer = new ResizeObserver(entries => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      let next = DEFAULT_COLUMNS;
+      for (const bp of BREAKPOINTS) {
+        if (width >= bp.minWidth) {
+          next = bp.columns;
+          break;
+        }
+      }
+      setColumns(next);
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return columns;
+}

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -24,6 +24,9 @@ export const CACHE_KEYS = {
   anonymousUserGraduation: "anonymous-user-graduation",
   anonymousGraduationToken: "anonymous-graduation-token",
   colorScheme: "color-scheme",
+  canvasPanelWidth: "canvas-panel-width",
+  canvasSelections: "canvas-selections",
+  canvasPanelVisible: "canvas-panel-visible",
 } as const;
 
 export type CacheKey = (typeof CACHE_KEYS)[keyof typeof CACHE_KEYS];

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -19,6 +19,7 @@ export const ROUTES = {
     PERSONAS_NEW: "/settings/personas/new",
     PERSONAS_EDIT: (id: string) => `/settings/personas/${id}/edit`,
   },
+  CANVAS: "/canvas",
   FAVORITES: "/chat/favorites",
   NOT_FOUND: "/404",
 } as const;

--- a/src/pages/canvas-page.tsx
+++ b/src/pages/canvas-page.tsx
@@ -1,0 +1,213 @@
+import { ArrowLeftIcon } from "@phosphor-icons/react";
+import { useCallback } from "react";
+import { Link } from "react-router-dom";
+import { PanelLeftIcon } from "@/components/animate-ui/icons/panel-left";
+import {
+  CanvasGenerateButton,
+  CanvasGenerationForm,
+} from "@/components/canvas/canvas-generation-form";
+import { CanvasMasonryGrid } from "@/components/canvas/canvas-masonry-grid";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { useReplicateApiKey } from "@/hooks/use-replicate-api-key";
+import { ROUTES } from "@/lib/routes";
+import type { CanvasFilterMode } from "@/stores/canvas-store";
+import { useCanvasStore } from "@/stores/canvas-store";
+
+function CanvasGateCheck({ children }: { children: React.ReactNode }) {
+  const { hasReplicateApiKey, isLoading } = useReplicateApiKey();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[100dvh] items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!hasReplicateApiKey) {
+    return (
+      <div className="flex h-[100dvh] items-center justify-center">
+        <div className="mx-auto max-w-md text-center stack-md">
+          <h2 className="text-lg font-semibold">Replicate API Key Required</h2>
+          <p className="text-sm text-muted-foreground">
+            Canvas mode uses your Replicate API key for image generation. Add
+            your key in settings to get started.
+          </p>
+          <div className="flex items-center justify-center gap-3">
+            <Link to={ROUTES.HOME}>
+              <Button variant="ghost" size="sm">
+                Back to Chat
+              </Button>
+            </Link>
+            <Link to={ROUTES.SETTINGS.API_KEYS}>
+              <Button size="sm">Add API Key</Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+const FILTER_OPTIONS: { label: string; value: CanvasFilterMode }[] = [
+  { label: "All", value: "all" },
+  { label: "Canvas", value: "canvas" },
+  { label: "Conversations", value: "conversations" },
+];
+
+export default function CanvasPage() {
+  const filterMode = useCanvasStore(s => s.filterMode);
+  const setFilterMode = useCanvasStore(s => s.setFilterMode);
+  const panelWidth = useCanvasStore(s => s.panelWidth);
+  const setPanelWidth = useCanvasStore(s => s.setPanelWidth);
+  const setIsResizing = useCanvasStore(s => s.setIsResizing);
+  const resetPanelWidth = useCanvasStore(s => s.resetPanelWidth);
+  const isPanelVisible = useCanvasStore(s => s.isPanelVisible);
+  const togglePanel = useCanvasStore(s => s.togglePanel);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsResizing(true);
+
+      const startX = e.clientX;
+      const startWidth = panelWidth;
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        const deltaX = moveEvent.clientX - startX;
+        setPanelWidth(startWidth + deltaX);
+      };
+
+      const handleMouseUp = () => {
+        setIsResizing(false);
+        document.documentElement.classList.remove("select-none");
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.documentElement.classList.add("select-none");
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [panelWidth, setPanelWidth, setIsResizing]
+  );
+
+  const handleDoubleClick = useCallback(() => {
+    resetPanelWidth();
+  }, [resetPanelWidth]);
+
+  return (
+    <CanvasGateCheck>
+      <div className="flex h-[100dvh] bg-background">
+        {/* Expand zone when panel is hidden */}
+        {!isPanelVisible && (
+          <button
+            type="button"
+            aria-label="Expand panel"
+            className="fixed inset-y-0 left-0 z-sidebar w-5 cursor-e-resize bg-transparent transition-colors duration-200 hover:bg-muted/40"
+            onClick={togglePanel}
+          />
+        )}
+
+        {/* Side panel (left) — matches main sidebar styling */}
+        <aside
+          className="relative flex flex-col shrink-0 bg-sidebar dark:bg-sidebar border-r border-border/40 transition-[width] duration-300 ease-out overflow-hidden"
+          style={{ width: isPanelVisible ? panelWidth : 0 }}
+        >
+          {/* Panel header — mirrors sidebar header structure */}
+          <div className="shrink-0 py-4 px-3">
+            <div className="flex items-center justify-between mb-4 pl-2 pr-2">
+              <div className="flex items-center gap-2">
+                <Link
+                  className="group flex items-center gap-2 text-sidebar-foreground/90 hover:text-sidebar-foreground transition-colors"
+                  to={ROUTES.HOME}
+                >
+                  <ArrowLeftIcon className="size-4.5" />
+                  <span className="font-semibold text-sm tracking-tight">
+                    Canvas
+                  </span>
+                </Link>
+              </div>
+
+              <div className="flex items-center gap-1">
+                <Button
+                  size="icon-sm"
+                  title="Collapse panel"
+                  variant="ghost"
+                  className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover h-8 w-8"
+                  onClick={togglePanel}
+                >
+                  <PanelLeftIcon animateOnHover className="size-4.5" />
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-3 scrollbar-thin min-h-0">
+            <CanvasGenerationForm />
+          </div>
+
+          {/* Fixed generate button footer */}
+          <div className="shrink-0 border-t border-border/40 px-3 py-3">
+            <CanvasGenerateButton />
+          </div>
+
+          {/* Resize handle */}
+          {isPanelVisible && (
+            <div
+              className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/10 active:bg-primary/20 transition-colors z-10 group"
+              onMouseDown={handleResizeStart}
+              onDoubleClick={handleDoubleClick}
+            >
+              <div className="absolute right-0 top-0 bottom-0 w-[1px] bg-transparent group-hover:bg-border/50 transition-colors" />
+            </div>
+          )}
+        </aside>
+
+        {/* Main content area */}
+        <div className="flex flex-1 flex-col min-w-0">
+          {/* Header */}
+          <header className="flex items-center gap-3 border-b border-border/40 px-4 py-3 shrink-0">
+            {/* Show expand button when panel is hidden */}
+            {!isPanelVisible && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground hover:text-foreground"
+                onClick={togglePanel}
+              >
+                <PanelLeftIcon className="size-4" />
+              </Button>
+            )}
+
+            {/* Filter toggle — left side */}
+            <div className="flex items-center gap-1 rounded-lg bg-muted/50 p-0.5">
+              {FILTER_OPTIONS.map(opt => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                    filterMode === opt.value
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                  onClick={() => setFilterMode(opt.value)}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </header>
+
+          {/* Masonry grid */}
+          <div className="flex-1 overflow-y-auto p-4">
+            <CanvasMasonryGrid filterMode={filterMode} />
+          </div>
+        </div>
+      </div>
+    </CanvasGateCheck>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -52,6 +52,7 @@ const SettingsNewPersonaPage = lazy(
 const SettingsEditPersonaPage = lazy(
   () => import("./pages/settings/edit-persona-page")
 );
+const CanvasPage = lazy(() => import("./pages/canvas-page"));
 const SignOutPage = lazy(() => import("./pages/sign-out-page"));
 
 const PageLoader = ({
@@ -133,6 +134,15 @@ export const routes: RouteObject[] = [
             ),
           },
         ],
+      },
+      {
+        path: "canvas",
+        element: (
+          <ProtectedSuspense fallback={<PageLoader size="full" />}>
+            <CanvasPage />
+          </ProtectedSuspense>
+        ),
+        errorElement: routeErrorElement,
       },
       {
         path: "signout",

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -1,0 +1,190 @@
+import { devtools } from "zustand/middleware";
+import { shallow } from "zustand/shallow";
+import { useStoreWithEqualityFn } from "zustand/traditional";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { CACHE_KEYS, get, set } from "@/lib/local-storage";
+
+export type CanvasFilterMode = "all" | "canvas" | "conversations";
+
+const MIN_PANEL_WIDTH = 300;
+const MAX_PANEL_WIDTH = 520;
+const DEFAULT_PANEL_WIDTH = 380;
+
+type CanvasSelections = {
+  selectedModelIds: string[];
+  aspectRatio: string;
+  quality: number | undefined;
+  filterMode: CanvasFilterMode;
+};
+
+export type CanvasState = {
+  selectedModelIds: string[];
+  prompt: string;
+  aspectRatio: string;
+  advancedParams: {
+    steps?: number;
+    guidanceScale?: number;
+    seed?: number;
+    negativePrompt?: string;
+    count?: number;
+    quality?: number;
+  };
+  filterMode: CanvasFilterMode;
+  panelWidth: number;
+  isResizing: boolean;
+  isPanelVisible: boolean;
+
+  // Actions
+  toggleModel: (modelId: string) => void;
+  setSelectedModelIds: (ids: string[]) => void;
+  setPrompt: (prompt: string) => void;
+  setAspectRatio: (ratio: string) => void;
+  setAdvancedParams: (params: Partial<CanvasState["advancedParams"]>) => void;
+  setFilterMode: (mode: CanvasFilterMode) => void;
+  setPanelWidth: (width: number) => void;
+  setIsResizing: (resizing: boolean) => void;
+  resetPanelWidth: () => void;
+  resetForm: () => void;
+  togglePanel: () => void;
+};
+
+type CanvasStoreApi = StoreApi<CanvasState>;
+
+function getInitialPanelWidth(): number {
+  if (typeof window === "undefined") {
+    return DEFAULT_PANEL_WIDTH;
+  }
+  const saved = get(CACHE_KEYS.canvasPanelWidth, DEFAULT_PANEL_WIDTH);
+  return Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH, saved));
+}
+
+function getInitialSelections(): Partial<CanvasSelections> {
+  if (typeof window === "undefined") {
+    return {};
+  }
+  return get<Partial<CanvasSelections>>(CACHE_KEYS.canvasSelections, {});
+}
+
+function getInitialPanelVisible(): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+  return get(CACHE_KEYS.canvasPanelVisible, true);
+}
+
+function persistSelections(get_: CanvasStoreApi["getState"]) {
+  const state = get_();
+  const selections: CanvasSelections = {
+    selectedModelIds: state.selectedModelIds,
+    aspectRatio: state.aspectRatio,
+    quality: state.advancedParams.quality,
+    filterMode: state.filterMode,
+  };
+  set(CACHE_KEYS.canvasSelections, selections);
+}
+
+const savedSelections = getInitialSelections();
+
+const INITIAL_STATE = {
+  selectedModelIds: savedSelections.selectedModelIds ?? ([] as string[]),
+  prompt: "",
+  aspectRatio: savedSelections.aspectRatio ?? "1:1",
+  advancedParams:
+    savedSelections.quality !== undefined
+      ? { quality: savedSelections.quality }
+      : {},
+  filterMode: savedSelections.filterMode ?? ("all" as CanvasFilterMode),
+  panelWidth: getInitialPanelWidth(),
+  isResizing: false,
+  isPanelVisible: getInitialPanelVisible(),
+};
+
+function createCanvasState(
+  set_: CanvasStoreApi["setState"],
+  get_: CanvasStoreApi["getState"]
+): CanvasState {
+  return {
+    ...INITIAL_STATE,
+
+    toggleModel: modelId => {
+      const current = get_().selectedModelIds;
+      if (current.includes(modelId)) {
+        set_({ selectedModelIds: current.filter(id => id !== modelId) });
+      } else {
+        set_({ selectedModelIds: [...current, modelId] });
+      }
+      persistSelections(get_);
+    },
+
+    setSelectedModelIds: ids => {
+      set_({ selectedModelIds: ids });
+      persistSelections(get_);
+    },
+    setPrompt: prompt => set_({ prompt }),
+    setAspectRatio: ratio => {
+      set_({ aspectRatio: ratio });
+      persistSelections(get_);
+    },
+    setAdvancedParams: params => {
+      set_({ advancedParams: { ...get_().advancedParams, ...params } });
+      persistSelections(get_);
+    },
+    setFilterMode: mode => {
+      set_({ filterMode: mode });
+      persistSelections(get_);
+    },
+    setPanelWidth: width => {
+      const clamped = Math.max(
+        MIN_PANEL_WIDTH,
+        Math.min(MAX_PANEL_WIDTH, width)
+      );
+      set_({ panelWidth: clamped });
+      set(CACHE_KEYS.canvasPanelWidth, clamped);
+    },
+    setIsResizing: resizing => set_({ isResizing: resizing }),
+    resetPanelWidth: () => {
+      set_({ panelWidth: DEFAULT_PANEL_WIDTH });
+      set(CACHE_KEYS.canvasPanelWidth, DEFAULT_PANEL_WIDTH);
+    },
+    resetForm: () =>
+      set_({
+        prompt: "",
+        advancedParams: {},
+      }),
+    togglePanel: () => {
+      const next = !get_().isPanelVisible;
+      set_({ isPanelVisible: next });
+      set(CACHE_KEYS.canvasPanelVisible, next);
+    },
+  };
+}
+
+export const createCanvasStore = () =>
+  createStore<CanvasState>()(
+    devtools((s, g) => createCanvasState(s, g), {
+      name: "CanvasStore",
+    })
+  );
+
+const canvasStoreApi: CanvasStoreApi = createCanvasStore();
+
+type CanvasSelector<T> = (state: CanvasState) => T;
+
+function useCanvasStoreBase<T>(
+  selector: CanvasSelector<T>,
+  equalityFn?: (a: T, b: T) => boolean
+): T {
+  return useStoreWithEqualityFn(
+    canvasStoreApi,
+    selector,
+    equalityFn ?? shallow
+  );
+}
+
+export const useCanvasStore = Object.assign(useCanvasStoreBase, {
+  getState: () => canvasStoreApi.getState(),
+  setState: (...args: Parameters<CanvasStoreApi["setState"]>) =>
+    canvasStoreApi.setState(...args),
+  subscribe: (...args: Parameters<CanvasStoreApi["subscribe"]>) =>
+    canvasStoreApi.subscribe(...args),
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -396,6 +396,38 @@ export type ExportData = {
 };
 
 // ============================================================================
+// CANVAS / GENERATION TYPES
+// ============================================================================
+
+export type GenerationStatus =
+  | "pending"
+  | "starting"
+  | "processing"
+  | "succeeded"
+  | "failed"
+  | "canceled";
+
+/** Unified image type for the "All Images" merged view in canvas mode. */
+export type CanvasImage = {
+  id: string;
+  source: "canvas" | "conversation";
+  imageUrl: string;
+  prompt?: string;
+  model?: string;
+  status: GenerationStatus;
+  seed?: number;
+  duration?: number;
+  createdAt: number;
+  aspectRatio?: string;
+  // Canvas-specific
+  generationId?: Id<"generations">;
+  batchId?: string;
+  // Conversation-specific
+  messageId?: Id<"messages">;
+  conversationId?: ConversationId;
+};
+
+// ============================================================================
 // ROUTE TYPES
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Adds a standalone **Canvas** page (`/canvas`) for generating and browsing AI-generated images
- **Image generation form** with model selection, prompt input, aspect ratio, seed, and batch controls
- **Masonry grid** layout displaying both canvas-generated and conversation images with responsive column breakpoints
- **Full-screen image viewer** modal with keyboard navigation (arrows, Home/End, Escape), prev/next buttons, counter pill, and image metadata display
- **Convex backend** for the generations table (create, poll external APIs, retry failed, list with pagination)
- **Zustand store** for canvas UI state (prompt, model, params, filters)
- Sidebar navigation link and route wiring

## Test plan

- [ ] Navigate to `/canvas` — page loads with generation form and empty state
- [ ] Generate an image — card appears as pending, then succeeds with the image
- [ ] Click a succeeded image — viewer modal opens full-size
- [ ] Arrow keys and nav buttons navigate between images in the viewer
- [ ] Escape or click backdrop closes the viewer
- [ ] Counter pill shows correct position (e.g. "2 / 5")
- [ ] Filter between "All", "Canvas", and "Conversations" tabs
- [ ] Failed generations show retry button
- [ ] Responsive: grid columns adjust at different viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)