### PR TITLE
improve(canvas): undo-able deletion for generations and upscale versions

### DIFF
--- a/convex/generations.ts
+++ b/convex/generations.ts
@@ -75,6 +75,7 @@ async function normalizeUpscales(
       duration?: number;
       startedAt?: number;
       completedAt?: number;
+      isArchived?: boolean;
     }>;
   }
 ): Promise<UpscaleEntryWithUrl[]> {
@@ -117,6 +118,7 @@ async function normalizeUpscales(
           duration: entry.duration,
           startedAt: entry.startedAt,
           completedAt: entry.completedAt,
+          isArchived: entry.isArchived,
         } satisfies UpscaleEntryWithUrl;
       })
     );

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -1036,6 +1036,7 @@ export const upscaleEntrySchema = v.object({
   duration: v.optional(v.number()),
   startedAt: v.optional(v.number()),
   completedAt: v.optional(v.number()),
+  isArchived: v.optional(v.boolean()),
 });
 
 // Standalone generation schema (canvas mode, decoupled from chat)
@@ -1082,6 +1083,7 @@ export const generationSchema = v.object({
     completedAt: v.optional(v.number()),
   })),
   upscales: v.optional(v.array(upscaleEntrySchema)),
+  isArchived: v.optional(v.boolean()),
   createdAt: v.number(),
   completedAt: v.optional(v.number()),
 });

--- a/src/components/canvas/canvas-masonry-grid.tsx
+++ b/src/components/canvas/canvas-masonry-grid.tsx
@@ -355,7 +355,7 @@ export function CanvasMasonryGrid({
       let undone = false;
       const count = toArchive.length;
       managedToast.success(`${count} image${count === 1 ? "" : "s"} deleted`, {
-        id: "delete-gen-batch",
+        id: `delete-gen-batch-${Date.now()}`,
         duration: 5000,
         isUndo: true,
         action: {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -76,6 +76,7 @@ export { useProfiles } from "./use-profiles";
 // =============================================================================
 
 export { useArchiveConversation } from "./use-archive-conversation";
+export { useArchiveGeneration } from "./use-archive-generation";
 export { useConversationImport } from "./use-conversation-import";
 export { useConversationLimit } from "./use-conversation-limit";
 export { useDeleteConversation } from "./use-delete-conversation";

--- a/src/hooks/use-archive-generation.ts
+++ b/src/hooks/use-archive-generation.ts
@@ -1,0 +1,49 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useMutation } from "convex/react";
+import { useCallback } from "react";
+
+/**
+ * Centralized hook for archiving/unarchiving canvas generations and upscale entries.
+ *
+ * Does NOT include toasts — callers handle their own UX (countdown toast + undo).
+ */
+export function useArchiveGeneration() {
+  const archiveMutation = useMutation(api.generations.archiveGeneration);
+  const unarchiveMutation = useMutation(api.generations.unarchiveGeneration);
+  const archiveUpscaleMutation = useMutation(
+    api.generations.archiveUpscaleEntry
+  );
+  const unarchiveUpscaleMutation = useMutation(
+    api.generations.unarchiveUpscaleEntry
+  );
+
+  const archiveGeneration = useCallback(
+    (id: Id<"generations">) => archiveMutation({ id }),
+    [archiveMutation]
+  );
+
+  const unarchiveGeneration = useCallback(
+    (id: Id<"generations">) => unarchiveMutation({ id }),
+    [unarchiveMutation]
+  );
+
+  const archiveUpscaleEntry = useCallback(
+    (id: Id<"generations">, upscaleId: string) =>
+      archiveUpscaleMutation({ id, upscaleId }),
+    [archiveUpscaleMutation]
+  );
+
+  const unarchiveUpscaleEntry = useCallback(
+    (id: Id<"generations">, upscaleId: string) =>
+      unarchiveUpscaleMutation({ id, upscaleId }),
+    [unarchiveUpscaleMutation]
+  );
+
+  return {
+    archiveGeneration,
+    unarchiveGeneration,
+    archiveUpscaleEntry,
+    unarchiveUpscaleEntry,
+  };
+}


### PR DESCRIPTION
## Summary

- Replace permanent-delete-with-confirmation-dialog with **archive → 5s countdown toast with undo → permanent delete** pattern, matching the existing conversation delete UX
- Add `isArchived` soft-delete field to generation and upscale entry schemas with archive/unarchive mutations
- Rewire all canvas delete flows: grid single, grid batch, edit node, upscale version, and failed generations
- Remove confirmation dialog from grid deletes (undo toast replaces it)
- Fix grid card fade-in animation replaying when cards shift position after deletion

## Test plan

- [ ] Delete single image from grid → verify toast with countdown → click undo → image reappears
- [ ] Batch select + delete → verify single toast → undo restores all
- [ ] Delete edit node → verify toast → undo restores node in thumbnail strip
- [ ] Delete upscale version → verify toast → undo restores version in viewer
- [ ] Let countdown expire → verify permanent deletion (image gone after refresh)
- [ ] Delete image → verify remaining cards don't replay fade-in animation
- [ ] Delete then navigate away → verify no unexpected redirects during countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)