### PR TITLE
feat(canvas): image management, multi-select, and img2img support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
         "jszip": "^3.10.1",
         "katex": "^0.16.27",
         "markdown-to-jsx": "^9.5.1",
-        "motion": "^12.34.2",
+        "motion": "^12.34.3",
         "postcss": "^8.5.4",
         "prism-react-renderer": "^2.4.1",
         "react": "19.2.3",
@@ -1129,7 +1129,7 @@
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
-    "motion": ["motion@12.34.2", "", { "dependencies": { "framer-motion": "^12.34.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-QAthwCtW6N0TpZ+bBmBMzdwuftoay2yFV2DT44jRcUQhPbFPdAX+pjzmIUNM3sMYDD5OAraJagRGAKE8q5OsmA=="],
+    "motion": ["motion@12.34.3", "", { "dependencies": { "framer-motion": "^12.34.3", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-xZIkBGO7v/Uvm+EyaqYd+9IpXu0sZqLywVlGdCFrrMiaO9JI4Kx51mO9KlHSWwll+gZUVY5OJsWgYI5FywJ/tw=="],
 
     "motion-dom": ["motion-dom@12.24.11", "", { "dependencies": { "motion-utils": "^12.24.10" } }, "sha512-DlWOmsXMJrV8lzZyd+LKjG2CXULUs++bkq8GZ2Sr0R0RRhs30K2wtY+LKiTjhmJU3W61HK+rB0GLz6XmPvTA1A=="],
 
@@ -1543,7 +1543,7 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "motion/framer-motion": ["framer-motion@12.34.2", "", { "dependencies": { "motion-dom": "^12.34.2", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-CcnYTzbRybm1/OE8QLXfXI8gR1cx5T4dF3D2kn5IyqsGNeLAKl2iFHb2BzFyXBGqESntDt6rPYl4Jhrb7tdB8g=="],
+    "motion/framer-motion": ["framer-motion@12.34.3", "", { "dependencies": { "motion-dom": "^12.34.3", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -1607,7 +1607,7 @@
 
     "micromark-extension-math/katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
-    "motion/framer-motion/motion-dom": ["motion-dom@12.34.2", "", { "dependencies": { "motion-utils": "^12.29.2" } }, "sha512-n7gknp7gHcW7DUcmet0JVPLVHmE3j9uWwDp5VbE3IkCNnW5qdu0mOhjNYzXMkrQjrgr+h6Db3EDM2QBhW2qNxQ=="],
+    "motion/framer-motion/motion-dom": ["motion-dom@12.34.3", "", { "dependencies": { "motion-utils": "^12.29.2" } }, "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ=="],
 
     "motion/framer-motion/motion-utils": ["motion-utils@12.29.2", "", {}, "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A=="],
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -96,6 +96,7 @@ import type * as lib_conversation_export_handlers from "../lib/conversation_expo
 import type * as lib_conversation_export_helpers from "../lib/conversation_export/helpers.js";
 import type * as lib_conversation_utils from "../lib/conversation_utils.js";
 import type * as lib_cors from "../lib/cors.js";
+import type * as lib_encoding from "../lib/encoding.js";
 import type * as lib_file_storage_attachment_queries from "../lib/file_storage/attachment_queries.js";
 import type * as lib_file_storage_file_queries from "../lib/file_storage/file_queries.js";
 import type * as lib_file_storage_helpers from "../lib/file_storage/helpers.js";
@@ -251,6 +252,7 @@ declare const fullApi: ApiFromModules<{
   "lib/conversation_export/helpers": typeof lib_conversation_export_helpers;
   "lib/conversation_utils": typeof lib_conversation_utils;
   "lib/cors": typeof lib_cors;
+  "lib/encoding": typeof lib_encoding;
   "lib/file_storage/attachment_queries": typeof lib_file_storage_attachment_queries;
   "lib/file_storage/file_queries": typeof lib_file_storage_file_queries;
   "lib/file_storage/helpers": typeof lib_file_storage_helpers;

--- a/convex/ai/message_converter/image.ts
+++ b/convex/ai/message_converter/image.ts
@@ -7,46 +7,15 @@
 
 import type { ImagePart, TextPart } from "ai";
 import type { ActionCtx } from "../../_generated/server";
+import { arrayBufferToBase64 } from "../../lib/encoding";
 import { fetchStorageWithRetry, getRetryConfig } from "./core";
 import type { StoredAttachment } from "./core";
 
-// ==================== Utility Functions ====================
-
 /**
- * Convert Uint8Array to base64 string
- * Uses pure JavaScript for Convex compatibility
+ * @deprecated Use `arrayBufferToBase64` from `convex/lib/encoding` instead.
  */
 export function bufferToBase64(bytes: Uint8Array): string {
-  const base64chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-  let result = "";
-  let i;
-
-  for (i = 0; i < bytes.length - 2; i += 3) {
-    const byte0 = bytes[i]!;
-    const byte1 = bytes[i + 1]!;
-    const byte2 = bytes[i + 2]!;
-    result += base64chars[byte0 >> 2];
-    result += base64chars[((byte0 & 3) << 4) | (byte1 >> 4)];
-    result += base64chars[((byte1 & 15) << 2) | (byte2 >> 6)];
-    result += base64chars[byte2 & 63];
-  }
-
-  if (i < bytes.length) {
-    const lastByte = bytes[i]!;
-    result += base64chars[lastByte >> 2];
-    if (i === bytes.length - 1) {
-      result += base64chars[(lastByte & 3) << 4];
-      result += "==";
-    } else {
-      const nextByte = bytes[i + 1]!;
-      result += base64chars[((lastByte & 3) << 4) | (nextByte >> 4)];
-      result += base64chars[(nextByte & 15) << 2];
-      result += "=";
-    }
-  }
-
-  return result;
+  return arrayBufferToBase64(bytes.buffer as ArrayBuffer);
 }
 
 // ==================== Image Conversion ====================
@@ -99,7 +68,7 @@ export async function convertImageAttachment(
     try {
       const blob = await fetchStorageWithRetry(ctx, attachment.storageId);
       const arrayBuffer = await blob.arrayBuffer();
-      const base64 = bufferToBase64(new Uint8Array(arrayBuffer));
+      const base64 = arrayBufferToBase64(arrayBuffer);
       const mimeType = blob.type || attachment.mimeType || "image/jpeg";
       return { type: "image", image: `data:${mimeType};base64,${base64}` };
     } catch (error) {

--- a/convex/ai/messages.ts
+++ b/convex/ai/messages.ts
@@ -12,6 +12,7 @@ import type { ActionCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import { api } from "../_generated/api";
 import { CONFIG } from "./config";
+import { arrayBufferToBase64 } from "../lib/encoding";
 import { shouldExtractPdfText } from "./pdf";
 
 /**
@@ -72,7 +73,7 @@ export const convertStorageToData = async (
 }> => {
   const blob = await fetchStorageWithRetry(ctx, storageId);
   const arrayBuffer = await blob.arrayBuffer();
-  const base64 = Buffer.from(new Uint8Array(arrayBuffer)).toString("base64");
+  const base64 = arrayBufferToBase64(arrayBuffer);
   const mimeType =
     (blob as any).type ||
     CONFIG.MIME_TYPES[

--- a/convex/ai/replicate.ts
+++ b/convex/ai/replicate.ts
@@ -6,6 +6,7 @@ import { getApiKey } from "./encryption";
 import Replicate from "replicate";
 import type { Prediction } from "replicate";
 import { getUserFriendlyErrorMessage } from "./error_handlers";
+import { arrayBufferToBase64 } from "../lib/encoding";
 import { scheduleRunAfter } from "../lib/scheduler";
 import { validateFreeModelUsage } from "../lib/shared_utils";
 
@@ -43,7 +44,7 @@ export async function resolveImageUrlsFromAttachments(
           const response = await fetch(storageUrl);
           if (response.ok) {
             const buffer = await response.arrayBuffer();
-            const base64 = Buffer.from(buffer).toString("base64");
+            const base64 = arrayBufferToBase64(buffer);
             const mimeType =
               att.mimeType ||
               response.headers.get("content-type") ||

--- a/convex/lib/encoding.ts
+++ b/convex/lib/encoding.ts
@@ -1,0 +1,40 @@
+/**
+ * V8-safe base64 encoding for ArrayBuffer / Uint8Array.
+ *
+ * Convex actions that don't use "use node" run in a V8 isolate where
+ * `Buffer` is unavailable. This implementation works in both V8 and
+ * Node.js runtimes.
+ */
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const base64chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let result = "";
+  let i;
+
+  for (i = 0; i < bytes.length - 2; i += 3) {
+    const byte0 = bytes[i]!;
+    const byte1 = bytes[i + 1]!;
+    const byte2 = bytes[i + 2]!;
+    result += base64chars[byte0 >> 2];
+    result += base64chars[((byte0 & 3) << 4) | (byte1 >> 4)];
+    result += base64chars[((byte1 & 15) << 2) | (byte2 >> 6)];
+    result += base64chars[byte2 & 63];
+  }
+
+  if (i < bytes.length) {
+    const lastByte = bytes[i]!;
+    result += base64chars[lastByte >> 2];
+    if (i === bytes.length - 1) {
+      result += base64chars[(lastByte & 3) << 4];
+      result += "==";
+    } else {
+      const nextByte = bytes[i + 1]!;
+      result += base64chars[((lastByte & 3) << 4) | (nextByte >> 4)];
+      result += base64chars[(nextByte & 15) << 2];
+      result += "=";
+    }
+  }
+
+  return result;
+}

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -1043,6 +1043,7 @@ export const generationSchema = v.object({
     negativePrompt: v.optional(v.string()),
     count: v.optional(v.number()),
     quality: v.optional(v.number()),
+    referenceImageIds: v.optional(v.array(v.id("_storage"))),
   })),
   duration: v.optional(v.number()),
   batchId: v.optional(v.string()), // Groups multi-model generations

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jszip": "^3.10.1",
     "katex": "^0.16.27",
     "markdown-to-jsx": "^9.5.1",
-    "motion": "^12.34.2",
+    "motion": "^12.34.3",
     "postcss": "^8.5.4",
     "prism-react-renderer": "^2.4.1",
     "react": "19.2.3",

--- a/src/components/animate-ui/icons/download.tsx
+++ b/src/components/animate-ui/icons/download.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { motion, type Variants } from "motion/react";
+import * as React from "react";
+
+import {
+  getVariants,
+  type IconProps,
+  IconWrapper,
+  useAnimateIconContext,
+} from "@/components/animate-ui/icons/icon";
+
+type DownloadProps = IconProps<keyof typeof animations>;
+
+const animations = {
+  default: {
+    group: {
+      initial: {
+        y: 0,
+        transition: { duration: 0.3, ease: "easeInOut" },
+      },
+      animate: {
+        y: 2,
+        transition: { duration: 0.3, ease: "easeInOut" },
+      },
+    },
+    path1: {},
+    path2: {},
+    path3: {},
+  } satisfies Record<string, Variants>,
+  "default-loop": {
+    group: {
+      initial: {
+        y: 0,
+      },
+      animate: {
+        y: [0, 2, 0],
+        transition: { duration: 0.6, ease: "easeInOut" },
+      },
+    },
+    path1: {},
+    path2: {},
+    path3: {},
+  } satisfies Record<string, Variants>,
+} as const;
+
+function IconComponent({ size, ...props }: DownloadProps) {
+  const { controls } = useAnimateIconContext();
+  const variants = getVariants(animations);
+
+  return (
+    <motion.svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <motion.g variants={variants.group} initial="initial" animate={controls}>
+        <motion.path
+          d="M12 15V3"
+          variants={variants.path1}
+          initial="initial"
+          animate={controls}
+        />
+        <motion.path
+          d="m7 10 5 5 5-5"
+          variants={variants.path2}
+          initial="initial"
+          animate={controls}
+        />
+      </motion.g>
+      <motion.path
+        d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
+        variants={variants.path3}
+        initial="initial"
+        animate={controls}
+      />
+    </motion.svg>
+  );
+}
+
+function Download(props: DownloadProps) {
+  return <IconWrapper icon={IconComponent} {...props} />;
+}
+
+export {
+  animations,
+  Download,
+  Download as DownloadIcon,
+  type DownloadProps,
+  type DownloadProps as DownloadIconProps,
+};

--- a/src/components/canvas/canvas-grid-card.tsx
+++ b/src/components/canvas/canvas-grid-card.tsx
@@ -1,17 +1,42 @@
 import { api } from "@convex/_generated/api";
-import { ArrowClockwiseIcon } from "@phosphor-icons/react";
+import {
+  ArrowClockwiseIcon,
+  CheckCircleIcon,
+  CircleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import { useMutation } from "convex/react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { CopyIcon } from "@/components/animate-ui/icons/copy";
+import { DownloadIcon } from "@/components/animate-ui/icons/download";
+import { TrashIcon } from "@/components/animate-ui/icons/trash";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  copyImageToClipboard,
+  downloadFromUrl,
+  generateImageFilename,
+} from "@/lib/export";
+import { useToast } from "@/providers/toast-context";
+import { useCanvasStore } from "@/stores/canvas-store";
 import type { CanvasImage } from "@/types";
 
 type CanvasGridCardProps = {
   image: CanvasImage;
   onClick?: () => void;
+  onRequestDelete?: (image: CanvasImage) => void;
 };
 
-export function CanvasGridCard({ image, onClick }: CanvasGridCardProps) {
+export function CanvasGridCard({
+  image,
+  onClick,
+  onRequestDelete,
+}: CanvasGridCardProps) {
   // Pending/processing states
   if (
     image.status === "pending" ||
@@ -23,20 +48,42 @@ export function CanvasGridCard({ image, onClick }: CanvasGridCardProps) {
 
   // Failed state
   if (image.status === "failed" || image.status === "canceled") {
-    return <FailedCard image={image} />;
+    return <FailedCard image={image} onRequestDelete={onRequestDelete} />;
   }
 
   // Succeeded state
-  return <SucceededCard image={image} onClick={onClick} />;
+  return (
+    <SucceededCard
+      image={image}
+      onClick={onClick}
+      onRequestDelete={onRequestDelete}
+    />
+  );
 }
 
 function PendingCard({ image }: { image: CanvasImage }) {
+  const cancelGeneration = useMutation(api.generations.cancelGeneration);
+  const [isCanceling, setIsCanceling] = useState(false);
+
+  const handleCancel = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!image.generationId) {
+      return;
+    }
+    setIsCanceling(true);
+    try {
+      await cancelGeneration({ id: image.generationId });
+    } finally {
+      setIsCanceling(false);
+    }
+  };
+
   return (
-    <div className="relative overflow-hidden rounded-lg border border-border/40 bg-muted/30">
-      <div
-        className="animate-pulse bg-muted/50"
-        style={{ aspectRatio: formatAspectRatio(image.aspectRatio) }}
-      />
+    <div
+      className="group relative overflow-hidden rounded-lg border border-border/40 bg-muted/30"
+      style={{ aspectRatio: formatAspectRatio(image.aspectRatio) }}
+    >
+      <div className="absolute inset-0 animate-pulse bg-muted/50" />
       <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4">
         <Spinner />
         <span className="text-xs font-medium text-muted-foreground">
@@ -48,11 +95,33 @@ function PendingCard({ image }: { image: CanvasImage }) {
           </p>
         )}
       </div>
+      {image.generationId && (
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              type="button"
+              className="absolute right-2 top-2 z-10 flex size-7 items-center justify-center rounded-md bg-black/40 text-white/80 opacity-0 backdrop-blur-sm transition-all hover:bg-black/60 group-hover:opacity-100 disabled:opacity-50"
+              onClick={handleCancel}
+              disabled={isCanceling}
+              aria-label="Cancel generation"
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Cancel</TooltipContent>
+        </Tooltip>
+      )}
     </div>
   );
 }
 
-function FailedCard({ image }: { image: CanvasImage }) {
+function FailedCard({
+  image,
+  onRequestDelete,
+}: {
+  image: CanvasImage;
+  onRequestDelete?: (image: CanvasImage) => void;
+}) {
   const retryGeneration = useMutation(api.generations.retryGeneration);
   const [isRetrying, setIsRetrying] = useState(false);
 
@@ -68,6 +137,11 @@ function FailedCard({ image }: { image: CanvasImage }) {
     }
   };
 
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRequestDelete?.(image);
+  };
+
   return (
     <div className="relative overflow-hidden rounded-lg border border-destructive/30 bg-destructive/5">
       <div style={{ aspectRatio: formatAspectRatio(image.aspectRatio) }} />
@@ -81,16 +155,31 @@ function FailedCard({ image }: { image: CanvasImage }) {
           </span>
         )}
         {image.generationId && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleRetry}
-            disabled={isRetrying}
-            className="gap-1.5"
-          >
-            <ArrowClockwiseIcon className="size-3.5" />
-            Retry
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRetry}
+              disabled={isRetrying}
+              className="gap-1.5"
+            >
+              <ArrowClockwiseIcon className="size-3.5" />
+              Retry
+            </Button>
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  variant="outline"
+                  size="icon-sm"
+                  onClick={handleDelete}
+                  aria-label="Delete generation"
+                >
+                  <TrashIcon className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Delete</TooltipContent>
+            </Tooltip>
+          </div>
         )}
       </div>
     </div>
@@ -100,22 +189,79 @@ function FailedCard({ image }: { image: CanvasImage }) {
 function SucceededCard({
   image,
   onClick,
+  onRequestDelete,
 }: {
   image: CanvasImage;
   onClick?: () => void;
+  onRequestDelete?: (image: CanvasImage) => void;
 }) {
-  const [isHovered, setIsHovered] = useState(false);
+  const selectedImageIds = useCanvasStore(s => s.selectedImageIds);
+  const toggleImageSelection = useCanvasStore(s => s.toggleImageSelection);
+  const isSelected = selectedImageIds.has(image.id);
+  const isSelecting = selectedImageIds.size > 0;
+  const managedToast = useToast();
+
+  const handleCopyImage = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      try {
+        await copyImageToClipboard(image.imageUrl);
+        managedToast.success("Image copied to clipboard");
+      } catch {
+        managedToast.error("Failed to copy image");
+      }
+    },
+    [image.imageUrl, managedToast]
+  );
+
+  const handleDownload = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      try {
+        const filename = generateImageFilename(image.imageUrl, image.prompt);
+        await downloadFromUrl(image.imageUrl, filename);
+        managedToast.success("Image downloaded");
+      } catch {
+        managedToast.error("Failed to download image");
+      }
+    },
+    [image.imageUrl, image.prompt, managedToast]
+  );
+
+  const handleDelete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onRequestDelete?.(image);
+    },
+    [image, onRequestDelete]
+  );
+
+  const handleSelect = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      toggleImageSelection(image.id);
+    },
+    [image.id, toggleImageSelection]
+  );
+
+  const handleClick = useCallback(() => {
+    if (isSelecting) {
+      toggleImageSelection(image.id);
+    } else {
+      onClick?.();
+    }
+  }, [isSelecting, toggleImageSelection, image.id, onClick]);
 
   return (
     <div
-      className="group relative overflow-hidden rounded-lg border border-border/40 bg-muted/30 transition-shadow hover:shadow-md cursor-zoom-in"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      onClick={onClick}
+      className={`group relative overflow-hidden rounded-lg border bg-muted/30 transition-all duration-200 hover:shadow-md ${
+        isSelecting ? "cursor-pointer" : "cursor-zoom-in"
+      } ${isSelected ? "border-primary ring-2 ring-primary/30" : "border-border/40"}`}
+      onClick={handleClick}
       onKeyDown={e => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          onClick?.();
+          handleClick();
         }
       }}
       tabIndex={0}
@@ -124,24 +270,104 @@ function SucceededCard({
       <img
         src={image.imageUrl}
         alt={image.prompt || "Generated image"}
-        className="block w-full"
+        className="block w-full transition-transform duration-500 ease-out group-hover:scale-[1.03]"
         loading="lazy"
       />
-      {/* Hover overlay */}
-      {isHovered && (
-        <div className="absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/70 via-black/20 to-transparent p-3">
-          {image.prompt && (
-            <p className="line-clamp-3 text-xs text-white/90">{image.prompt}</p>
+
+      {/* Selection checkbox — fades in/out */}
+      <button
+        type="button"
+        className={`absolute left-2 top-2 z-10 flex items-center justify-center rounded-full transition-opacity duration-200 hover:scale-110 ${
+          isSelected || isSelecting
+            ? "opacity-100"
+            : "opacity-0 group-hover:opacity-100"
+        }`}
+        onClick={handleSelect}
+        aria-label={isSelected ? "Deselect image" : "Select image"}
+      >
+        {isSelected ? (
+          <CheckCircleIcon
+            weight="fill"
+            className="size-6 text-primary drop-shadow-md"
+          />
+        ) : (
+          <CircleIcon
+            weight="regular"
+            className="size-6 text-white/80 drop-shadow-md"
+          />
+        )}
+      </button>
+
+      {/* Action buttons — fade in on hover, hidden during multi-select */}
+      <div
+        className={`absolute right-2 top-2 z-10 flex items-center gap-1 transition-opacity duration-200 ${
+          isSelecting
+            ? "pointer-events-none opacity-0"
+            : "opacity-0 group-hover:opacity-100"
+        }`}
+      >
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              type="button"
+              className="flex size-8 items-center justify-center rounded-md bg-black/50 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/70"
+              onClick={handleCopyImage}
+              aria-label="Copy image"
+            >
+              <CopyIcon animateOnHover size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Copy image</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              type="button"
+              className="flex size-8 items-center justify-center rounded-md bg-black/50 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/70"
+              onClick={handleDownload}
+              aria-label="Download image"
+            >
+              <DownloadIcon animateOnHover size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Download image</TooltipContent>
+        </Tooltip>
+        {image.source === "canvas" && image.generationId && (
+          <Tooltip>
+            <TooltipTrigger>
+              <button
+                type="button"
+                className="flex size-8 items-center justify-center rounded-md bg-black/50 text-white/90 backdrop-blur-sm transition-colors hover:bg-red-600/70"
+                onClick={handleDelete}
+                aria-label="Delete image"
+              >
+                <TrashIcon animateOnHover size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Delete image</TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+
+      {/* Info overlay — fades in at bottom on hover, hidden during multi-select */}
+      <div
+        className={`absolute inset-x-0 bottom-0 flex flex-col justify-end bg-gradient-to-t from-black/70 via-black/40 to-transparent p-3 pt-12 transition-opacity duration-200 ${
+          isSelecting ? "opacity-0" : "opacity-0 group-hover:opacity-100"
+        }`}
+      >
+        {image.prompt && (
+          <p className="line-clamp-3 text-xs text-white drop-shadow-sm">
+            {image.prompt}
+          </p>
+        )}
+        <div className="mt-1.5 flex items-center gap-2 text-[10px] text-white/80">
+          {image.model && <span>{formatModelName(image.model)}</span>}
+          {image.seed !== undefined && <span>Seed: {image.seed}</span>}
+          {image.duration !== undefined && (
+            <span>{image.duration.toFixed(1)}s</span>
           )}
-          <div className="mt-1.5 flex items-center gap-2 text-[10px] text-white/60">
-            {image.model && <span>{formatModelName(image.model)}</span>}
-            {image.seed !== undefined && <span>Seed: {image.seed}</span>}
-            {image.duration !== undefined && (
-              <span>{image.duration.toFixed(1)}s</span>
-            )}
-          </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/components/canvas/canvas-masonry-grid.tsx
+++ b/src/components/canvas/canvas-masonry-grid.tsx
@@ -1,8 +1,27 @@
 import { api } from "@convex/_generated/api";
-import { useQuery } from "convex/react";
-import { useRef, useState } from "react";
+import {
+  DownloadSimpleIcon,
+  TrashSimpleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { useMutation, useQuery } from "convex/react";
+import { useCallback, useRef, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { useBreakpointColumns } from "@/hooks/use-breakpoint-columns";
+import { downloadFromUrl, generateImageFilename } from "@/lib/export";
+import { useToast } from "@/providers/toast-context";
 import type { CanvasFilterMode } from "@/stores/canvas-store";
+import { useCanvasStore } from "@/stores/canvas-store";
 import type { CanvasImage } from "@/types";
 import { CanvasGridCard } from "./canvas-grid-card";
 import { CanvasImageViewer } from "./canvas-image-viewer";
@@ -14,6 +33,16 @@ type CanvasMasonryGridProps = {
 export function CanvasMasonryGrid({ filterMode }: CanvasMasonryGridProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useBreakpointColumns(containerRef);
+  const managedToast = useToast();
+  const deleteGeneration = useMutation(api.generations.deleteGeneration);
+  const selectedImageIds = useCanvasStore(s => s.selectedImageIds);
+  const clearImageSelection = useCanvasStore(s => s.clearImageSelection);
+
+  // Delete confirmation state
+  const [deleteTarget, setDeleteTarget] = useState<
+    { type: "single"; image: CanvasImage } | { type: "batch" } | null
+  >(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   // Canvas generations
   const canvasData = useQuery(
@@ -46,6 +75,7 @@ export function CanvasMasonryGrid({ filterMode }: CanvasMasonryGridProps) {
             duration: gen.duration,
             createdAt: gen.createdAt,
             aspectRatio: gen.params?.aspectRatio,
+            quality: gen.params?.quality,
             generationId: gen._id,
             batchId: gen.batchId,
           });
@@ -63,6 +93,7 @@ export function CanvasMasonryGrid({ filterMode }: CanvasMasonryGridProps) {
           duration: gen.duration,
           createdAt: gen.createdAt,
           aspectRatio: gen.params?.aspectRatio,
+          quality: gen.params?.quality,
           generationId: gen._id,
           batchId: gen.batchId,
         });
@@ -108,6 +139,106 @@ export function CanvasMasonryGrid({ filterMode }: CanvasMasonryGridProps) {
     }
   };
 
+  const handleRequestDelete = useCallback((image: CanvasImage) => {
+    setDeleteTarget({ type: "single", image });
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      if (deleteTarget?.type === "single") {
+        const { image } = deleteTarget;
+        if (image.source === "canvas" && image.generationId) {
+          await deleteGeneration({ id: image.generationId });
+          managedToast.success("Image deleted");
+        }
+      } else if (deleteTarget?.type === "batch") {
+        // Collect unique generationIds from selected images
+        const seen = new Set<string>();
+        const toDelete: CanvasImage[] = [];
+        for (const img of allImages) {
+          if (
+            selectedImageIds.has(img.id) &&
+            img.source === "canvas" &&
+            img.generationId &&
+            !seen.has(img.generationId)
+          ) {
+            seen.add(img.generationId);
+            toDelete.push(img);
+          }
+        }
+        await Promise.all(
+          toDelete.map(img => {
+            // generationId is guaranteed non-null by the filter above
+            const genId = img.generationId;
+            if (!genId) {
+              return Promise.resolve();
+            }
+            return deleteGeneration({ id: genId });
+          })
+        );
+        managedToast.success(
+          `${toDelete.length} image${toDelete.length === 1 ? "" : "s"} deleted`
+        );
+        clearImageSelection();
+      }
+    } catch {
+      managedToast.error("Failed to delete");
+    } finally {
+      setIsDeleting(false);
+      setDeleteTarget(null);
+    }
+  }, [
+    deleteTarget,
+    deleteGeneration,
+    managedToast,
+    selectedImageIds,
+    clearImageSelection,
+  ]);
+
+  const handleBatchDownload = useCallback(async () => {
+    const selected = allImages.filter(
+      img =>
+        selectedImageIds.has(img.id) &&
+        img.status === "succeeded" &&
+        img.imageUrl
+    );
+    if (selected.length === 0) {
+      return;
+    }
+
+    let downloaded = 0;
+    for (const img of selected) {
+      try {
+        const filename = generateImageFilename(
+          img.imageUrl,
+          img.prompt,
+          String(downloaded + 1)
+        );
+        await downloadFromUrl(img.imageUrl, filename);
+        downloaded++;
+      } catch {
+        // continue with remaining downloads
+      }
+    }
+    managedToast.success(
+      `${downloaded} image${downloaded === 1 ? "" : "s"} downloaded`
+    );
+  }, [selectedImageIds, managedToast]);
+
+  const handleBatchDelete = useCallback(() => {
+    setDeleteTarget({ type: "batch" });
+  }, []);
+
+  // Count how many selected images are deletable (canvas-sourced)
+  const selectedCount = selectedImageIds.size;
+  const selectedDeletableCount = allImages.filter(
+    img =>
+      selectedImageIds.has(img.id) &&
+      img.source === "canvas" &&
+      img.generationId
+  ).length;
+
   if (allImages.length === 0) {
     return (
       <div
@@ -136,32 +267,111 @@ export function CanvasMasonryGrid({ filterMode }: CanvasMasonryGridProps) {
     }
   }
 
-  return (
-    <div ref={containerRef} className="flex items-start gap-4">
-      {columns.map((col, colIdx) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: stable column layout, index is the only meaningful key
-        <div key={colIdx} className="flex flex-1 flex-col gap-4">
-          {col.map(image => (
-            <CanvasGridCard
-              key={image.id}
-              image={image}
-              onClick={
-                image.status === "succeeded" && image.imageUrl
-                  ? () => handleImageClick(image)
-                  : undefined
-              }
-            />
-          ))}
-        </div>
-      ))}
+  const deleteMessage =
+    deleteTarget?.type === "single"
+      ? "This will permanently delete this image and cannot be undone."
+      : `This will permanently delete ${selectedDeletableCount} image${selectedDeletableCount === 1 ? "" : "s"} and cannot be undone.`;
 
-      <CanvasImageViewer
-        images={succeededImages}
-        currentIndex={viewerIndex}
-        open={viewerOpen}
-        onOpenChange={setViewerOpen}
-        onIndexChange={setViewerIndex}
-      />
-    </div>
+  return (
+    <>
+      <div ref={containerRef} className="flex items-start gap-4">
+        {columns.map((col, colIdx) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable column layout, index is the only meaningful key
+          <div key={colIdx} className="flex flex-1 flex-col gap-4">
+            {col.map(image => (
+              <CanvasGridCard
+                key={image.id}
+                image={image}
+                onClick={
+                  image.status === "succeeded" && image.imageUrl
+                    ? () => handleImageClick(image)
+                    : undefined
+                }
+                onRequestDelete={handleRequestDelete}
+              />
+            ))}
+          </div>
+        ))}
+
+        <CanvasImageViewer
+          images={succeededImages}
+          currentIndex={viewerIndex}
+          open={viewerOpen}
+          onOpenChange={setViewerOpen}
+          onIndexChange={setViewerIndex}
+          onRequestDelete={handleRequestDelete}
+        />
+      </div>
+
+      {/* Batch action bar */}
+      {selectedCount > 0 && (
+        <div className="fixed bottom-6 left-1/2 z-modal -translate-x-1/2 flex items-center gap-3 rounded-xl bg-card px-4 py-2.5 shadow-xl ring-1 ring-border/50 backdrop-blur-md dark:ring-white/[0.08]">
+          <span className="text-sm font-medium tabular-nums">
+            {selectedCount} selected
+          </span>
+          <div className="h-4 w-px bg-border" />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5"
+            onClick={handleBatchDownload}
+          >
+            <DownloadSimpleIcon className="size-4" />
+            Download
+          </Button>
+          {selectedDeletableCount > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 text-destructive hover:text-destructive"
+              onClick={handleBatchDelete}
+            >
+              <TrashSimpleIcon className="size-4" />
+              Delete
+            </Button>
+          )}
+          <div className="h-4 w-px bg-border" />
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={clearImageSelection}
+            aria-label="Clear selection"
+          >
+            <XIcon className="size-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={open => {
+          if (!open) {
+            setDeleteTarget(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {deleteTarget?.type === "batch"
+                ? `Delete ${selectedDeletableCount} image${selectedDeletableCount === 1 ? "" : "s"}?`
+                : "Delete image?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>{deleteMessage}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/src/components/chat/message/image-actions.test.tsx
+++ b/src/components/chat/message/image-actions.test.tsx
@@ -13,12 +13,16 @@ Object.defineProperty(navigator, "clipboard", {
   writable: true,
 });
 
-// Mock the download function
+// Mock the download function — re-export the real generateImageFilename
 const mockDownloadFromUrl = mock((url: string, filename: string) =>
   Promise.resolve()
 );
+const { generateImageFilename: realGenerateImageFilename } = await import(
+  "@/lib/export"
+);
 mock.module("@/lib/export", () => ({
   downloadFromUrl: mockDownloadFromUrl,
+  generateImageFilename: realGenerateImageFilename,
 }));
 
 // Toast functionality is tested separately in ToastProvider tests
@@ -433,7 +437,7 @@ describe("ImageActions", () => {
         const filename = call[1];
         expect(url).toBe("https://example.com/image");
         expect(filename).toMatch(
-          /^a-beautiful-sunset-over-mountains-\d{4}-\d{2}-\d{2}\.\/image$/
+          /^a-beautiful-sunset-over-mountains-\d{4}-\d{2}-\d{2}\.png$/
         );
       }
     });

--- a/src/components/chat/message/image-actions.tsx
+++ b/src/components/chat/message/image-actions.tsx
@@ -11,7 +11,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { downloadFromUrl } from "@/lib/export";
+import { downloadFromUrl, generateImageFilename } from "@/lib/export";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/providers/toast-context";
 import { ActionButton } from "./action-button";
@@ -110,22 +110,7 @@ export const ImageActions = ({
 
     setIsDownloading(true);
     try {
-      // Generate filename from prompt or use default
-      const timestamp = new Date().toISOString().split("T")[0];
-      const baseFilename = prompt
-        ? prompt
-            .slice(0, 50)
-            .replace(/[^\d\sA-Za-z-]/g, "")
-            .replace(/\s+/g, "-")
-            .toLowerCase()
-        : "generated-image";
-
-      // Extract file extension from URL or default to .png
-      const urlPath = new URL(imageUrl).pathname;
-      const extension = urlPath.split(".").pop() || "png";
-
-      const filename = `${baseFilename}-${timestamp}.${extension}`;
-
+      const filename = generateImageFilename(imageUrl, prompt);
       await downloadFromUrl(imageUrl, filename);
       managedToast.success("Image downloaded successfully");
     } catch (error) {

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -472,7 +472,7 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
                     </Link>
                   )}
 
-                  <Link to={ROUTES.CANVAS}>
+                  <Link to={ROUTES.CANVAS} viewTransition>
                     <Button
                       size="icon-sm"
                       title="Canvas"

--- a/src/globals.css
+++ b/src/globals.css
@@ -2962,3 +2962,34 @@ pre {
   animation: message-highlight 2s ease-out forwards;
   border-radius: 0.75rem;
 }
+
+/* Page view transitions — cross-fade between routes */
+@view-transition {
+  navigation: auto;
+}
+
+::view-transition-old(root) {
+  animation: 150ms ease-out both fade-out;
+}
+
+::view-transition-new(root) {
+  animation: 200ms ease-in 50ms both fade-in;
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/pages/canvas-page.tsx
+++ b/src/pages/canvas-page.tsx
@@ -119,20 +119,43 @@ export default function CanvasPage() {
         >
           {/* Panel header — mirrors sidebar header structure */}
           <div className="shrink-0 py-4 px-3">
-            <div className="flex items-center justify-between mb-4 pl-2 pr-2">
+            <div className="flex items-center justify-between pl-2 pr-2">
               <div className="flex items-center gap-2">
                 <Link
                   className="group flex items-center gap-2 text-sidebar-foreground/90 hover:text-sidebar-foreground transition-colors"
                   to={ROUTES.HOME}
+                  viewTransition
                 >
-                  <ArrowLeftIcon className="size-4.5" />
+                  <div
+                    className="polly-logo-gradient-unified flex-shrink-0 w-6 h-6"
+                    style={{
+                      maskImage: "url('/favicon.svg')",
+                      maskSize: "contain",
+                      maskRepeat: "no-repeat",
+                      maskPosition: "center",
+                      WebkitMaskImage: "url('/favicon.svg')",
+                      WebkitMaskSize: "contain",
+                      WebkitMaskRepeat: "no-repeat",
+                      WebkitMaskPosition: "center",
+                    }}
+                  />
                   <span className="font-semibold text-sm tracking-tight">
-                    Canvas
+                    Polly
                   </span>
                 </Link>
               </div>
 
               <div className="flex items-center gap-1">
+                <Link to={ROUTES.HOME} viewTransition>
+                  <Button
+                    size="icon-sm"
+                    title="Back to chat"
+                    variant="ghost"
+                    className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover h-8 w-8"
+                  >
+                    <ArrowLeftIcon className="size-4.5" />
+                  </Button>
+                </Link>
                 <Button
                   size="icon-sm"
                   title="Collapse panel"
@@ -170,7 +193,7 @@ export default function CanvasPage() {
         {/* Main content area */}
         <div className="flex flex-1 flex-col min-w-0">
           {/* Header */}
-          <header className="flex items-center gap-3 border-b border-border/40 px-4 py-3 shrink-0">
+          <header className="flex h-16 items-center gap-3 px-4 shrink-0">
             {/* Show expand button when panel is hidden */}
             {!isPanelVisible && (
               <Button
@@ -203,7 +226,7 @@ export default function CanvasPage() {
           </header>
 
           {/* Masonry grid */}
-          <div className="flex-1 overflow-y-auto p-4">
+          <div className="flex-1 overflow-y-auto px-4 pb-4">
             <CanvasMasonryGrid filterMode={filterMode} />
           </div>
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -419,6 +419,7 @@ export type CanvasImage = {
   duration?: number;
   createdAt: number;
   aspectRatio?: string;
+  quality?: number;
   // Canvas-specific
   generationId?: Id<"generations">;
   batchId?: string;


### PR DESCRIPTION
## Summary
- **Image-to-image**: Reference image upload in the generation form, with storage-backed data URI conversion and automatic model capability detection (schema introspection + hardcoded fallback for known editing models)
- **Image management**: Cancel pending generations, delete images with confirmation dialog, copy to clipboard, and download with properly generated filenames
- **Multi-select**: Checkbox selection on grid cards with a floating batch action bar for bulk download and delete
- **Redesigned viewer**: Portal-based lightbox with a right info panel showing metadata badges (duration, aspect ratio, quality, seed), copyable prompt, and action buttons
- **Model picker**: Popover with capability tags (Multi, Negative, Img2Img), keyboard navigation, and search
- **Shared helpers**: Extract `copyImageToClipboard` and `generateImageFilename` to `lib/export`, fixing a bug where Convex storage URLs (no file extension) produced malformed download filenames — also fixes the same bug in chat image downloads
- **View transitions**: Cross-fade CSS `@view-transition` between routes, Polly branding in canvas header
- **Dep bump**: motion 12.34.2 → 12.34.3

## Test plan
- [ ] Generate images on canvas — verify pending/processing/succeeded/failed states render correctly
- [ ] Upload reference images and generate with an img2img-capable model
- [ ] Cancel a pending generation — verify it stops and shows canceled state
- [ ] Delete a single image via grid card, viewer, and failed card — confirm dialog appears
- [ ] Multi-select images and batch download / batch delete
- [ ] Open image viewer — check info panel, copy prompt, copy seed, download, delete actions
- [ ] Download an image from chat (conversation) — verify filename has `.png` extension (not the storage path)
- [ ] Navigate between chat and canvas — verify cross-fade transition
- [ ] Test model picker: search, keyboard nav (arrow keys, Enter, Space), capability tag highlighting with reference images attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)