### PR TITLE
improve(canvas): paginate generations and reduce loading flicker

### DIFF
--- a/src/components/canvas/canvas-gate-check.tsx
+++ b/src/components/canvas/canvas-gate-check.tsx
@@ -1,18 +1,16 @@
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import { useReplicateApiKey } from "@/hooks/use-replicate-api-key";
 import { ROUTES } from "@/lib/routes";
 
 export function CanvasGateCheck({ children }: { children: React.ReactNode }) {
   const { hasReplicateApiKey, isLoading } = useReplicateApiKey();
 
+  // While loading, render children normally — the masonry grid has its own
+  // loading state (spinner). This avoids flashing "API key required" before
+  // capabilities are resolved.
   if (isLoading) {
-    return (
-      <div className="flex h-[100dvh] items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <>{children}</>;
   }
 
   if (!hasReplicateApiKey) {

--- a/src/components/canvas/canvas-generation-form.tsx
+++ b/src/components/canvas/canvas-generation-form.tsx
@@ -975,26 +975,53 @@ export function CanvasGenerationForm() {
       {/* Model selection */}
       <div className="stack-xs">
         <span className="text-xs font-medium text-sidebar-muted">Models</span>
-        {!models || models.length === 0 ? (
-          <p className="text-xs text-sidebar-muted/70">
-            No image models available. Add models in{" "}
-            <a href="/settings/models/image" className="text-primary underline">
-              Settings
-            </a>
-            .
-          </p>
-        ) : (
-          <ModelPickerPopover
-            models={models}
-            filteredModels={filteredModels}
-            selectedModelIds={selectedModelIds}
-            toggleModel={toggleModel}
-            showSearch={showSearch}
-            searchQuery={searchQuery}
-            setSearchQuery={setSearchQuery}
-            referenceImages={referenceImages}
-          />
-        )}
+        {(() => {
+          if (models === undefined) {
+            /* Loading — spinner in the trigger shape */
+            return (
+              <div className="flex min-h-9 w-full items-center gap-2 rounded-lg border border-border/50 bg-sidebar-hover px-3 py-1.5">
+                <Spinner className="size-3.5" />
+                <span className="text-sm text-sidebar-muted">
+                  Loading models…
+                </span>
+              </div>
+            );
+          }
+          if (models.length === 0) {
+            /* No models — disabled trigger with settings link */
+            return (
+              <div>
+                <div className="flex min-h-9 w-full items-center gap-1 rounded-lg border border-border/50 bg-sidebar-hover px-2 py-1.5 opacity-50">
+                  <span className="min-w-0 flex-1 truncate px-1 text-sm text-sidebar-muted">
+                    No models available
+                  </span>
+                  <CaretDownIcon className="size-3.5 shrink-0 opacity-40" />
+                </div>
+                <p className="mt-1.5 text-[11px] text-sidebar-muted/70">
+                  Enable image models in{" "}
+                  <a
+                    href="/settings/models/image"
+                    className="text-primary hover:underline"
+                  >
+                    Settings
+                  </a>
+                </p>
+              </div>
+            );
+          }
+          return (
+            <ModelPickerPopover
+              models={models}
+              filteredModels={filteredModels}
+              selectedModelIds={selectedModelIds}
+              toggleModel={toggleModel}
+              showSearch={showSearch}
+              searchQuery={searchQuery}
+              setSearchQuery={setSearchQuery}
+              referenceImages={referenceImages}
+            />
+          );
+        })()}
       </div>
 
       {/* Aspect ratio */}

--- a/src/hooks/use-replicate-api-key.ts
+++ b/src/hooks/use-replicate-api-key.ts
@@ -24,7 +24,7 @@ function hasStoredKey(k: unknown): k is ApiKeyInfo {
  * Consumes apiKeys from UserDataContext to avoid duplicate queries.
  */
 export function useReplicateApiKey() {
-  const { apiKeys, user } = useUserDataContext();
+  const { apiKeys, user, capabilitiesReady } = useUserDataContext();
 
   const hasReplicateApiKey = useMemo(() => {
     // Anonymous users can't have API keys
@@ -47,7 +47,6 @@ export function useReplicateApiKey() {
 
   return {
     hasReplicateApiKey,
-    // No longer loading since we consume from context which handles loading state
-    isLoading: false,
+    isLoading: !capabilitiesReady,
   };
 }

--- a/src/pages/canvas-page.tsx
+++ b/src/pages/canvas-page.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftIcon } from "@phosphor-icons/react";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { Link, Outlet } from "react-router-dom";
 import { PanelLeftIcon } from "@/components/animate-ui/icons/panel-left";
 import { CanvasGateCheck } from "@/components/canvas/canvas-gate-check";
@@ -15,10 +15,9 @@ import { useCanvasStore } from "@/stores/canvas-store";
 
 const FILTER_OPTIONS: { label: string; value: CanvasFilterMode }[] = [
   { label: "All", value: "all" },
-  { label: "Canvas", value: "canvas" },
-  { label: "Conversations", value: "conversations" },
-  { label: "Upscaled", value: "upscaled" },
   { label: "Edits", value: "edits" },
+  { label: "Upscaled", value: "upscaled" },
+  { label: "Chat", value: "conversations" },
 ];
 
 export default function CanvasPage() {
@@ -30,6 +29,7 @@ export default function CanvasPage() {
   const resetPanelWidth = useCanvasStore(s => s.resetPanelWidth);
   const isPanelVisible = useCanvasStore(s => s.isPanelVisible);
   const togglePanel = useCanvasStore(s => s.togglePanel);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
@@ -190,10 +190,15 @@ export default function CanvasPage() {
 
           {/* Masonry grid */}
           <div
+            ref={scrollContainerRef}
             id="canvas-grid-scroll"
             className="flex-1 overflow-y-auto px-4 pb-4"
+            style={{ overflowAnchor: "auto" }}
           >
-            <CanvasMasonryGrid filterMode={filterMode} />
+            <CanvasMasonryGrid
+              filterMode={filterMode}
+              scrollContainerRef={scrollContainerRef}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Paginated canvas grid**: Switch from loading all generations at once to cursor-based pagination (50 initial + 30 per scroll), eliminating slow initial loads for large galleries
- **Eliminated loading flicker**: Skeleton grid while auth/data resolves, synchronous localStorage model catalog, ref-callback for browser-cached images, deferred scroll-sentinel to prevent eager load cascades
- **Reduced re-renders**: Memoized `CanvasGridCard` with custom comparator, separated canvas vs conversation data paths to prevent column redistribution on page growth
- **UX tweaks**: Reordered filter tabs, added client-side "canvas-only" filter (excludes edits), lazy loading + async decoding on all images

## Test plan
- [ ] Open canvas with 50+ generations — verify initial load shows skeleton then images without flash
- [ ] Scroll down — verify more images load seamlessly without layout jumps
- [ ] Switch between filter tabs (All, Edits, Upscaled, Chat) — verify correct filtering
- [ ] Open canvas without Replicate API key — verify gate check still works without blank flash
- [ ] Test edit filmstrip on cards with children — verify edits still display correctly
- [ ] Check model picker shows loading state then resolves without "No models" flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)