### PR TITLE
feat(canvas): image edit pipeline with hover filmstrip

### DIFF
--- a/convex/ai/replicate_helpers.ts
+++ b/convex/ai/replicate_helpers.ts
@@ -205,39 +205,39 @@ export function convertAspectRatioToDimensions(aspectRatio: string): {
   width: number;
   height: number;
 } {
-  const baseSize = 1024; // Standard size for most models (already divisible by 8)
+  const baseSize = 1024; // Standard size for most models (already divisible by 16)
 
-  // Helper to round to nearest multiple of 8
-  const roundToMultipleOf8 = (value: number): number => {
-    return Math.round(value / 8) * 8;
+  // Helper to round to nearest multiple of 16 (some edit models require this)
+  const roundToMultipleOf16 = (value: number): number => {
+    return Math.round(value / 16) * 16;
   };
 
   switch (aspectRatio) {
     case "1:1":
       return { width: baseSize, height: baseSize }; // 1024x1024
     case "16:9":
-      // 16:9 ratio from 1024 height = 1820x1024, round to 1824x1024
+      // 16:9 ratio from 1024 height = 1820x1024, round to 1824x1024 (divisible by 16)
       return {
-        width: roundToMultipleOf8(baseSize * (16 / 9)),
+        width: roundToMultipleOf16(baseSize * (16 / 9)),
         height: baseSize,
       };
     case "9:16":
       // 9:16 ratio from 1024 width = 1024x1820, round to 1024x1824
       return {
         width: baseSize,
-        height: roundToMultipleOf8(baseSize * (16 / 9)),
+        height: roundToMultipleOf16(baseSize * (16 / 9)),
       };
     case "4:3":
-      // 4:3 ratio from 1024 height = 1365x1024, round to 1368x1024
+      // 4:3 ratio from 1024 height = 1365x1024, round to 1360x1024
       return {
-        width: roundToMultipleOf8(baseSize * (4 / 3)),
+        width: roundToMultipleOf16(baseSize * (4 / 3)),
         height: baseSize,
       };
     case "3:4":
-      // 3:4 ratio from 1024 width = 1024x1365, round to 1024x1368
+      // 3:4 ratio from 1024 width = 1024x1365, round to 1024x1360
       return {
         width: baseSize,
-        height: roundToMultipleOf8(baseSize * (4 / 3)),
+        height: roundToMultipleOf16(baseSize * (4 / 3)),
       };
     default: {
       // Parse custom ratio like "3:2"
@@ -247,14 +247,14 @@ export function convertAspectRatioToDimensions(aspectRatio: string): {
         if (ratio > 1) {
           // Landscape: fix height, calculate width
           return {
-            width: roundToMultipleOf8(baseSize * ratio),
+            width: roundToMultipleOf16(baseSize * ratio),
             height: baseSize,
           };
         } else {
           // Portrait: fix width, calculate height
           return {
             width: baseSize,
-            height: roundToMultipleOf8(baseSize / ratio),
+            height: roundToMultipleOf16(baseSize / ratio),
           };
         }
       }

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -1069,6 +1069,8 @@ export const generationSchema = v.object({
   })),
   duration: v.optional(v.number()),
   batchId: v.optional(v.string()), // Groups multi-model generations
+  parentGenerationId: v.optional(v.id("generations")),  // immediate parent edit
+  rootGenerationId: v.optional(v.id("generations")),     // root of edit tree (for grouping)
   /** @deprecated Use upscales array instead. Kept read-only for backward compat. */
   upscale: v.optional(v.object({
     status: replicateStatusValidator,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -167,7 +167,9 @@ export default defineSchema({
     .index("by_user_created", ["userId", "createdAt"])
     .index("by_user_status", ["userId", "status", "createdAt"])
     .index("by_replicate_id", ["replicateId"])
-    .index("by_batch", ["batchId", "createdAt"]),
+    .index("by_batch", ["batchId", "createdAt"])
+    .index("by_parent", ["parentGenerationId", "createdAt"])
+    .index("by_root", ["rootGenerationId", "createdAt"]),
 
   userFiles: defineTable(userFileSchema)
     .index("by_user_created", ["userId", "createdAt"])

--- a/src/components/canvas/canvas-gate-check.tsx
+++ b/src/components/canvas/canvas-gate-check.tsx
@@ -1,0 +1,43 @@
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { useReplicateApiKey } from "@/hooks/use-replicate-api-key";
+import { ROUTES } from "@/lib/routes";
+
+export function CanvasGateCheck({ children }: { children: React.ReactNode }) {
+  const { hasReplicateApiKey, isLoading } = useReplicateApiKey();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[100dvh] items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!hasReplicateApiKey) {
+    return (
+      <div className="flex h-[100dvh] items-center justify-center">
+        <div className="mx-auto max-w-md text-center stack-md">
+          <h2 className="text-lg font-semibold">Replicate API Key Required</h2>
+          <p className="text-sm text-muted-foreground">
+            Canvas mode uses your Replicate API key for image generation. Add
+            your key in settings to get started.
+          </p>
+          <div className="flex items-center justify-center gap-3">
+            <Link to={ROUTES.HOME}>
+              <Button variant="ghost" size="sm">
+                Back to Chat
+              </Button>
+            </Link>
+            <Link to={ROUTES.SETTINGS.API_KEYS}>
+              <Button size="sm">Add API Key</Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -27,6 +27,7 @@ export const CACHE_KEYS = {
   canvasPanelWidth: "canvas-panel-width",
   canvasSelections: "canvas-selections",
   canvasPanelVisible: "canvas-panel-visible",
+  canvasLastEditModel: "canvas-last-edit-model",
 } as const;
 
 export type CacheKey = (typeof CACHE_KEYS)[keyof typeof CACHE_KEYS];

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -20,6 +20,7 @@ export const ROUTES = {
     PERSONAS_EDIT: (id: string) => `/settings/personas/${id}/edit`,
   },
   CANVAS: "/canvas",
+  CANVAS_IMAGE: (generationId: string) => `/canvas/image/${generationId}`,
   FAVORITES: "/chat/favorites",
   NOT_FOUND: "/404",
 } as const;

--- a/src/pages/canvas-image-page.tsx
+++ b/src/pages/canvas-image-page.tsx
@@ -1,0 +1,770 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import {
+  ArrowClockwiseIcon,
+  ArrowLeftIcon,
+  CaretDown,
+  CheckIcon,
+  PaperPlaneTiltIcon,
+  TrashSimpleIcon,
+  WarningCircleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { useAction, useMutation, useQuery } from "convex/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
+import { DownloadIcon } from "@/components/animate-ui/icons/download";
+import { ProviderIcon } from "@/components/models/provider-icons";
+import { Button } from "@/components/ui/button";
+import { ResponsivePicker } from "@/components/ui/responsive-picker";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useEnabledImageModels } from "@/hooks/use-enabled-image-models";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { useRequiredParam } from "@/hooks/use-required-param";
+import { downloadFromUrl, generateImageFilename } from "@/lib/export";
+import { CACHE_KEYS, get, set } from "@/lib/local-storage";
+import { ROUTES } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+import { useToast } from "@/providers/toast-context";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type EditTreeNode = {
+  _id: Id<"generations">;
+  prompt: string;
+  model: string;
+  status: string;
+  parentGenerationId?: Id<"generations">;
+  rootGenerationId?: Id<"generations">;
+  imageUrl?: string;
+  error?: string;
+  createdAt: number;
+  aspectRatio?: string;
+};
+
+// ============================================================================
+// Full-screen edit view
+// ============================================================================
+
+export default function CanvasImagePage() {
+  const generationId = useRequiredParam("generationId") as Id<"generations">;
+  const navigate = useNavigate();
+  const managedToast = useToast();
+  const imageAreaRef = useRef<HTMLDivElement>(null);
+
+  // Fetch the target generation
+  const generation = useQuery(api.generations.getGeneration, {
+    id: generationId,
+  });
+
+  // Compute root ID for edit tree
+  const rootId =
+    generation?.rootGenerationId ?? (generation ? generationId : undefined);
+
+  // Fetch edit tree
+  const editTree = useQuery(
+    api.generations.getEditTree,
+    rootId ? { rootId } : "skip"
+  ) as EditTreeNode[] | undefined;
+
+  // Selected node — defaults to the latest
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  // Edit input state
+  const [editPrompt, setEditPrompt] = useState("");
+  const [editModelId, setEditModelId] = useState<string>(() =>
+    get(CACHE_KEYS.canvasLastEditModel, "")
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [promptExpanded, setPromptExpanded] = useState(false);
+  // Track hero image rendered size so placeholders match exactly
+  const [heroSize, setHeroSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+
+  const startEditGeneration = useAction(api.generations.startEditGeneration);
+  const deleteGeneration = useMutation(api.generations.deleteGeneration);
+  const cancelGeneration = useMutation(api.generations.cancelGeneration);
+  const retryGeneration = useMutation(api.generations.retryGeneration);
+  const imageModels = useEnabledImageModels();
+  const img2imgModels = imageModels?.filter(m => m.supportsImageToImage) ?? [];
+
+  // Auto-select latest node when tree updates
+  const treeLength = editTree?.length ?? 0;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: select latest on tree change
+  useEffect(() => {
+    if (editTree && editTree.length > 0) {
+      const latest = editTree[editTree.length - 1];
+      if (latest) {
+        setSelectedNodeId(latest._id);
+      }
+    }
+  }, [treeLength]);
+
+  // Scroll thumbnail strip to show selected
+  const thumbStripRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!(selectedNodeId && thumbStripRef.current)) {
+      return;
+    }
+    const el = thumbStripRef.current.querySelector(
+      `[data-node-id="${selectedNodeId}"]`
+    );
+    el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    setPromptExpanded(false);
+  }, [selectedNodeId]);
+
+  // Resolve selected node
+  const selectedNode = editTree?.find(n => n._id === selectedNodeId);
+  const activeNode = selectedNode ?? editTree?.[editTree.length - 1];
+  const heroImageUrl = activeNode?.imageUrl ?? "";
+
+  // Find the last succeeded node as parent for new edits
+  const lastSucceededNode = editTree
+    ? [...editTree].reverse().find(n => n.status === "succeeded" && n.imageUrl)
+    : undefined;
+
+  // Back handler — return to canvas grid
+  const handleBack = useCallback(() => {
+    navigate(ROUTES.CANVAS);
+  }, [navigate]);
+
+  // Lock body scroll & keyboard
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        handleBack();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => {
+      document.body.style.overflow = prev;
+      document.removeEventListener("keydown", handleKeyDown, { capture: true });
+    };
+  }, [handleBack]);
+
+  // Focus image area on mount
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      imageAreaRef.current?.focus();
+    });
+  }, []);
+
+  // ---- Handlers ----
+
+  const handleSubmitEdit = useCallback(async () => {
+    if (
+      !(lastSucceededNode && editPrompt.trim() && editModelId) ||
+      isSubmitting
+    ) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await startEditGeneration({
+        prompt: editPrompt.trim(),
+        modelId: editModelId,
+        parentGenerationId: lastSucceededNode._id,
+      });
+      set(CACHE_KEYS.canvasLastEditModel, editModelId);
+      setEditPrompt("");
+    } catch {
+      managedToast.error("Failed to start edit");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    lastSucceededNode,
+    editPrompt,
+    editModelId,
+    isSubmitting,
+    startEditGeneration,
+    managedToast,
+  ]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSubmitEdit();
+      }
+    },
+    [handleSubmitEdit]
+  );
+
+  const handleDownload = useCallback(async () => {
+    if (!heroImageUrl) {
+      return;
+    }
+    try {
+      const filename = generateImageFilename(heroImageUrl, activeNode?.prompt);
+      await downloadFromUrl(heroImageUrl, filename);
+      managedToast.success("Image downloaded");
+    } catch {
+      managedToast.error("Failed to download image");
+    }
+  }, [heroImageUrl, activeNode, managedToast]);
+
+  const handleSelectModelFromNode = useCallback(
+    (model: string) => {
+      const match = img2imgModels.find(m => m.modelId === model);
+      if (match) {
+        setEditModelId(match.modelId);
+        set(CACHE_KEYS.canvasLastEditModel, match.modelId);
+        managedToast.success(`Model set to ${match.name}`);
+      }
+    },
+    [img2imgModels, managedToast]
+  );
+
+  const handleDeleteNode = useCallback(
+    async (nodeId: Id<"generations">) => {
+      try {
+        await deleteGeneration({ id: nodeId });
+        managedToast.success("Edit deleted");
+        // If we deleted the active node, select the previous one
+        if (activeNode?._id === nodeId && editTree) {
+          const idx = editTree.findIndex(n => n._id === nodeId);
+          const prev = editTree[idx - 1];
+          if (prev) {
+            setSelectedNodeId(prev._id);
+          }
+        }
+      } catch {
+        managedToast.error("Failed to delete edit");
+      }
+    },
+    [deleteGeneration, managedToast, activeNode, editTree]
+  );
+
+  const handleCancelGeneration = useCallback(
+    async (nodeId: Id<"generations">) => {
+      try {
+        await cancelGeneration({ id: nodeId });
+      } catch {
+        managedToast.error("Failed to cancel");
+      }
+    },
+    [cancelGeneration, managedToast]
+  );
+
+  const handleRetryGeneration = useCallback(
+    async (nodeId: Id<"generations">) => {
+      try {
+        await retryGeneration({ id: nodeId });
+      } catch {
+        managedToast.error("Failed to retry");
+      }
+    },
+    [retryGeneration, managedToast]
+  );
+
+  // ---- Derived state ----
+  const isLoading = !(generation && editTree);
+  const isPending =
+    activeNode?.status === "pending" ||
+    activeNode?.status === "starting" ||
+    activeNode?.status === "processing";
+  const isFailed =
+    activeNode?.status === "failed" || activeNode?.status === "canceled";
+  // Compute placeholder dimensions from aspect ratio + viewport when heroSize isn't available
+  const rootAspectRatio = editTree?.[0]?.aspectRatio;
+  const placeholderSize = (() => {
+    if (heroSize) {
+      return { width: heroSize.width, height: heroSize.height };
+    }
+    // Derive from aspect ratio and max viewport height
+    const maxH = typeof window !== "undefined" ? window.innerHeight - 180 : 600;
+    const [w, h] = (rootAspectRatio ?? "1:1").split(":").map(Number);
+    const ratio = (w ?? 1) / (h ?? 1);
+    if (ratio >= 1) {
+      // Landscape or square: height is the constraint
+      return { width: Math.round(maxH * ratio), height: maxH };
+    }
+    // Portrait: height is constraint, width = height * ratio
+    return { width: Math.round(maxH * ratio), height: maxH };
+  })();
+  const nodeIndex = editTree
+    ? editTree.findIndex(n => n._id === activeNode?._id)
+    : -1;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-label="Edit image"
+      aria-modal="true"
+      className="fixed inset-0 z-modal flex flex-col bg-background"
+    >
+      {/* Back button — always visible, top-left */}
+      <div className="absolute left-4 top-4 z-10">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="gap-1.5 rounded-full bg-card/80 shadow-sm backdrop-blur-md ring-1 ring-border/30 hover:bg-card"
+          onClick={handleBack}
+        >
+          <ArrowLeftIcon className="size-4" />
+          Canvas
+        </Button>
+      </div>
+
+      {/* Image area */}
+      <div
+        ref={imageAreaRef}
+        tabIndex={-1}
+        className="relative flex flex-1 items-center justify-center outline-none min-h-0"
+      >
+        {isLoading ? (
+          <div className="flex items-center justify-center">
+            <Spinner className="size-5 text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="flex items-center gap-3">
+            {/* Thumbnail strip */}
+            {editTree.length > 1 && (
+              <div
+                ref={thumbStripRef}
+                className="flex max-h-[70vh] flex-col gap-1.5 overflow-y-auto scrollbar-none"
+              >
+                {editTree.map((node, idx) => (
+                  <Tooltip key={node._id}>
+                    <TooltipTrigger
+                      data-node-id={node._id}
+                      className={cn(
+                        "relative size-12 shrink-0 overflow-hidden rounded-lg border-2 transition-all",
+                        node._id === activeNode?._id
+                          ? "border-primary ring-1 ring-primary/30"
+                          : "border-transparent hover:border-border/60"
+                      )}
+                      onClick={() => setSelectedNodeId(node._id)}
+                    >
+                      {(() => {
+                        const nodePending =
+                          node.status === "pending" ||
+                          node.status === "starting" ||
+                          node.status === "processing";
+                        if (node.imageUrl) {
+                          return (
+                            <img
+                              src={node.imageUrl}
+                              alt={node.prompt || "Edit"}
+                              className="h-full w-full object-cover"
+                            />
+                          );
+                        }
+                        if (nodePending) {
+                          return (
+                            <div className="flex h-full w-full items-center justify-center bg-muted/30">
+                              <Spinner className="size-3.5" />
+                            </div>
+                          );
+                        }
+                        return (
+                          <div className="flex h-full w-full items-center justify-center bg-destructive/5">
+                            <WarningCircleIcon className="size-3.5 text-destructive" />
+                          </div>
+                        );
+                      })()}
+                    </TooltipTrigger>
+                    <TooltipContent side="left">
+                      {idx === 0 ? "Original" : `Edit ${idx}`}
+                    </TooltipContent>
+                  </Tooltip>
+                ))}
+              </div>
+            )}
+
+            {/* Hero image with info overlay */}
+            <div className="group/hero relative">
+              {(() => {
+                if (heroImageUrl) {
+                  return (
+                    <>
+                      <img
+                        key={activeNode?._id}
+                        src={heroImageUrl}
+                        alt={activeNode?.prompt || "Generated image"}
+                        className="max-h-[calc(100dvh-180px)] rounded-lg object-contain drop-shadow-2xl animate-in fade-in-0 duration-300"
+                        draggable={false}
+                        onLoad={e => {
+                          const img = e.currentTarget;
+                          setHeroSize({
+                            width: img.clientWidth,
+                            height: img.clientHeight,
+                          });
+                        }}
+                      />
+
+                      {/* Download button — top-right on hover */}
+                      <div className="absolute right-2 top-2 opacity-0 transition-opacity duration-200 group-hover/hero:opacity-100">
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <button
+                              type="button"
+                              className="flex size-8 items-center justify-center rounded-md bg-black/40 text-white/80 backdrop-blur-sm transition-all hover:bg-black/60"
+                              onClick={e => {
+                                e.stopPropagation();
+                                handleDownload();
+                              }}
+                              aria-label="Download image"
+                            >
+                              <DownloadIcon animateOnHover size={16} />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>Download</TooltipContent>
+                        </Tooltip>
+                      </div>
+
+                      {/* Info overlay — bottom gradient on hover */}
+                      <div className="absolute inset-x-0 bottom-0 flex flex-col justify-end rounded-b-lg bg-gradient-to-t from-black/70 via-black/40 to-transparent p-3 pt-12 opacity-0 transition-opacity duration-200 group-hover/hero:opacity-100">
+                        {/* Prompt — smooth expand/collapse via max-height */}
+                        {activeNode?.prompt && (
+                          <button
+                            type="button"
+                            className="text-left"
+                            onClick={e => {
+                              e.stopPropagation();
+                              setPromptExpanded(prev => !prev);
+                            }}
+                            title={
+                              promptExpanded
+                                ? "Click to collapse"
+                                : "Click to expand"
+                            }
+                          >
+                            <p
+                              className={cn(
+                                "text-sm leading-snug text-white drop-shadow-sm transition-[max-height] duration-300 ease-out overflow-hidden",
+                                promptExpanded
+                                  ? "max-h-[50vh]"
+                                  : "max-h-[2.625rem]"
+                              )}
+                            >
+                              {activeNode.prompt}
+                            </p>
+                          </button>
+                        )}
+
+                        <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-white/80">
+                          <span className="rounded bg-white/25 px-1.5 py-0.5 font-medium backdrop-blur-sm">
+                            {nodeIndex === 0 ? "Original" : `Edit ${nodeIndex}`}
+                          </span>
+                          {activeNode?.model && (
+                            <Tooltip>
+                              <TooltipTrigger>
+                                <button
+                                  type="button"
+                                  className={cn(
+                                    "rounded px-1.5 py-0.5 transition-colors",
+                                    img2imgModels.some(
+                                      m => m.modelId === activeNode.model
+                                    )
+                                      ? "hover:bg-white/30 cursor-pointer"
+                                      : "cursor-default"
+                                  )}
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    handleSelectModelFromNode(activeNode.model);
+                                  }}
+                                >
+                                  {formatModelName(activeNode.model)}
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                {img2imgModels.some(
+                                  m => m.modelId === activeNode.model
+                                )
+                                  ? "Use this model for edits"
+                                  : "Not available for image editing"}
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
+                          {/* Delete button — only for non-root edits */}
+                          {nodeIndex > 0 && activeNode && (
+                            <Tooltip>
+                              <TooltipTrigger>
+                                <button
+                                  type="button"
+                                  className="rounded px-1.5 py-0.5 text-white/60 transition-colors hover:bg-red-500/30 hover:text-white"
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    handleDeleteNode(activeNode._id);
+                                  }}
+                                >
+                                  <TrashSimpleIcon className="size-3.5" />
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>Delete this edit</TooltipContent>
+                            </Tooltip>
+                          )}
+                        </div>
+                      </div>
+                    </>
+                  );
+                }
+                if (isPending) {
+                  const sizeStyle = placeholderSize;
+                  return (
+                    <div
+                      className="relative flex items-center justify-center rounded-lg skeleton-surface"
+                      style={sizeStyle}
+                    >
+                      <div className="flex flex-col items-center gap-2">
+                        <Spinner />
+                        <span className="text-xs font-medium text-muted-foreground">
+                          Generating edit…
+                        </span>
+                      </div>
+                      {activeNode && (
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <button
+                              type="button"
+                              className="absolute right-2 top-2 flex size-7 items-center justify-center rounded-md bg-black/40 text-white/80 backdrop-blur-sm transition-all hover:bg-black/60"
+                              onClick={() =>
+                                handleCancelGeneration(activeNode._id)
+                              }
+                              aria-label="Cancel generation"
+                            >
+                              <XIcon className="size-3.5" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>Cancel</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                  );
+                }
+                if (isFailed) {
+                  const sizeStyle = placeholderSize;
+                  return (
+                    <div
+                      className="relative flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-destructive/30 bg-destructive/5 px-8 text-center"
+                      style={sizeStyle}
+                    >
+                      <WarningCircleIcon className="size-6 text-destructive" />
+                      <span className="text-sm text-destructive">
+                        {activeNode?.status === "canceled"
+                          ? "Canceled"
+                          : activeNode?.error || "Generation failed"}
+                      </span>
+                      {activeNode && (
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            className="inline-flex items-center gap-1.5 rounded-md bg-background/80 px-2.5 py-1.5 text-xs font-medium text-foreground shadow-sm ring-1 ring-border/40 transition-colors hover:bg-muted"
+                            onClick={() =>
+                              handleRetryGeneration(activeNode._id)
+                            }
+                          >
+                            <ArrowClockwiseIcon className="size-3.5" />
+                            Retry
+                          </button>
+                          <button
+                            type="button"
+                            className="inline-flex items-center gap-1.5 rounded-md bg-background/80 px-2.5 py-1.5 text-xs font-medium text-destructive shadow-sm ring-1 ring-border/40 transition-colors hover:bg-muted"
+                            onClick={() => handleDeleteNode(activeNode._id)}
+                          >
+                            <TrashSimpleIcon className="size-3.5" />
+                            Delete
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  );
+                }
+                return null;
+              })()}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Bottom edit input */}
+      {!isLoading && lastSucceededNode && (
+        <div className="shrink-0 px-4 pb-4 pt-2">
+          <div className="mx-auto max-w-2xl">
+            <div className="chat-input-container">
+              {/* Source image thumbnail */}
+              {lastSucceededNode.imageUrl && (
+                <div className="flex items-center gap-2 px-2.5 pt-2">
+                  <div className="relative size-10 shrink-0 overflow-hidden rounded-md ring-1 ring-border/40">
+                    <img
+                      src={lastSucceededNode.imageUrl}
+                      alt="Edit source"
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    Editing this image
+                  </span>
+                </div>
+              )}
+
+              {/* Auto-resize textarea */}
+              <div
+                className="auto-resize-textarea w-full overflow-y-auto px-2.5 py-1.5 max-h-40"
+                data-replicated-value={`${editPrompt || ""}\u200b`}
+                data-autoresize="true"
+              >
+                <textarea
+                  className="w-full bg-transparent border-0 outline-none ring-0 text-base leading-relaxed transition-colors duration-200 focus:bg-transparent focus:outline-none touch-action-manipulation md:scrollbar-thin resize-none overflow-y-auto placeholder:text-muted-foreground/60 p-0"
+                  rows={1}
+                  placeholder="Describe your edit..."
+                  value={editPrompt}
+                  onChange={e => setEditPrompt(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                />
+              </div>
+
+              {/* Bottom bar — model picker + submit */}
+              <div className="chat-input-bottom-bar flex items-center justify-between p-1">
+                <div className="flex min-w-0 flex-1 items-center">
+                  <EditModelPicker
+                    models={img2imgModels}
+                    selectedModelId={editModelId}
+                    onSelect={id => {
+                      setEditModelId(id);
+                      set(CACHE_KEYS.canvasLastEditModel, id);
+                    }}
+                  />
+                </div>
+                <div className="flex items-center">
+                  <Button
+                    size="icon-sm"
+                    className="h-8 w-8 shrink-0 rounded-full"
+                    onClick={handleSubmitEdit}
+                    disabled={
+                      isSubmitting ||
+                      !editPrompt.trim() ||
+                      !editModelId ||
+                      !lastSucceededNode
+                    }
+                  >
+                    {isSubmitting ? (
+                      <Spinner className="size-4" />
+                    ) : (
+                      <PaperPlaneTiltIcon className="size-4" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>,
+    document.getElementById("root") ?? document.body
+  );
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatModelName(model?: string): string {
+  if (!model) {
+    return "Unknown";
+  }
+  const parts = model.split("/");
+  return parts[parts.length - 1] || model;
+}
+
+// ============================================================================
+// EditModelPicker
+// ============================================================================
+
+type EditModelPickerProps = {
+  models: Array<{
+    modelId: string;
+    name: string;
+    provider?: string;
+  }>;
+  selectedModelId: string;
+  onSelect: (modelId: string) => void;
+};
+
+function EditModelPicker({
+  models,
+  selectedModelId,
+  onSelect,
+}: EditModelPickerProps) {
+  const [open, setOpen] = useState(false);
+  const isDesktop = useMediaQuery("(min-width: 640px)");
+
+  const selectedModel = models.find(m => m.modelId === selectedModelId);
+  const triggerLabel = selectedModel?.name || "Select model";
+  const triggerProvider = selectedModel?.provider || "replicate";
+
+  const desktopTrigger = (
+    <>
+      <div className="flex items-center gap-1.5">
+        <ProviderIcon provider={triggerProvider} className="h-3.5 w-3.5" />
+        <span className="max-w-[180px] truncate font-semibold tracking-tight">
+          {triggerLabel}
+        </span>
+      </div>
+      <CaretDown className="size-3.5 opacity-70" />
+    </>
+  );
+
+  const mobileTrigger = (
+    <ProviderIcon provider={triggerProvider} className="h-4 w-4" />
+  );
+
+  return (
+    <ResponsivePicker
+      open={open}
+      onOpenChange={setOpen}
+      trigger={isDesktop ? desktopTrigger : mobileTrigger}
+      title="Edit model"
+      tooltip="Select edit model"
+      pickerVariant="accent"
+      contentClassName="p-0"
+    >
+      <div className="max-h-[min(calc(100dvh-14rem),280px)] overflow-y-auto p-1">
+        {models.map(m => (
+          <button
+            key={m.modelId}
+            type="button"
+            className={cn(
+              "flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm transition-colors",
+              m.modelId === selectedModelId
+                ? "bg-primary/10 text-foreground"
+                : "text-foreground/80 hover:bg-muted"
+            )}
+            onClick={() => {
+              onSelect(m.modelId);
+              setOpen(false);
+            }}
+          >
+            <ProviderIcon
+              provider={m.provider || "replicate"}
+              className="h-4 w-4 shrink-0"
+            />
+            <span className="flex-1 truncate">{m.name}</span>
+            {m.modelId === selectedModelId && (
+              <CheckIcon className="size-4 shrink-0 text-primary" />
+            )}
+          </button>
+        ))}
+      </div>
+    </ResponsivePicker>
+  );
+}

--- a/src/pages/canvas-page.tsx
+++ b/src/pages/canvas-page.tsx
@@ -1,62 +1,24 @@
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import { useCallback } from "react";
-import { Link } from "react-router-dom";
+import { Link, Outlet } from "react-router-dom";
 import { PanelLeftIcon } from "@/components/animate-ui/icons/panel-left";
+import { CanvasGateCheck } from "@/components/canvas/canvas-gate-check";
 import {
   CanvasGenerateButton,
   CanvasGenerationForm,
 } from "@/components/canvas/canvas-generation-form";
 import { CanvasMasonryGrid } from "@/components/canvas/canvas-masonry-grid";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
-import { useReplicateApiKey } from "@/hooks/use-replicate-api-key";
 import { ROUTES } from "@/lib/routes";
 import type { CanvasFilterMode } from "@/stores/canvas-store";
 import { useCanvasStore } from "@/stores/canvas-store";
-
-function CanvasGateCheck({ children }: { children: React.ReactNode }) {
-  const { hasReplicateApiKey, isLoading } = useReplicateApiKey();
-
-  if (isLoading) {
-    return (
-      <div className="flex h-[100dvh] items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (!hasReplicateApiKey) {
-    return (
-      <div className="flex h-[100dvh] items-center justify-center">
-        <div className="mx-auto max-w-md text-center stack-md">
-          <h2 className="text-lg font-semibold">Replicate API Key Required</h2>
-          <p className="text-sm text-muted-foreground">
-            Canvas mode uses your Replicate API key for image generation. Add
-            your key in settings to get started.
-          </p>
-          <div className="flex items-center justify-center gap-3">
-            <Link to={ROUTES.HOME}>
-              <Button variant="ghost" size="sm">
-                Back to Chat
-              </Button>
-            </Link>
-            <Link to={ROUTES.SETTINGS.API_KEYS}>
-              <Button size="sm">Add API Key</Button>
-            </Link>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  return <>{children}</>;
-}
 
 const FILTER_OPTIONS: { label: string; value: CanvasFilterMode }[] = [
   { label: "All", value: "all" },
   { label: "Canvas", value: "canvas" },
   { label: "Conversations", value: "conversations" },
   { label: "Upscaled", value: "upscaled" },
+  { label: "Edits", value: "edits" },
 ];
 
 export default function CanvasPage() {
@@ -235,6 +197,9 @@ export default function CanvasPage() {
           </div>
         </div>
       </div>
+
+      {/* Child route overlay (image detail modal) */}
+      <Outlet />
     </CanvasGateCheck>
   );
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -53,6 +53,7 @@ const SettingsEditPersonaPage = lazy(
   () => import("./pages/settings/edit-persona-page")
 );
 const CanvasPage = lazy(() => import("./pages/canvas-page"));
+const CanvasImagePage = lazy(() => import("./pages/canvas-image-page"));
 const SignOutPage = lazy(() => import("./pages/sign-out-page"));
 
 const PageLoader = ({
@@ -143,6 +144,12 @@ export const routes: RouteObject[] = [
           </ProtectedSuspense>
         ),
         errorElement: routeErrorElement,
+        children: [
+          {
+            path: "image/:generationId",
+            element: withSuspense(<CanvasImagePage />),
+          },
+        ],
       },
       {
         path: "signout",

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -5,7 +5,12 @@ import { useStoreWithEqualityFn } from "zustand/traditional";
 import { createStore, type StoreApi } from "zustand/vanilla";
 import { CACHE_KEYS, get, set } from "@/lib/local-storage";
 
-export type CanvasFilterMode = "all" | "canvas" | "conversations" | "upscaled";
+export type CanvasFilterMode =
+  | "all"
+  | "canvas"
+  | "conversations"
+  | "upscaled"
+  | "edits";
 
 export type ReferenceImage = {
   storageId: Id<"_storage">;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -446,6 +446,10 @@ export type CanvasImage = {
   // Canvas-specific
   generationId?: Id<"generations">;
   batchId?: string;
+  parentGenerationId?: Id<"generations">;
+  rootGenerationId?: Id<"generations">;
+  editCount?: number;
+  referenceImageUrls?: string[];
   upscales: UpscaleEntry[];
   // Conversation-specific
   messageId?: Id<"messages">;


### PR DESCRIPTION
## Summary
- **Image editing backend**: parent/child generation tracking (`parentGenerationId`, `rootGenerationId`), `startEditGeneration` action, `getEditTree` query, new `by_parent` and `by_root` indexes
- **Edit page** (`canvas-image-page.tsx`): full-screen portal overlay with edit tree thumbnail strip, hero image with hover info, chat-style edit input with model picker, pending/failed state handling
- **Hover filmstrip on grid cards**: replaces the old stacked card visual — hovering shows small thumbnails at the bottom to scrub through edit versions inline, clicking opens the viewer at that image
- **Image viewer improvements**: added section icons (Upscale, Versions), removed Prompt section heading in favor of hover-reveal copy button, added Edit button + Input Images / Edit tree sections
- **Cleanup**: consolidated `convertAspectRatioToDimensions` into single export from `replicate_helpers.ts`, switched image input from base64 data URIs to direct storage URLs, dimension rounding from 8→16 for edit model compat

## Test plan
- [ ] Generate an image, create 2-3 edits via the edit page, verify edit tree displays correctly
- [ ] On grid: hover a root image with edits, verify filmstrip appears with thumbnails
- [ ] Hover filmstrip thumbnails — main image should swap instantly
- [ ] Click a filmstrip thumbnail — viewer should open at that specific edit
- [ ] Verify "Edits" filter mode shows only child edits
- [ ] Verify "Upscaled" filter still works
- [ ] Selection mode: filmstrip should be hidden, multi-select still works
- [ ] Image viewer: verify Upscale/Versions section icons, prompt copy button on hover
- [ ] Edit page: model picker, Cmd+Enter submit, cancel/retry/delete on pending/failed edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)