### PR TITLE
feat(canvas): AI-powered prompt generation with sparkle menu

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as ai_messages from "../ai/messages.js";
 import type * as ai_pdf from "../ai/pdf.js";
 import type * as ai_pdf_cache from "../ai/pdf_cache.js";
 import type * as ai_pdf_status from "../ai/pdf_status.js";
+import type * as ai_prompt_generation from "../ai/prompt_generation.js";
 import type * as ai_replicate from "../ai/replicate.js";
 import type * as ai_replicate_generate from "../ai/replicate/generate.js";
 import type * as ai_replicate_polling from "../ai/replicate/polling.js";
@@ -183,6 +184,7 @@ declare const fullApi: ApiFromModules<{
   "ai/pdf": typeof ai_pdf;
   "ai/pdf_cache": typeof ai_pdf_cache;
   "ai/pdf_status": typeof ai_pdf_status;
+  "ai/prompt_generation": typeof ai_prompt_generation;
   "ai/replicate": typeof ai_replicate;
   "ai/replicate/generate": typeof ai_replicate_generate;
   "ai/replicate/polling": typeof ai_replicate_polling;

--- a/convex/ai/prompt_generation.ts
+++ b/convex/ai/prompt_generation.ts
@@ -1,0 +1,183 @@
+/**
+ * AI-powered prompt generation for canvas image generation.
+ *
+ * Two modes:
+ * 1. "describe_image" — vision model describes an uploaded image as a generation prompt
+ * 2. "enhance_prompt" — text model expands a simple prompt into a detailed one
+ */
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { generateText } from "ai";
+import { v } from "convex/values";
+
+import { api } from "../_generated/api";
+import { action } from "../_generated/server";
+import { getAuthUserId } from "../lib/auth";
+import { arrayBufferToBase64 } from "../lib/encoding";
+import { CONFIG } from "./config";
+import { createLanguageModel } from "./server_streaming";
+import { generateTextWithProvider } from "./text_generation";
+import type { ProviderType } from "../types";
+import { DEFAULT_BUILTIN_MODEL_ID } from "../../shared/constants";
+
+const DESCRIBE_IMAGE_PROMPT = `You are an expert at writing image generation prompts. Given this image, describe it as a detailed prompt that could be used to recreate it with an AI image generator.
+
+Focus on:
+- Subject matter and composition
+- Art style, medium, and technique
+- Lighting, colors, and mood
+- Camera angle and perspective (if photographic)
+- Key details and textures
+
+Write ONLY the prompt text, no explanations or preamble. Keep it under 200 words.`;
+
+const ENHANCE_PROMPT_SYSTEM = `You are an expert at writing prompts for AI image generation. Transform the user's simple description into a detailed, vivid image generation prompt.
+
+Add specifics about:
+- Art style and medium (e.g., digital painting, photograph, watercolor)
+- Lighting and atmosphere
+- Composition and perspective
+- Colors and mood
+- Fine details and textures
+- Quality modifiers (e.g., highly detailed, 8k, professional)
+
+Write ONLY the enhanced prompt text, no explanations or preamble. Keep it under 200 words.
+
+If the input is empty or very vague, create an interesting, creative prompt.`;
+
+async function fetchImageData(
+	ctx: { storage: { get: (id: string) => Promise<Blob | null> } },
+	storageId: string,
+): Promise<{ base64: string; mediaType: string }> {
+	const blob = await ctx.storage.get(storageId);
+	if (!blob) {
+		throw new Error("Image not found in storage");
+	}
+	const arrayBuffer = await blob.arrayBuffer();
+	const base64 = arrayBufferToBase64(arrayBuffer);
+	const mediaType = blob.type || "image/jpeg";
+	return { base64, mediaType };
+}
+
+export const generateImagePrompt = action({
+	args: {
+		mode: v.union(v.literal("describe_image"), v.literal("enhance_prompt")),
+		imageStorageId: v.optional(v.id("_storage")),
+		simplePrompt: v.optional(v.string()),
+		provider: v.optional(v.string()),
+		modelId: v.optional(v.string()),
+		personaId: v.optional(v.id("personas")),
+	},
+	handler: async (ctx, args) => {
+		const userId = await getAuthUserId(ctx);
+		if (!userId) {
+			throw new Error("Not authenticated");
+		}
+
+		// Resolve persona style instructions if provided
+		let personaStyle = "";
+		if (args.personaId) {
+			const persona = await ctx.runQuery(api.personas.get, { id: args.personaId });
+			if (persona?.prompt) {
+				personaStyle = `\n\nAdopt the following style and perspective:\n${persona.prompt}`;
+			}
+		}
+
+		// If user specified a provider + model, resolve their API key and create model
+		if (args.provider && args.modelId) {
+			// biome-ignore lint/suspicious/noExplicitAny: provider string validated at runtime by Convex
+			const apiKey = await ctx.runAction(api.apiKeys.getDecryptedApiKey, {
+				provider: args.provider as any,
+			});
+
+			if (!apiKey) {
+				throw new Error(`No API key found for provider: ${args.provider}`);
+			}
+
+			const languageModel = await createLanguageModel(
+				ctx,
+				args.provider as ProviderType,
+				args.modelId,
+				apiKey as string,
+			);
+
+			if (args.mode === "describe_image") {
+				if (!args.imageStorageId) {
+					throw new Error("imageStorageId is required for describe_image mode");
+				}
+
+				const imageData = await fetchImageData(ctx, args.imageStorageId);
+
+				const result = await generateText({
+					model: languageModel,
+					messages: [
+						{
+							role: "user",
+							content: [
+								{ type: "image", image: imageData.base64, mediaType: imageData.mediaType },
+								{ type: "text", text: DESCRIBE_IMAGE_PROMPT + personaStyle },
+							],
+						},
+					],
+					maxOutputTokens: 500,
+					temperature: 0.7,
+				});
+
+				return result.text;
+			}
+
+			// enhance_prompt mode
+			const result = await generateText({
+				model: languageModel,
+				system: ENHANCE_PROMPT_SYSTEM + personaStyle,
+				prompt: args.simplePrompt || "Create a visually striking and creative image",
+				maxOutputTokens: 500,
+				temperature: 0.8,
+			});
+
+			return result.text;
+		}
+
+		// Default: use internal model
+		if (args.mode === "describe_image") {
+			if (!args.imageStorageId) {
+				throw new Error("imageStorageId is required for describe_image mode");
+			}
+
+			const apiKey = process.env[CONFIG.PROVIDER_ENV_KEYS.google];
+			if (!apiKey) {
+				throw new Error(
+					"No internal API key available. Please select a model with a configured API key.",
+				);
+			}
+
+			const imageData = await fetchImageData(ctx, args.imageStorageId);
+
+			const google = createGoogleGenerativeAI({ apiKey });
+			const model = google.chat(DEFAULT_BUILTIN_MODEL_ID);
+
+			const result = await generateText({
+				model,
+				messages: [
+					{
+						role: "user",
+						content: [
+							{ type: "image", image: imageData.base64, mediaType: imageData.mediaType },
+							{ type: "text", text: DESCRIBE_IMAGE_PROMPT + personaStyle },
+						],
+					},
+				],
+				maxOutputTokens: 500,
+				temperature: 0.7,
+			});
+
+			return result.text;
+		}
+
+		// enhance_prompt with internal model
+		return generateTextWithProvider({
+			prompt: `${ENHANCE_PROMPT_SYSTEM}${personaStyle}\n\nUser prompt: ${args.simplePrompt || "Create a visually striking and creative image"}`,
+			maxOutputTokens: 500,
+			temperature: 0.8,
+		});
+	},
+});

--- a/convex/ai/prompt_generation.ts
+++ b/convex/ai/prompt_generation.ts
@@ -19,30 +19,23 @@ import { generateTextWithProvider } from "./text_generation";
 import type { ProviderType } from "../types";
 import { DEFAULT_BUILTIN_MODEL_ID } from "../../shared/constants";
 
-const DESCRIBE_IMAGE_PROMPT = `You are an expert at writing image generation prompts. Given this image, describe it as a detailed prompt that could be used to recreate it with an AI image generator.
+const DESCRIBE_IMAGE_PROMPT = `Describe this image as a prompt that could recreate it with an AI image generator.
 
-Focus on:
-- Subject matter and composition
-- Art style, medium, and technique
-- Lighting, colors, and mood
-- Camera angle and perspective (if photographic)
-- Key details and textures
+Write direct, descriptive language — as if captioning a photo that already exists. Structure: subject first, then scene/setting, then visual style or medium, then lighting, then 1–2 key details or textures. Be concrete — "a tabby cat curled on a sun-faded velvet armchair" not "a cat on furniture". For photos, mention lens or film characteristics. For illustrations, name the style.
 
-Write ONLY the prompt text, no explanations or preamble. Keep it under 200 words.`;
+Write ONLY the prompt, no labels or preamble. Keep it 30–80 words.`;
 
-const ENHANCE_PROMPT_SYSTEM = `You are an expert at writing prompts for AI image generation. Transform the user's simple description into a detailed, vivid image generation prompt.
+const ENHANCE_PROMPT_SYSTEM = `You enhance simple ideas into effective AI image generation prompts.
 
-Add specifics about:
-- Art style and medium (e.g., digital painting, photograph, watercolor)
-- Lighting and atmosphere
-- Composition and perspective
-- Colors and mood
-- Fine details and textures
-- Quality modifiers (e.g., highly detailed, 8k, professional)
+Write direct, descriptive language — as if captioning a photo that already exists. Never use conversational phrasing like "Create an image of..." or "The scene shows...".
 
-Write ONLY the enhanced prompt text, no explanations or preamble. Keep it under 200 words.
+Structure: subject first (concrete, specific), then setting/scene, then visual style or medium, then lighting, then 1–2 key details or textures.
 
-If the input is empty or very vague, create an interesting, creative prompt.`;
+Be concrete — "a weathered fisherman mending nets on a dock at dawn" not "a person working". Name a specific style: "35mm film photography", "watercolor illustration", "cel-shaded". Describe lighting precisely: "golden hour side-lighting" not "nice lighting". Translate abstract emotions into visual elements: "hunched shoulders, rain-soaked bench, desaturated tones" not "a feeling of sadness".
+
+Only describe what IS in the image — no negative instructions or "without" phrases. Skip generic quality tokens like "8k, masterpiece, best quality, ultra detailed" — use specific visual details instead. Every word should contribute visual direction.
+
+Keep it 30–80 words. Write ONLY the prompt. If the input is empty or vague, invent a vivid scene. Preserve the user's core idea.`;
 
 async function fetchImageData(
 	ctx: { storage: { get: (id: string) => Promise<Blob | null> } },

--- a/src/components/canvas/canvas-generation-form.tsx
+++ b/src/components/canvas/canvas-generation-form.tsx
@@ -463,14 +463,15 @@ function PromptSparkleMenu() {
       setIsGeneratingPrompt(true);
       try {
         const attachment = await uploadFile(file);
-        if (attachment.storageId) {
-          const result = await generatePrompt({
-            mode: "describe_image",
-            imageStorageId: attachment.storageId,
-            ...sharedArgs(),
-          });
-          setPrompt(result);
+        if (!attachment.storageId) {
+          throw new Error("Upload succeeded but no storage ID returned");
         }
+        const result = await generatePrompt({
+          mode: "describe_image",
+          imageStorageId: attachment.storageId,
+          ...sharedArgs(),
+        });
+        setPrompt(result);
       } catch (err) {
         console.error("Failed to upload and describe image:", err);
         managedToast.error(

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -41,6 +41,10 @@ export type CanvasState = {
   isPanelVisible: boolean;
   selectedImageIds: Set<string>;
   referenceImages: ReferenceImage[];
+  isGeneratingPrompt: boolean;
+  promptModelId?: string;
+  promptModelProvider?: string;
+  promptPersonaId?: string;
 
   // Actions
   toggleModel: (modelId: string) => void;
@@ -59,6 +63,9 @@ export type CanvasState = {
   addReferenceImage: (storageId: Id<"_storage">, previewUrl: string) => void;
   removeReferenceImage: (index: number) => void;
   clearReferenceImages: () => void;
+  setIsGeneratingPrompt: (v: boolean) => void;
+  setPromptModel: (modelId?: string, provider?: string) => void;
+  setPromptPersonaId: (id?: string) => void;
 };
 
 type CanvasStoreApi = StoreApi<CanvasState>;
@@ -112,6 +119,10 @@ const INITIAL_STATE = {
   isPanelVisible: getInitialPanelVisible(),
   selectedImageIds: new Set<string>(),
   referenceImages: [] as ReferenceImage[],
+  isGeneratingPrompt: false,
+  promptModelId: undefined as string | undefined,
+  promptModelProvider: undefined as string | undefined,
+  promptPersonaId: undefined as string | undefined,
 };
 
 function createCanvasState(
@@ -212,6 +223,10 @@ function createCanvasState(
       }
       set_({ referenceImages: [] });
     },
+    setIsGeneratingPrompt: v => set_({ isGeneratingPrompt: v }),
+    setPromptModel: (modelId, provider) =>
+      set_({ promptModelId: modelId, promptModelProvider: provider }),
+    setPromptPersonaId: id => set_({ promptPersonaId: id }),
   };
 }
 


### PR DESCRIPTION
## Summary

- Add sparkle button menu on the canvas prompt textarea with two AI-powered modes:
  - **Enhance prompt** — expands simple text into detailed image generation prompts
  - **Describe from image** — vision model describes uploaded/library/reference images as prompts
- Backend action (`convex/ai/prompt_generation.ts`) supports both built-in and user-configured models
- Nested submenus for **model** and **persona** selection — persona style instructions are injected into generation
- Reference image thumbnails shown inline in the menu for quick describe access
- Canvas store extended with prompt generation state (`isGeneratingPrompt`, model/persona selection)

## Test plan

- [ ] Type a simple prompt → click sparkle → "Enhance prompt" → verify textarea gets replaced with detailed prompt
- [ ] Upload a reference image → click sparkle → click the thumbnail → verify description prompt appears
- [ ] Click sparkle → "Describe uploaded image" → pick a file → verify prompt appears
- [ ] Click sparkle → "Describe from library" → select an image → verify prompt appears
- [ ] Change model via submenu → verify generation uses that model
- [ ] Select a persona via submenu → verify persona style influences the generated prompt
- [ ] Test with no API keys → verify graceful error toast
- [ ] Run `bun run check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)