### PR TITLE
improve(canvas): smooth loading transitions with skeleton shimmer

### DIFF
--- a/src/components/canvas/canvas-masonry-grid.tsx
+++ b/src/components/canvas/canvas-masonry-grid.tsx
@@ -169,7 +169,11 @@ export function CanvasMasonryGrid({ filterMode }: CanvasMasonryGridProps) {
   const editChildrenMap = new Map<string, CanvasImage[]>();
   if (filterMode !== "edits") {
     for (const img of allImages) {
-      if (img.parentGenerationId && img.status === "succeeded") {
+      if (
+        img.parentGenerationId &&
+        img.status !== "failed" &&
+        img.status !== "canceled"
+      ) {
         const rootId = img.rootGenerationId ?? img.parentGenerationId;
         if (rootId) {
           let children = editChildrenMap.get(rootId);

--- a/src/pages/canvas-image-page.tsx
+++ b/src/pages/canvas-image-page.tsx
@@ -335,12 +335,12 @@ export default function CanvasImagePage() {
             <Spinner className="size-5 text-muted-foreground" />
           </div>
         ) : (
-          <div className="flex items-center gap-3">
-            {/* Thumbnail strip */}
+          <div className="relative flex items-center justify-center">
+            {/* Thumbnail strip — positioned outside the hero so it doesn't shift centering */}
             {editTree.length > 1 && (
               <div
                 ref={thumbStripRef}
-                className="flex max-h-[70vh] flex-col gap-1.5 overflow-y-auto scrollbar-none"
+                className="absolute right-full mr-3 flex max-h-[70vh] flex-col gap-1.5 overflow-y-auto scrollbar-none"
               >
                 {editTree.map((node, idx) => (
                   <Tooltip key={node._id}>
@@ -525,12 +525,9 @@ export default function CanvasImagePage() {
                       className="relative flex items-center justify-center rounded-lg skeleton-surface"
                       style={sizeStyle}
                     >
-                      <div className="flex flex-col items-center gap-2">
-                        <Spinner />
-                        <span className="text-xs font-medium text-muted-foreground">
-                          Generating edit…
-                        </span>
-                      </div>
+                      <span className="text-xs font-medium text-muted-foreground">
+                        Generating edit…
+                      </span>
                       {activeNode && (
                         <Tooltip>
                           <TooltipTrigger>


### PR DESCRIPTION
## Summary
- Replace `animate-pulse` with `skeleton-surface` shimmer in canvas grid cards (pending + succeeded states) for consistency with chat image loading
- Add crossfade transition from skeleton to loaded image in grid cards (opacity + aspect-ratio sizing to prevent layout collapse)
- Show pending/generating edits in the grid card filmstrip with spinner thumbnails
- Remove spinner from canvas edit page hero pending state, use just text + shimmer
- Center hero image on edit page by absolutely positioning the thumbnail strip

## Test plan
- [ ] Generate an image in canvas — pending card shows shimmer sweep instead of pulse
- [ ] When image completes, it fades in smoothly over the shimmer
- [ ] Start an edit on a grid image — filmstrip shows spinner thumbnail for the pending edit
- [ ] Open `/canvas/image/:id` — hero image is centered, thumbnail strip doesn't push it off-center
- [ ] Pending edit in edit page shows shimmer with "Generating edit…" text, no spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)