### PR TITLE
feat(canvas): dual upscaler with multiple versions

### DIFF
--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -1016,6 +1016,28 @@ export const userFileSchema = v.object({
   generatedImagePrompt: v.optional(v.string()), // Prompt used for generation
 });
 
+// Shared Replicate prediction status validator
+export const replicateStatusValidator = v.union(
+  v.literal("pending"),
+  v.literal("starting"),
+  v.literal("processing"),
+  v.literal("succeeded"),
+  v.literal("failed"),
+);
+
+// Upscale entry schema for multi-version upscaling
+export const upscaleEntrySchema = v.object({
+  id: v.string(), // crypto.randomUUID()
+  type: v.union(v.literal("standard"), v.literal("creative")),
+  status: replicateStatusValidator,
+  replicateId: v.optional(v.string()),
+  storageId: v.optional(v.id("_storage")),
+  error: v.optional(v.string()),
+  duration: v.optional(v.number()),
+  startedAt: v.optional(v.number()),
+  completedAt: v.optional(v.number()),
+});
+
 // Standalone generation schema (canvas mode, decoupled from chat)
 export const generationSchema = v.object({
   userId: v.id("users"),
@@ -1047,6 +1069,17 @@ export const generationSchema = v.object({
   })),
   duration: v.optional(v.number()),
   batchId: v.optional(v.string()), // Groups multi-model generations
+  /** @deprecated Use upscales array instead. Kept read-only for backward compat. */
+  upscale: v.optional(v.object({
+    status: replicateStatusValidator,
+    replicateId: v.optional(v.string()),
+    storageId: v.optional(v.id("_storage")),
+    error: v.optional(v.string()),
+    duration: v.optional(v.number()),
+    startedAt: v.optional(v.number()),
+    completedAt: v.optional(v.number()),
+  })),
+  upscales: v.optional(v.array(upscaleEntrySchema)),
   createdAt: v.number(),
   completedAt: v.optional(v.number()),
 });
@@ -1075,3 +1108,4 @@ export type CreatePersonaArgs = Infer<typeof personaImportSchema>;
 export type UpdateUserSettingsArgs = Infer<typeof userSettingsUpdateSchema>;
 export type CreateUserModelArgs = Infer<typeof userModelSchema>;
 export type GenerationDoc = Infer<typeof generationSchema>;
+export type UpscaleEntryDoc = Infer<typeof upscaleEntrySchema>;

--- a/src/components/canvas/canvas-generation-form.tsx
+++ b/src/components/canvas/canvas-generation-form.tsx
@@ -1217,6 +1217,9 @@ export function CanvasGenerateButton() {
         batchId,
       });
       resetForm();
+      document
+        .getElementById("canvas-grid-scroll")
+        ?.scrollTo({ top: 0, behavior: "smooth" });
     } finally {
       setIsGenerating(false);
     }

--- a/src/hooks/use-breakpoint-columns.ts
+++ b/src/hooks/use-breakpoint-columns.ts
@@ -1,9 +1,11 @@
 import { type RefObject, useEffect, useState } from "react";
 
 const BREAKPOINTS = [
-  { minWidth: 1280, columns: 4 }, // xl
-  { minWidth: 1024, columns: 3 }, // lg
-  { minWidth: 640, columns: 2 }, // sm
+  { minWidth: 1400, columns: 6 },
+  { minWidth: 1150, columns: 5 },
+  { minWidth: 900, columns: 4 },
+  { minWidth: 650, columns: 3 },
+  { minWidth: 400, columns: 2 },
 ];
 const DEFAULT_COLUMNS = 1;
 

--- a/src/pages/canvas-page.tsx
+++ b/src/pages/canvas-page.tsx
@@ -56,6 +56,7 @@ const FILTER_OPTIONS: { label: string; value: CanvasFilterMode }[] = [
   { label: "All", value: "all" },
   { label: "Canvas", value: "canvas" },
   { label: "Conversations", value: "conversations" },
+  { label: "Upscaled", value: "upscaled" },
 ];
 
 export default function CanvasPage() {
@@ -226,7 +227,10 @@ export default function CanvasPage() {
           </header>
 
           {/* Masonry grid */}
-          <div className="flex-1 overflow-y-auto px-4 pb-4">
+          <div
+            id="canvas-grid-scroll"
+            className="flex-1 overflow-y-auto px-4 pb-4"
+          >
             <CanvasMasonryGrid filterMode={filterMode} />
           </div>
         </div>

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -5,7 +5,7 @@ import { useStoreWithEqualityFn } from "zustand/traditional";
 import { createStore, type StoreApi } from "zustand/vanilla";
 import { CACHE_KEYS, get, set } from "@/lib/local-storage";
 
-export type CanvasFilterMode = "all" | "canvas" | "conversations";
+export type CanvasFilterMode = "all" | "canvas" | "conversations" | "upscaled";
 
 export type ReferenceImage = {
   storageId: Id<"_storage">;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -407,6 +407,28 @@ export type GenerationStatus =
   | "failed"
   | "canceled";
 
+export type UpscaleType = "standard" | "creative";
+
+/** Check whether an upscale entry is still running (pending/starting/processing). */
+export function isUpscaleInProgress(u: { status: string }): boolean {
+  return (
+    u.status === "pending" ||
+    u.status === "starting" ||
+    u.status === "processing"
+  );
+}
+
+export type UpscaleEntry = {
+  id: string;
+  type: UpscaleType;
+  status: "pending" | "starting" | "processing" | "succeeded" | "failed";
+  error?: string;
+  imageUrl?: string;
+  duration?: number;
+  startedAt?: number;
+  completedAt?: number;
+};
+
 /** Unified image type for the "All Images" merged view in canvas mode. */
 export type CanvasImage = {
   id: string;
@@ -420,9 +442,11 @@ export type CanvasImage = {
   createdAt: number;
   aspectRatio?: string;
   quality?: number;
+  error?: string;
   // Canvas-specific
   generationId?: Id<"generations">;
   batchId?: string;
+  upscales: UpscaleEntry[];
   // Conversation-specific
   messageId?: Id<"messages">;
   conversationId?: ConversationId;


### PR DESCRIPTION
## Summary
- Add two-tier upscale system: fast faithful Real-ESRGAN ("Upscale") as primary, opt-in generative Clarity ("Creative Enhance") with tunable presets (Auto, Sharpen, Enhance, Reimagine)
- Support multiple upscaled versions per image with `upscales` array on generations schema (legacy `upscale` field preserved read-only for backward compat)
- Version thumbnail gallery in image viewer with in-progress placeholder, inline cancel, and version switching
- Atomic in-progress guard inside `addUpscaleEntry` mutation to prevent TOCTOU race, idempotent mutations for OCC safety, parallel URL resolution in `normalizeUpscales`

## Test plan
- [ ] "Upscale" button triggers Real-ESRGAN, produces faithful 2x result in version gallery
- [ ] "Creative Enhance" triggers Clarity with conservative defaults, second version appears
- [ ] Toggle between Original / Standard / Creative versions in viewer
- [ ] Delete one version — other remains, storage cleaned up
- [ ] Cancel in-progress upscale — entry removed, can restart
- [ ] Grid card shows latest upscale with correct badge (2x / 2x+)
- [ ] "Upscaled" filter in canvas page works
- [ ] Delete generation cleans up all upscale storage
- [ ] Cannot start two upscales simultaneously (button disabled + server guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)