### PR TITLE
feat(canvas): copy-to-form, advanced settings indicator, image paste/drop

### DIFF
--- a/convex/ai/prompt_generation.ts
+++ b/convex/ai/prompt_generation.ts
@@ -17,7 +17,7 @@ import { CONFIG } from "./config";
 import { createLanguageModel } from "./server_streaming";
 import { generateTextWithProvider } from "./text_generation";
 import type { ProviderType } from "../types";
-import { DEFAULT_BUILTIN_MODEL_ID } from "../../shared/constants";
+import { DEFAULT_BUILTIN_VISION_MODEL_ID } from "../../shared/constants";
 
 const DESCRIBE_IMAGE_PROMPT = `Describe this image as a prompt that could recreate it with an AI image generator.
 
@@ -111,7 +111,7 @@ export const generateImagePrompt = action({
 							],
 						},
 					],
-					maxOutputTokens: 500,
+					maxOutputTokens: 2048,
 					temperature: 0.7,
 				});
 
@@ -123,7 +123,7 @@ export const generateImagePrompt = action({
 				model: languageModel,
 				system: ENHANCE_PROMPT_SYSTEM + personaStyle,
 				prompt: args.simplePrompt || "Create a visually striking and creative image",
-				maxOutputTokens: 500,
+				maxOutputTokens: 2048,
 				temperature: 0.8,
 			});
 
@@ -146,7 +146,7 @@ export const generateImagePrompt = action({
 			const imageData = await fetchImageData(ctx, args.imageStorageId);
 
 			const google = createGoogleGenerativeAI({ apiKey });
-			const model = google.chat(DEFAULT_BUILTIN_MODEL_ID);
+			const model = google.chat(DEFAULT_BUILTIN_VISION_MODEL_ID);
 
 			const result = await generateText({
 				model,
@@ -159,7 +159,7 @@ export const generateImagePrompt = action({
 						],
 					},
 				],
-				maxOutputTokens: 500,
+				maxOutputTokens: 2048,
 				temperature: 0.7,
 			});
 
@@ -169,7 +169,7 @@ export const generateImagePrompt = action({
 		// enhance_prompt with internal model
 		return generateTextWithProvider({
 			prompt: `${ENHANCE_PROMPT_SYSTEM}${personaStyle}\n\nUser prompt: ${args.simplePrompt || "Create a visually striking and creative image"}`,
-			maxOutputTokens: 500,
+			maxOutputTokens: 2048,
 			temperature: 0.8,
 		});
 	},

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -8,6 +8,7 @@ export const ANONYMOUS_MESSAGE_LIMIT = 10;
 
 // Built-in model constants
 export const DEFAULT_BUILTIN_MODEL_ID = "gemini-2.5-flash-lite";
+export const DEFAULT_BUILTIN_VISION_MODEL_ID = "gemini-flash-latest";
 
 // Streaming defaults
 export const DEFAULT_TEMPERATURE = 0.7;

--- a/src/components/canvas/canvas-grid-card.tsx
+++ b/src/components/canvas/canvas-grid-card.tsx
@@ -1,6 +1,7 @@
 import { api } from "@convex/_generated/api";
 import {
   ArrowClockwiseIcon,
+  ArrowsClockwiseIcon,
   CheckCircleIcon,
   CircleIcon,
   XIcon,
@@ -197,6 +198,7 @@ function SucceededCard({
 }) {
   const selectedImageIds = useCanvasStore(s => s.selectedImageIds);
   const toggleImageSelection = useCanvasStore(s => s.toggleImageSelection);
+  const loadImageSettings = useCanvasStore(s => s.loadImageSettings);
   const isSelected = selectedImageIds.has(image.id);
   const isSelecting = selectedImageIds.size > 0;
   const managedToast = useToast();
@@ -242,6 +244,15 @@ function SucceededCard({
       toggleImageSelection(image.id);
     },
     [image.id, toggleImageSelection]
+  );
+
+  const handleUseSettings = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      loadImageSettings(image);
+      managedToast.success("Settings loaded into form");
+    },
+    [image, loadImageSettings, managedToast]
   );
 
   const handleClick = useCallback(() => {
@@ -331,6 +342,19 @@ function SucceededCard({
             </button>
           </TooltipTrigger>
           <TooltipContent>Download image</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              type="button"
+              className="flex size-8 items-center justify-center rounded-md bg-black/50 text-white/90 backdrop-blur-sm transition-colors hover:bg-black/70"
+              onClick={handleUseSettings}
+              aria-label="Use settings"
+            >
+              <ArrowsClockwiseIcon className="size-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Use settings</TooltipContent>
         </Tooltip>
         {image.source === "canvas" && image.generationId && (
           <Tooltip>

--- a/src/components/canvas/canvas-image-viewer.tsx
+++ b/src/components/canvas/canvas-image-viewer.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowsClockwiseIcon,
   CaretLeftIcon,
   CaretRightIcon,
   ClockIcon,
@@ -21,6 +22,7 @@ import {
   generateImageFilename,
 } from "@/lib/export";
 import { useToast } from "@/providers/toast-context";
+import { useCanvasStore } from "@/stores/canvas-store";
 import type { CanvasImage } from "@/types";
 
 type CanvasImageViewerProps = {
@@ -173,6 +175,16 @@ export function CanvasImageViewer({
     onRequestDelete?.(image);
   }, [image, onRequestDelete]);
 
+  const loadImageSettings = useCanvasStore(s => s.loadImageSettings);
+  const handleUseSettings = useCallback(() => {
+    if (!image) {
+      return;
+    }
+    loadImageSettings(image);
+    onOpenChange(false);
+    managedToast.success("Settings loaded into form");
+  }, [image, loadImageSettings, onOpenChange, managedToast]);
+
   if (!(open && image)) {
     return null;
   }
@@ -309,6 +321,19 @@ export function CanvasImageViewer({
                   <TooltipContent>Delete image</TooltipContent>
                 </Tooltip>
               )}
+              <Tooltip>
+                <TooltipTrigger>
+                  <button
+                    type="button"
+                    className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    onClick={handleUseSettings}
+                    aria-label="Use settings"
+                  >
+                    <ArrowsClockwiseIcon className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Use settings</TooltipContent>
+              </Tooltip>
               <div className="mx-1 h-4 w-px bg-border/60" />
               <Tooltip>
                 <TooltipTrigger>

--- a/src/hooks/use-file-upload.ts
+++ b/src/hooks/use-file-upload.ts
@@ -9,7 +9,7 @@ import { useConvexFileUpload } from "@/hooks/use-convex-file-upload";
 import { useNotificationDialog } from "@/hooks/use-dialog-management";
 import {
   base64ToUint8Array,
-  convertImageToWebP,
+  compressImage,
   isHeicFile,
   readFileAsBase64,
   readFileAsText,
@@ -97,7 +97,7 @@ async function processImageFile(file: File): Promise<
   const isHeic = isHeicFile(file);
 
   try {
-    const converted = await convertImageToWebP(file);
+    const converted = await compressImage(file);
     const thumbnail = `data:${converted.mimeType};base64,${converted.base64}`;
     const processedFile = new File(
       [base64ToUint8Array(converted.base64)],

--- a/src/lib/file-utils.ts
+++ b/src/lib/file-utils.ts
@@ -72,10 +72,11 @@ function scaleDimensions(
   return { width: Math.round((width * maxSize) / height), height: maxSize };
 }
 
-export async function convertImageToWebP(
+export async function compressImage(
   file: File,
   maxDimension = FILE_LIMITS.MAX_DIMENSION,
-  quality = FILE_LIMITS.IMAGE_QUALITY
+  quality = FILE_LIMITS.IMAGE_QUALITY,
+  format: "image/webp" | "image/jpeg" = "image/webp"
 ): Promise<{
   base64: string;
   mimeType: string;
@@ -124,7 +125,7 @@ export async function convertImageToWebP(
                 }
                 resolve({
                   base64,
-                  mimeType: "image/webp",
+                  mimeType: format,
                   width: scaled.width,
                   height: scaled.height,
                 });
@@ -136,7 +137,7 @@ export async function convertImageToWebP(
               reject(new Error("Failed to convert image"));
             }
           },
-          "image/webp",
+          format,
           quality
         );
       };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -43,7 +43,7 @@ export { validateApiKey } from "./validation";
 
 export {
   base64ToUint8Array,
-  convertImageToWebP,
+  compressImage,
   FILE_EXTENSION_TO_LANGUAGE,
   generateThumbnail,
   generateVideoThumbnail,

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -66,6 +66,13 @@ export type CanvasState = {
   setIsGeneratingPrompt: (v: boolean) => void;
   setPromptModel: (modelId?: string, provider?: string) => void;
   setPromptPersonaId: (id?: string) => void;
+  loadImageSettings: (image: {
+    prompt?: string;
+    model?: string;
+    seed?: number;
+    aspectRatio?: string;
+    quality?: number;
+  }) => void;
 };
 
 type CanvasStoreApi = StoreApi<CanvasState>;
@@ -227,6 +234,30 @@ function createCanvasState(
     setPromptModel: (modelId, provider) =>
       set_({ promptModelId: modelId, promptModelProvider: provider }),
     setPromptPersonaId: id => set_({ promptPersonaId: id }),
+    loadImageSettings: image => {
+      const updates: Partial<CanvasState> = {};
+      if (image.prompt !== undefined) {
+        updates.prompt = image.prompt;
+      }
+      if (image.model) {
+        updates.selectedModelIds = [image.model];
+      }
+      const advancedUpdates: CanvasState["advancedParams"] = {
+        ...get_().advancedParams,
+      };
+      if (image.seed !== undefined) {
+        advancedUpdates.seed = image.seed;
+      }
+      if (image.quality !== undefined) {
+        advancedUpdates.quality = image.quality;
+      }
+      updates.advancedParams = advancedUpdates;
+      if (image.aspectRatio) {
+        updates.aspectRatio = image.aspectRatio;
+      }
+      set_(updates);
+      persistSelections(get_);
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- **Use settings button**: Added to canvas grid cards (hover) and image viewer panel — loads generation parameters (prompt, model, seed, aspect ratio, quality) back into the form for easy iteration
- **Advanced settings indicator**: Small dot badge on the "Advanced Settings" toggle when any non-default value (steps, guidance, seed, negative prompt) is set
- **Image paste/drop**: Paste (Cmd+V) or drag-and-drop images onto the prompt textarea to trigger describe-image flow, with visual drag feedback
- **Bug fixes**: Use vision-capable model (`gemini-flash-latest`) for image description, compress images client-side before describe upload, bump `maxOutputTokens` for thinking-model compatibility, rename `convertImageToWebP` → `compressImage` with configurable output format

## Test plan
- [ ] Hover a succeeded canvas card → "Use settings" button appears, loads params into form
- [ ] Open image viewer → "Use settings" in header loads params and closes viewer
- [ ] Set non-default advanced settings → dot indicator appears on toggle
- [ ] Clear advanced settings → dot disappears
- [ ] Paste a screenshot into prompt textarea → triggers describe flow, generates prompt
- [ ] Drag-drop an image file onto textarea → dashed border feedback, triggers describe flow
- [ ] Verify describe works with both built-in model and user-selected models

🤖 Generated with [Claude Code](https://claude.com/claude-code)