### PR TITLE
Add mobile-responsive layout for canvas image viewer

### DIFF
--- a/src/components/canvas/canvas-gate-check.tsx
+++ b/src/components/canvas/canvas-gate-check.tsx
@@ -15,7 +15,7 @@ export function CanvasGateCheck({ children }: { children: React.ReactNode }) {
 
   if (!hasReplicateApiKey) {
     return (
-      <div className="flex h-[100dvh] items-center justify-center">
+      <div className="flex h-[100dvh] items-center justify-center px-4">
         <div className="mx-auto max-w-md text-center stack-md">
           <h2 className="text-lg font-semibold">Replicate API Key Required</h2>
           <p className="text-sm text-muted-foreground">

--- a/src/components/canvas/canvas-generation-form.tsx
+++ b/src/components/canvas/canvas-generation-form.tsx
@@ -242,10 +242,10 @@ function ModelPickerPopover({
         <CaretDownIcon className="size-3.5 shrink-0 opacity-60" />
       </PopoverTrigger>
       <PopoverContent
-        side="right"
+        side="bottom"
         align="start"
         sideOffset={8}
-        className="w-[360px] p-0"
+        className="w-[min(360px,calc(100vw-2rem))] p-0"
       >
         <div
           className="flex max-h-[min(480px,60vh)] flex-col"

--- a/src/components/canvas/canvas-image-viewer.tsx
+++ b/src/components/canvas/canvas-image-viewer.tsx
@@ -30,6 +30,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useArchiveGeneration } from "@/hooks/use-archive-generation";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import {
   copyImageToClipboard,
   downloadFromUrl,
@@ -446,6 +447,9 @@ export function CanvasImageViewer({
     ]
   );
 
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [mobileInfoOpen, setMobileInfoOpen] = useState(false);
+
   const loadImageSettings = useCanvasStore(s => s.loadImageSettings);
   const handleUseSettings = useCallback(() => {
     if (!image) {
@@ -470,13 +474,17 @@ export function CanvasImageViewer({
       <div className="fixed inset-0 z-modal bg-background/95 backdrop-blur-lg animate-in fade-in-0 [animation-duration:200ms]" />
 
       {/* Full-screen container */}
-      <div className="fixed inset-0 z-modal flex">
-        {/* Image area (left) */}
+      <div className="fixed inset-0 z-modal flex flex-col md:flex-row">
+        {/* Image area */}
         <div
           ref={imageAreaRef}
           tabIndex={-1}
-          className="relative flex flex-1 items-center justify-center outline-none"
-          onClick={() => onOpenChange(false)}
+          className="relative flex flex-1 items-center justify-center outline-none min-h-0"
+          onClick={() => {
+            if (isDesktop) {
+              onOpenChange(false);
+            }
+          }}
           onKeyDown={e => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
@@ -484,6 +492,46 @@ export function CanvasImageViewer({
             }
           }}
         >
+          {/* Mobile: Close + Info buttons at top */}
+          {!isDesktop && (
+            <div className="absolute left-3 right-3 top-3 z-10 flex items-center justify-between">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => onOpenChange(false)}
+                className="h-9 w-9 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md"
+                aria-label="Close"
+              >
+                <XIcon className="size-4" />
+              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={handleDownload}
+                  className="h-9 w-9 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md"
+                  aria-label="Download"
+                >
+                  <DownloadIcon size={16} />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => setMobileInfoOpen(!mobileInfoOpen)}
+                  className="h-9 w-9 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md"
+                  aria-label="Image details"
+                >
+                  <CaretDownIcon
+                    className={cn(
+                      "size-4 transition-transform",
+                      mobileInfoOpen && "rotate-180"
+                    )}
+                  />
+                </Button>
+              </div>
+            </div>
+          )}
+
           {/* Navigation buttons */}
           {images.length > 1 && (
             <>
@@ -494,10 +542,10 @@ export function CanvasImageViewer({
                   e.stopPropagation();
                   goToPrevious();
                 }}
-                className="absolute left-4 top-1/2 -translate-y-1/2 z-10 h-12 w-12 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md hover:bg-card transition-colors duration-200"
+                className="absolute left-2 top-1/2 -translate-y-1/2 z-10 h-9 w-9 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md hover:bg-card transition-colors duration-200 md:left-4 md:h-12 md:w-12"
                 aria-label="Previous image"
               >
-                <CaretLeftIcon className="size-6" />
+                <CaretLeftIcon className="size-4 md:size-6" />
               </Button>
 
               <Button
@@ -507,23 +555,23 @@ export function CanvasImageViewer({
                   e.stopPropagation();
                   goToNext();
                 }}
-                className="absolute right-4 top-1/2 -translate-y-1/2 z-10 h-12 w-12 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md hover:bg-card transition-colors duration-200"
+                className="absolute right-2 top-1/2 -translate-y-1/2 z-10 h-9 w-9 rounded-full bg-card/90 text-foreground shadow-lg dark:ring-1 dark:ring-white/[0.06] backdrop-blur-md hover:bg-card transition-colors duration-200 md:right-4 md:h-12 md:w-12"
                 aria-label="Next image"
               >
-                <CaretRightIcon className="size-6" />
+                <CaretRightIcon className="size-4 md:size-6" />
               </Button>
             </>
           )}
 
           {/* Counter pill */}
           {images.length > 1 && (
-            <div className="absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-card/90 px-3 py-1.5 text-xs font-medium tabular-nums text-muted-foreground shadow-lg backdrop-blur-md dark:ring-1 dark:ring-white/[0.06]">
+            <div className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full bg-card/90 px-3 py-1.5 text-xs font-medium tabular-nums text-muted-foreground shadow-lg backdrop-blur-md dark:ring-1 dark:ring-white/[0.06] md:bottom-4">
               {currentIndex + 1} / {images.length}
             </div>
           )}
 
           {/* Image */}
-          <div className="flex h-full w-full items-center justify-center p-8 pointer-events-none transition-all duration-300 ease-out animate-in fade-in-0 zoom-in-95">
+          <div className="flex h-full w-full items-center justify-center p-4 pointer-events-none transition-all duration-300 ease-out animate-in fade-in-0 zoom-in-95 md:p-8">
             <img
               key={`${image.id}-${activeVersionId}`}
               src={activeImageUrl}
@@ -537,533 +585,583 @@ export function CanvasImageViewer({
           </div>
         </div>
 
-        {/* Info panel (right) */}
-        <div
-          className="flex w-[380px] shrink-0 flex-col border-l border-border/50 bg-card/80 backdrop-blur-md animate-in slide-in-from-right-4 fade-in-0 duration-300"
-          onClick={e => e.stopPropagation()}
-          onKeyDown={e => e.stopPropagation()}
-        >
-          {/* Panel header with actions */}
-          <div className="flex items-start justify-between gap-3 border-b border-border/40 p-5">
-            <div className="min-w-0">
-              <h2 className="text-base font-semibold text-foreground">
-                {formatModelName(image.model)}
-              </h2>
-            </div>
-            <div className="flex shrink-0 items-center gap-1">
-              <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    type="button"
-                    className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                    onClick={handleCopyImage}
-                    aria-label="Copy image"
-                  >
-                    <CopyIcon animateOnHover size={16} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Copy image</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    type="button"
-                    className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                    onClick={handleDownload}
-                    aria-label="Download image"
-                  >
-                    <DownloadIcon animateOnHover size={16} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Download image</TooltipContent>
-              </Tooltip>
-              {image.source === "canvas" && image.generationId && (
-                <>
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <button
-                        type="button"
-                        className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
-                        onClick={handleDelete}
-                        aria-label="Delete image"
-                      >
-                        <TrashIcon animateOnHover size={16} />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>Delete image</TooltipContent>
-                  </Tooltip>
-                  {image.status === "succeeded" && (
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <button
-                          type="button"
-                          className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                          onClick={() => {
-                            if (!image.generationId) {
-                              return;
-                            }
-                            // Navigate directly — don't close the viewer first
-                            // to avoid a flash between the viewer closing and the
-                            // edit modal opening. The edit modal's backdrop covers
-                            // the viewer, and the viewer unmounts when the user
-                            // navigates back to /canvas.
-                            navigate(ROUTES.CANVAS_IMAGE(image.generationId));
-                          }}
-                          aria-label="Edit image"
-                        >
-                          <PencilSimpleIcon className="size-4" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent>Edit image</TooltipContent>
-                    </Tooltip>
-                  )}
-                </>
-              )}
-              <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    type="button"
-                    className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                    onClick={handleUseSettings}
-                    aria-label="Use settings"
-                  >
-                    <ArrowsClockwiseIcon className="size-4" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Use settings</TooltipContent>
-              </Tooltip>
-              <div className="mx-1 h-4 w-px bg-border/60" />
-              <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    type="button"
-                    className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                    onClick={() => onOpenChange(false)}
-                    aria-label="Close"
-                  >
-                    <XIcon className="size-4" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Close</TooltipContent>
-              </Tooltip>
-            </div>
+        {/* Mobile: Expandable info panel (bottom sheet style) */}
+        {!isDesktop && mobileInfoOpen && (
+          <div
+            className="shrink-0 max-h-[50dvh] overflow-y-auto border-t border-border/50 bg-card/95 backdrop-blur-md animate-in slide-in-from-bottom-4 fade-in-0 duration-200 scrollbar-thin"
+            onClick={e => e.stopPropagation()}
+            onKeyDown={e => e.stopPropagation()}
+          >
+            <ViewerInfoPanelContent
+              image={image}
+              activeVersionId={activeVersionId}
+              setActiveVersionId={setActiveVersionId}
+              succeededUpscales={succeededUpscales}
+              inProgressUpscale={inProgressUpscale}
+              failedUpscale={failedUpscale}
+              hasAnyInProgress={hasAnyInProgress}
+              isUpscaling={isUpscaling}
+              isCancelingUpscale={isCancelingUpscale}
+              showUpscaleSettings={showUpscaleSettings}
+              setShowUpscaleSettings={setShowUpscaleSettings}
+              creativePreset={creativePreset}
+              setCreativePreset={setCreativePreset}
+              upscalePrompt={upscalePrompt}
+              setUpscalePrompt={setUpscalePrompt}
+              hasNonDefaultCreativeSettings={hasNonDefaultCreativeSettings}
+              handleCopyImage={handleCopyImage}
+              handleDownload={handleDownload}
+              handleDelete={handleDelete}
+              handleCopyText={handleCopyText}
+              handleStandardUpscale={handleStandardUpscale}
+              handleCreativeUpscale={handleCreativeUpscale}
+              handleCancelUpscale={handleCancelUpscale}
+              handleRetryUpscale={handleRetryUpscale}
+              handleDeleteUpscaleVersion={handleDeleteUpscaleVersion}
+              handleUseSettings={handleUseSettings}
+              onOpenChange={onOpenChange}
+              navigate={navigate}
+              sourcePreviewUrl={sourcePreviewUrl}
+              setSourcePreviewUrl={setSourcePreviewUrl}
+              conversation={conversation}
+            />
           </div>
+        )}
 
-          {/* Metadata badges + Version switcher */}
-          <div className="flex flex-wrap items-center gap-2 border-b border-border/40 px-5 py-4">
-            {image.duration !== undefined && (
-              <span className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-xs font-medium text-foreground">
-                <ClockIcon className="size-3.5" />
-                {image.duration.toFixed(1)}s
-              </span>
-            )}
-            {image.aspectRatio && (
-              <span className="inline-flex items-center rounded-md bg-muted px-2.5 py-1 text-xs font-medium text-foreground">
-                {image.aspectRatio}
-              </span>
-            )}
-            {image.quality !== undefined && (
-              <span className="inline-flex items-center rounded-md bg-muted px-2.5 py-1 text-xs font-medium text-foreground">
-                Quality {image.quality}
-              </span>
-            )}
-            {image.seed !== undefined && (
-              <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    type="button"
-                    className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-xs font-medium tabular-nums text-foreground transition-colors hover:bg-muted/80"
-                    onClick={() => handleCopyText(String(image.seed), "Seed")}
-                  >
-                    {image.seed}
-                    <CopyIcon size={12} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Copy seed</TooltipContent>
-              </Tooltip>
-            )}
-
-            {succeededUpscales.length > 0 && (
-              <span className="inline-flex items-center rounded-md bg-primary/15 px-2.5 py-1 text-xs font-medium text-primary">
-                {succeededUpscales.length} upscale
-                {succeededUpscales.length > 1 ? "s" : ""}
-              </span>
-            )}
-          </div>
-
-          {/* Prompt + Upscale section (scrollable) */}
-          <div className="flex-1 overflow-y-auto px-5 py-4">
-            {image.prompt && (
-              <div className="group/prompt relative">
-                <p className="text-sm leading-relaxed text-foreground/90 pr-7">
-                  {image.prompt}
-                </p>
+        {/* Desktop: Info panel (right) */}
+        {isDesktop && (
+          <div
+            className="flex w-[380px] shrink-0 flex-col border-l border-border/50 bg-card/80 backdrop-blur-md animate-in slide-in-from-right-4 fade-in-0 duration-300"
+            onClick={e => e.stopPropagation()}
+            onKeyDown={e => e.stopPropagation()}
+          >
+            {/* Panel header with actions */}
+            <div className="flex items-start justify-between gap-3 border-b border-border/40 p-5">
+              <div className="min-w-0">
+                <h2 className="text-base font-semibold text-foreground">
+                  {formatModelName(image.model)}
+                </h2>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
                 <Tooltip>
                   <TooltipTrigger>
                     <button
                       type="button"
-                      className="absolute right-0 top-0 flex size-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-all hover:bg-muted hover:text-foreground group-hover/prompt:opacity-100"
-                      onClick={() =>
-                        handleCopyText(image.prompt ?? "", "Prompt")
-                      }
-                      aria-label="Copy prompt"
+                      className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      onClick={handleCopyImage}
+                      aria-label="Copy image"
                     >
-                      <CopyIcon animateOnHover size={14} />
+                      <CopyIcon animateOnHover size={16} />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent>Copy prompt</TooltipContent>
+                  <TooltipContent>Copy image</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <button
+                      type="button"
+                      className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      onClick={handleDownload}
+                      aria-label="Download image"
+                    >
+                      <DownloadIcon animateOnHover size={16} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Download image</TooltipContent>
+                </Tooltip>
+                {image.source === "canvas" && image.generationId && (
+                  <>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <button
+                          type="button"
+                          className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
+                          onClick={handleDelete}
+                          aria-label="Delete image"
+                        >
+                          <TrashIcon animateOnHover size={16} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>Delete image</TooltipContent>
+                    </Tooltip>
+                    {image.status === "succeeded" && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <button
+                            type="button"
+                            className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                            onClick={() => {
+                              if (!image.generationId) {
+                                return;
+                              }
+                              // Navigate directly — don't close the viewer first
+                              // to avoid a flash between the viewer closing and the
+                              // edit modal opening. The edit modal's backdrop covers
+                              // the viewer, and the viewer unmounts when the user
+                              // navigates back to /canvas.
+                              navigate(ROUTES.CANVAS_IMAGE(image.generationId));
+                            }}
+                            aria-label="Edit image"
+                          >
+                            <PencilSimpleIcon className="size-4" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>Edit image</TooltipContent>
+                      </Tooltip>
+                    )}
+                  </>
+                )}
+                <Tooltip>
+                  <TooltipTrigger>
+                    <button
+                      type="button"
+                      className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      onClick={handleUseSettings}
+                      aria-label="Use settings"
+                    >
+                      <ArrowsClockwiseIcon className="size-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Use settings</TooltipContent>
+                </Tooltip>
+                <div className="mx-1 h-4 w-px bg-border/60" />
+                <Tooltip>
+                  <TooltipTrigger>
+                    <button
+                      type="button"
+                      className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      onClick={() => onOpenChange(false)}
+                      aria-label="Close"
+                    >
+                      <XIcon className="size-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Close</TooltipContent>
                 </Tooltip>
               </div>
-            )}
+            </div>
 
-            {/* Input images section */}
-            {image.referenceImageUrls &&
-              image.referenceImageUrls.length > 0 && (
-                <div className="mt-4 border-t border-border/40 pt-4">
-                  <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                    <ImageIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
-                    Input Images
-                  </h3>
-                  <div className="flex gap-2">
-                    {image.referenceImageUrls.map((url, idx) => (
+            {/* Metadata badges + Version switcher */}
+            <div className="flex flex-wrap items-center gap-2 border-b border-border/40 px-5 py-4">
+              {image.duration !== undefined && (
+                <span className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-xs font-medium text-foreground">
+                  <ClockIcon className="size-3.5" />
+                  {image.duration.toFixed(1)}s
+                </span>
+              )}
+              {image.aspectRatio && (
+                <span className="inline-flex items-center rounded-md bg-muted px-2.5 py-1 text-xs font-medium text-foreground">
+                  {image.aspectRatio}
+                </span>
+              )}
+              {image.quality !== undefined && (
+                <span className="inline-flex items-center rounded-md bg-muted px-2.5 py-1 text-xs font-medium text-foreground">
+                  Quality {image.quality}
+                </span>
+              )}
+              {image.seed !== undefined && (
+                <Tooltip>
+                  <TooltipTrigger>
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-xs font-medium tabular-nums text-foreground transition-colors hover:bg-muted/80"
+                      onClick={() => handleCopyText(String(image.seed), "Seed")}
+                    >
+                      {image.seed}
+                      <CopyIcon size={12} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy seed</TooltipContent>
+                </Tooltip>
+              )}
+
+              {succeededUpscales.length > 0 && (
+                <span className="inline-flex items-center rounded-md bg-primary/15 px-2.5 py-1 text-xs font-medium text-primary">
+                  {succeededUpscales.length} upscale
+                  {succeededUpscales.length > 1 ? "s" : ""}
+                </span>
+              )}
+            </div>
+
+            {/* Prompt + Upscale section (scrollable) */}
+            <div className="flex-1 overflow-y-auto px-5 py-4">
+              {image.prompt && (
+                <div className="group/prompt relative">
+                  <p className="text-sm leading-relaxed text-foreground/90 pr-7">
+                    {image.prompt}
+                  </p>
+                  <Tooltip>
+                    <TooltipTrigger>
                       <button
-                        key={url}
                         type="button"
-                        className="relative size-14 shrink-0 overflow-hidden rounded-lg ring-1 ring-border/40 transition-all hover:ring-2 hover:ring-primary/50"
-                        onClick={() => setSourcePreviewUrl(url)}
+                        className="absolute right-0 top-0 flex size-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-all hover:bg-muted hover:text-foreground group-hover/prompt:opacity-100"
+                        onClick={() =>
+                          handleCopyText(image.prompt ?? "", "Prompt")
+                        }
+                        aria-label="Copy prompt"
                       >
-                        <img
-                          src={url}
-                          alt={`Source ${idx + 1}`}
-                          className="h-full w-full object-cover"
-                        />
-                        <span className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-0.5 text-center text-[10px] font-medium text-white backdrop-blur-sm">
-                          Source
-                        </span>
+                        <CopyIcon animateOnHover size={14} />
                       </button>
-                    ))}
-                  </div>
+                    </TooltipTrigger>
+                    <TooltipContent>Copy prompt</TooltipContent>
+                  </Tooltip>
                 </div>
               )}
 
-            {/* Edit tree section */}
-            {image.source === "canvas" &&
-              image.generationId &&
-              !image.parentGenerationId &&
-              (image.editCount ?? 0) > 0 && (
+              {/* Input images section */}
+              {image.referenceImageUrls &&
+                image.referenceImageUrls.length > 0 && (
+                  <div className="mt-4 border-t border-border/40 pt-4">
+                    <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      <ImageIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
+                      Input Images
+                    </h3>
+                    <div className="flex gap-2">
+                      {image.referenceImageUrls.map((url, idx) => (
+                        <button
+                          key={url}
+                          type="button"
+                          className="relative size-14 shrink-0 overflow-hidden rounded-lg ring-1 ring-border/40 transition-all hover:ring-2 hover:ring-primary/50"
+                          onClick={() => setSourcePreviewUrl(url)}
+                        >
+                          <img
+                            src={url}
+                            alt={`Source ${idx + 1}`}
+                            className="h-full w-full object-cover"
+                          />
+                          <span className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-0.5 text-center text-[10px] font-medium text-white backdrop-blur-sm">
+                            Source
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+              {/* Edit tree section */}
+              {image.source === "canvas" &&
+                image.generationId &&
+                !image.parentGenerationId &&
+                (image.editCount ?? 0) > 0 && (
+                  <div className="mt-4 border-t border-border/40 pt-4">
+                    <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      <TreeStructureIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
+                      Edits ({image.editCount})
+                    </h3>
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-3 rounded-lg border border-border/40 p-2.5 text-left transition-colors hover:bg-muted/50"
+                      onClick={() => {
+                        if (image.generationId) {
+                          navigate(ROUTES.CANVAS_IMAGE(image.generationId));
+                        }
+                      }}
+                    >
+                      <div className="relative size-10 shrink-0 overflow-hidden rounded-md ring-1 ring-border/40">
+                        <img
+                          src={image.imageUrl}
+                          alt="Edit tree"
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {image.prompt || "Edit tree"}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {image.editCount} edit
+                          {(image.editCount ?? 0) > 1 ? "s" : ""}
+                        </p>
+                      </div>
+                      <CaretRightIcon className="size-4 shrink-0 text-muted-foreground" />
+                    </button>
+                  </div>
+                )}
+
+              {/* Conversation link */}
+              {image.source === "conversation" && image.conversationId && (
                 <div className="mt-4 border-t border-border/40 pt-4">
                   <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                    <TreeStructureIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
-                    Edits ({image.editCount})
+                    <ChatCircleIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
+                    Conversation
                   </h3>
                   <button
                     type="button"
                     className="flex w-full items-center gap-3 rounded-lg border border-border/40 p-2.5 text-left transition-colors hover:bg-muted/50"
                     onClick={() => {
-                      if (image.generationId) {
-                        navigate(ROUTES.CANVAS_IMAGE(image.generationId));
-                      }
+                      navigate(
+                        ROUTES.CHAT_CONVERSATION(image.conversationId as string)
+                      );
+                      onOpenChange(false);
                     }}
                   >
-                    <div className="relative size-10 shrink-0 overflow-hidden rounded-md ring-1 ring-border/40">
-                      <img
-                        src={image.imageUrl}
-                        alt="Edit tree"
-                        className="h-full w-full object-cover"
-                      />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium text-foreground">
-                        {image.prompt || "Edit tree"}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {image.editCount} edit
-                        {(image.editCount ?? 0) > 1 ? "s" : ""}
-                      </p>
-                    </div>
+                    <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                      {conversation?.title ?? "Conversation"}
+                    </p>
                     <CaretRightIcon className="size-4 shrink-0 text-muted-foreground" />
                   </button>
                 </div>
               )}
 
-            {/* Conversation link */}
-            {image.source === "conversation" && image.conversationId && (
-              <div className="mt-4 border-t border-border/40 pt-4">
-                <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  <ChatCircleIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
-                  Conversation
-                </h3>
-                <button
-                  type="button"
-                  className="flex w-full items-center gap-3 rounded-lg border border-border/40 p-2.5 text-left transition-colors hover:bg-muted/50"
-                  onClick={() => {
-                    navigate(
-                      ROUTES.CHAT_CONVERSATION(image.conversationId as string)
-                    );
-                    onOpenChange(false);
-                  }}
-                >
-                  <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                    {conversation?.title ?? "Conversation"}
-                  </p>
-                  <CaretRightIcon className="size-4 shrink-0 text-muted-foreground" />
-                </button>
-              </div>
-            )}
+              {/* Upscale section */}
+              {image.source === "canvas" && image.generationId && (
+                <div className="mt-4 border-t border-border/40 pt-4">
+                  <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    <ArrowsOutIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
+                    Upscale
+                  </h3>
 
-            {/* Upscale section */}
-            {image.source === "canvas" && image.generationId && (
-              <div className="mt-4 border-t border-border/40 pt-4">
-                <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  <ArrowsOutIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
-                  Upscale
-                </h3>
-
-                {/* Failed state */}
-                {!hasAnyInProgress && failedUpscale && (
-                  <div className="stack-sm mb-3">
-                    <p className="text-sm text-destructive">
-                      {failedUpscale.error ?? "Upscale failed"}
-                    </p>
-                    <Button
-                      variant="outline"
-                      className="w-full gap-2"
-                      onClick={handleRetryUpscale}
-                      disabled={isUpscaling}
-                    >
-                      <ArrowClockwiseIcon className="size-4" />
-                      {isUpscaling ? "Retrying..." : "Retry"}
-                    </Button>
-                  </div>
-                )}
-
-                {/* Upscale buttons — always visible, disabled when in-progress */}
-                <div className="stack-sm">
-                  {/* Standard upscale — primary */}
-                  <div className="relative">
-                    <Button
-                      className="w-full gap-2"
-                      onClick={handleStandardUpscale}
-                      disabled={isUpscaling || hasAnyInProgress}
-                    >
-                      {inProgressUpscale?.type === "standard" ? (
-                        <Spinner className="size-4" />
-                      ) : (
-                        <ArrowsOutIcon className="size-4" />
-                      )}
-                      {inProgressUpscale?.type === "standard"
-                        ? "Upscaling..."
-                        : "Upscale"}
-                    </Button>
-                    {inProgressUpscale?.type === "standard" && (
+                  {/* Failed state */}
+                  {!hasAnyInProgress && failedUpscale && (
+                    <div className="stack-sm mb-3">
+                      <p className="text-sm text-destructive">
+                        {failedUpscale.error ?? "Upscale failed"}
+                      </p>
                       <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        className="absolute right-1 top-1/2 -translate-y-1/2"
-                        onClick={handleCancelUpscale}
-                        disabled={isCancelingUpscale}
-                        aria-label="Cancel upscale"
+                        variant="outline"
+                        className="w-full gap-2"
+                        onClick={handleRetryUpscale}
+                        disabled={isUpscaling}
                       >
-                        <XIcon className="size-4" />
+                        <ArrowClockwiseIcon className="size-4" />
+                        {isUpscaling ? "Retrying..." : "Retry"}
                       </Button>
-                    )}
-                  </div>
-
-                  {/* Creative enhance — secondary */}
-                  <div className="relative">
-                    <Button
-                      variant="outline"
-                      className="w-full gap-2"
-                      onClick={handleCreativeUpscale}
-                      disabled={isUpscaling || hasAnyInProgress}
-                    >
-                      {inProgressUpscale?.type === "creative" ? (
-                        <Spinner className="size-4" />
-                      ) : (
-                        <SparkleIcon className="size-4" />
-                      )}
-                      {inProgressUpscale?.type === "creative"
-                        ? "Enhancing..."
-                        : "Creative Enhance"}
-                    </Button>
-                    {inProgressUpscale?.type === "creative" && (
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        className="absolute right-1 top-1/2 -translate-y-1/2"
-                        onClick={handleCancelUpscale}
-                        disabled={isCancelingUpscale}
-                        aria-label="Cancel upscale"
-                      >
-                        <XIcon className="size-4" />
-                      </Button>
-                    )}
-                  </div>
-
-                  {/* Creative settings collapsible */}
-                  <button
-                    type="button"
-                    className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-                    onClick={() => setShowUpscaleSettings(!showUpscaleSettings)}
-                  >
-                    <CaretDownIcon
-                      className={cn(
-                        "size-3 transition-transform",
-                        showUpscaleSettings && "rotate-180"
-                      )}
-                    />
-                    Creative Settings
-                    {hasNonDefaultCreativeSettings && (
-                      <span className="size-1.5 rounded-full bg-primary" />
-                    )}
-                  </button>
-
-                  {showUpscaleSettings && (
-                    <div className="stack-sm rounded-lg border border-border/40 p-3">
-                      <div className="flex gap-1 rounded-lg bg-muted/50 p-1">
-                        {CREATIVE_PRESETS.map(preset => (
-                          <Tooltip key={preset.id}>
-                            <TooltipTrigger>
-                              <button
-                                type="button"
-                                className={cn(
-                                  "flex-1 rounded-md px-2 py-1.5 text-xs font-medium transition-all",
-                                  creativePreset === preset.id
-                                    ? "bg-background text-foreground shadow-sm"
-                                    : "text-muted-foreground hover:text-foreground"
-                                )}
-                                onClick={() => setCreativePreset(preset.id)}
-                              >
-                                {preset.label}
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              {preset.description}
-                            </TooltipContent>
-                          </Tooltip>
-                        ))}
-                      </div>
-
-                      <div className="stack-xs">
-                        <label
-                          htmlFor="upscale-prompt"
-                          className="text-xs text-muted-foreground"
-                        >
-                          Prompt
-                        </label>
-                        <textarea
-                          id="upscale-prompt"
-                          rows={2}
-                          className="w-full resize-none rounded-md border border-border/40 bg-background px-3 py-2 text-sm placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
-                          placeholder="Guide the upscaler..."
-                          value={upscalePrompt}
-                          onChange={e => setUpscalePrompt(e.target.value)}
-                        />
-                      </div>
                     </div>
                   )}
-                </div>
 
-                {/* Versions gallery */}
-                {(succeededUpscales.length > 0 || inProgressUpscale) && (
-                  <div className="mt-4 border-t border-border/40 pt-4">
-                    <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      <StackSimpleIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
-                      Versions
-                    </h3>
-                    <div className="grid grid-cols-3 gap-2">
-                      {/* Original thumbnail */}
-                      <div className="group/thumb relative">
-                        <button
-                          type="button"
-                          className={cn(
-                            "relative w-full overflow-hidden rounded-lg border-2 transition-all",
-                            activeVersionId === "original"
-                              ? "border-primary ring-1 ring-primary/30"
-                              : "border-transparent hover:border-border"
-                          )}
-                          onClick={() => setActiveVersionId("original")}
+                  {/* Upscale buttons — always visible, disabled when in-progress */}
+                  <div className="stack-sm">
+                    {/* Standard upscale — primary */}
+                    <div className="relative">
+                      <Button
+                        className="w-full gap-2"
+                        onClick={handleStandardUpscale}
+                        disabled={isUpscaling || hasAnyInProgress}
+                      >
+                        {inProgressUpscale?.type === "standard" ? (
+                          <Spinner className="size-4" />
+                        ) : (
+                          <ArrowsOutIcon className="size-4" />
+                        )}
+                        {inProgressUpscale?.type === "standard"
+                          ? "Upscaling..."
+                          : "Upscale"}
+                      </Button>
+                      {inProgressUpscale?.type === "standard" && (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="absolute right-1 top-1/2 -translate-y-1/2"
+                          onClick={handleCancelUpscale}
+                          disabled={isCancelingUpscale}
+                          aria-label="Cancel upscale"
                         >
-                          <img
-                            src={image.imageUrl}
-                            alt="Original"
-                            className="block aspect-square w-full object-cover"
-                          />
-                          <span className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-0.5 text-[10px] font-medium text-white backdrop-blur-sm">
-                            Original
-                          </span>
-                        </button>
-                      </div>
+                          <XIcon className="size-4" />
+                        </Button>
+                      )}
+                    </div>
 
-                      {/* Succeeded upscale thumbnails */}
-                      {succeededUpscales.map(upscale => (
-                        <div key={upscale.id} className="group/thumb relative">
+                    {/* Creative enhance — secondary */}
+                    <div className="relative">
+                      <Button
+                        variant="outline"
+                        className="w-full gap-2"
+                        onClick={handleCreativeUpscale}
+                        disabled={isUpscaling || hasAnyInProgress}
+                      >
+                        {inProgressUpscale?.type === "creative" ? (
+                          <Spinner className="size-4" />
+                        ) : (
+                          <SparkleIcon className="size-4" />
+                        )}
+                        {inProgressUpscale?.type === "creative"
+                          ? "Enhancing..."
+                          : "Creative Enhance"}
+                      </Button>
+                      {inProgressUpscale?.type === "creative" && (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="absolute right-1 top-1/2 -translate-y-1/2"
+                          onClick={handleCancelUpscale}
+                          disabled={isCancelingUpscale}
+                          aria-label="Cancel upscale"
+                        >
+                          <XIcon className="size-4" />
+                        </Button>
+                      )}
+                    </div>
+
+                    {/* Creative settings collapsible */}
+                    <button
+                      type="button"
+                      className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                      onClick={() =>
+                        setShowUpscaleSettings(!showUpscaleSettings)
+                      }
+                    >
+                      <CaretDownIcon
+                        className={cn(
+                          "size-3 transition-transform",
+                          showUpscaleSettings && "rotate-180"
+                        )}
+                      />
+                      Creative Settings
+                      {hasNonDefaultCreativeSettings && (
+                        <span className="size-1.5 rounded-full bg-primary" />
+                      )}
+                    </button>
+
+                    {showUpscaleSettings && (
+                      <div className="stack-sm rounded-lg border border-border/40 p-3">
+                        <div className="flex gap-1 rounded-lg bg-muted/50 p-1">
+                          {CREATIVE_PRESETS.map(preset => (
+                            <Tooltip key={preset.id}>
+                              <TooltipTrigger>
+                                <button
+                                  type="button"
+                                  className={cn(
+                                    "flex-1 rounded-md px-2 py-1.5 text-xs font-medium transition-all",
+                                    creativePreset === preset.id
+                                      ? "bg-background text-foreground shadow-sm"
+                                      : "text-muted-foreground hover:text-foreground"
+                                  )}
+                                  onClick={() => setCreativePreset(preset.id)}
+                                >
+                                  {preset.label}
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                {preset.description}
+                              </TooltipContent>
+                            </Tooltip>
+                          ))}
+                        </div>
+
+                        <div className="stack-xs">
+                          <label
+                            htmlFor="upscale-prompt"
+                            className="text-xs text-muted-foreground"
+                          >
+                            Prompt
+                          </label>
+                          <textarea
+                            id="upscale-prompt"
+                            rows={2}
+                            className="w-full resize-none rounded-md border border-border/40 bg-background px-3 py-2 text-sm placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
+                            placeholder="Guide the upscaler..."
+                            value={upscalePrompt}
+                            onChange={e => setUpscalePrompt(e.target.value)}
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Versions gallery */}
+                  {(succeededUpscales.length > 0 || inProgressUpscale) && (
+                    <div className="mt-4 border-t border-border/40 pt-4">
+                      <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                        <StackSimpleIcon className="mr-1.5 inline size-3.5 align-[-2px]" />
+                        Versions
+                      </h3>
+                      <div className="grid grid-cols-3 gap-2">
+                        {/* Original thumbnail */}
+                        <div className="group/thumb relative">
                           <button
                             type="button"
                             className={cn(
                               "relative w-full overflow-hidden rounded-lg border-2 transition-all",
-                              activeVersionId === upscale.id
+                              activeVersionId === "original"
                                 ? "border-primary ring-1 ring-primary/30"
                                 : "border-transparent hover:border-border"
                             )}
-                            onClick={() => setActiveVersionId(upscale.id)}
+                            onClick={() => setActiveVersionId("original")}
                           >
                             <img
-                              src={upscale.imageUrl}
-                              alt={
-                                upscale.type === "standard"
-                                  ? "Standard 2x"
-                                  : "Creative 2x"
-                              }
+                              src={image.imageUrl}
+                              alt="Original"
                               className="block aspect-square w-full object-cover"
                             />
                             <span className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-0.5 text-[10px] font-medium text-white backdrop-blur-sm">
-                              {upscale.type === "standard" ? "2x" : "2x+"}
+                              Original
                             </span>
                           </button>
-                          <button
-                            type="button"
-                            className="absolute -right-1 -top-1 z-10 flex size-5 items-center justify-center rounded-full bg-card text-muted-foreground opacity-0 shadow-sm ring-1 ring-border/40 transition-all hover:text-destructive group-hover/thumb:opacity-100"
-                            onClick={e => {
-                              e.stopPropagation();
-                              handleDeleteUpscaleVersion(upscale.id);
-                            }}
-                            aria-label="Remove version"
-                          >
-                            <XIcon className="size-3" />
-                          </button>
                         </div>
-                      ))}
 
-                      {/* In-progress placeholder */}
-                      {inProgressUpscale && (
-                        <div className="relative">
-                          <div className="aspect-square w-full overflow-hidden rounded-lg border-2 border-dashed border-border/60 bg-muted/30">
-                            <div className="flex h-full flex-col items-center justify-center gap-1.5">
-                              <Spinner className="size-4 text-muted-foreground" />
-                              <span className="text-[10px] font-medium text-muted-foreground">
-                                {inProgressUpscale.type === "standard"
-                                  ? "2x"
-                                  : "2x+"}
+                        {/* Succeeded upscale thumbnails */}
+                        {succeededUpscales.map(upscale => (
+                          <div
+                            key={upscale.id}
+                            className="group/thumb relative"
+                          >
+                            <button
+                              type="button"
+                              className={cn(
+                                "relative w-full overflow-hidden rounded-lg border-2 transition-all",
+                                activeVersionId === upscale.id
+                                  ? "border-primary ring-1 ring-primary/30"
+                                  : "border-transparent hover:border-border"
+                              )}
+                              onClick={() => setActiveVersionId(upscale.id)}
+                            >
+                              <img
+                                src={upscale.imageUrl}
+                                alt={
+                                  upscale.type === "standard"
+                                    ? "Standard 2x"
+                                    : "Creative 2x"
+                                }
+                                className="block aspect-square w-full object-cover"
+                              />
+                              <span className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-0.5 text-[10px] font-medium text-white backdrop-blur-sm">
+                                {upscale.type === "standard" ? "2x" : "2x+"}
                               </span>
+                            </button>
+                            <button
+                              type="button"
+                              className="absolute -right-1 -top-1 z-10 flex size-5 items-center justify-center rounded-full bg-card text-muted-foreground opacity-0 shadow-sm ring-1 ring-border/40 transition-all hover:text-destructive group-hover/thumb:opacity-100"
+                              onClick={e => {
+                                e.stopPropagation();
+                                handleDeleteUpscaleVersion(upscale.id);
+                              }}
+                              aria-label="Remove version"
+                            >
+                              <XIcon className="size-3" />
+                            </button>
+                          </div>
+                        ))}
+
+                        {/* In-progress placeholder */}
+                        {inProgressUpscale && (
+                          <div className="relative">
+                            <div className="aspect-square w-full overflow-hidden rounded-lg border-2 border-dashed border-border/60 bg-muted/30">
+                              <div className="flex h-full flex-col items-center justify-center gap-1.5">
+                                <Spinner className="size-4 text-muted-foreground" />
+                                <span className="text-[10px] font-medium text-muted-foreground">
+                                  {inProgressUpscale.type === "standard"
+                                    ? "2x"
+                                    : "2x+"}
+                                </span>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      )}
+                        )}
+                      </div>
                     </div>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
+                  )}
+                </div>
+              )}
+            </div>
 
-          {/* Timestamp footer */}
-          <div className="border-t border-border/40 px-5 py-3">
-            <p className="text-xs text-muted-foreground">
-              {formatTimestamp(image.createdAt)}
-            </p>
+            {/* Timestamp footer */}
+            <div className="border-t border-border/40 px-5 py-3">
+              <p className="text-xs text-muted-foreground">
+                {formatTimestamp(image.createdAt)}
+              </p>
+            </div>
           </div>
-        </div>
+        )}
       </div>
       {/* Source image preview modal */}
       {sourcePreviewUrl && (
@@ -1099,6 +1197,239 @@ export function CanvasImageViewer({
       )}
     </div>,
     document.getElementById("root") ?? document.body
+  );
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: shared props for mobile info panel
+function ViewerInfoPanelContent(props: any) {
+  const {
+    image,
+    activeVersionId,
+    setActiveVersionId,
+    succeededUpscales,
+    inProgressUpscale,
+    handleCopyImage,
+    handleDownload,
+    handleDelete,
+    handleCopyText,
+    handleStandardUpscale,
+    handleCreativeUpscale,
+    handleUseSettings,
+    onOpenChange,
+    navigate,
+    isUpscaling,
+    hasAnyInProgress,
+    conversation,
+  } = props;
+
+  return (
+    <div className="px-4 py-3 stack-sm">
+      {/* Model + actions row */}
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold text-foreground truncate">
+          {formatModelName(image.model)}
+        </h2>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <button
+            type="button"
+            className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={handleCopyImage}
+            aria-label="Copy image"
+          >
+            <CopyIcon size={14} />
+          </button>
+          <button
+            type="button"
+            className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={handleDownload}
+            aria-label="Download"
+          >
+            <DownloadIcon size={14} />
+          </button>
+          {image.source === "canvas" && image.generationId && (
+            <>
+              <button
+                type="button"
+                className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
+                onClick={handleDelete}
+                aria-label="Delete"
+              >
+                <TrashIcon size={14} />
+              </button>
+              {image.status === "succeeded" && (
+                <button
+                  type="button"
+                  className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  onClick={() => {
+                    if (image.generationId) {
+                      navigate(ROUTES.CANVAS_IMAGE(image.generationId));
+                    }
+                  }}
+                  aria-label="Edit image"
+                >
+                  <PencilSimpleIcon className="size-4" />
+                </button>
+              )}
+            </>
+          )}
+          <button
+            type="button"
+            className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={handleUseSettings}
+            aria-label="Use settings"
+          >
+            <ArrowsClockwiseIcon className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Metadata badges */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {image.duration !== undefined && (
+          <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground">
+            <ClockIcon className="size-3" />
+            {image.duration.toFixed(1)}s
+          </span>
+        )}
+        {image.aspectRatio && (
+          <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground">
+            {image.aspectRatio}
+          </span>
+        )}
+        {image.seed !== undefined && (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-foreground transition-colors hover:bg-muted/80"
+            onClick={() => handleCopyText(String(image.seed), "Seed")}
+          >
+            {image.seed}
+            <CopyIcon size={10} />
+          </button>
+        )}
+        {succeededUpscales.length > 0 && (
+          <span className="inline-flex items-center rounded-md bg-primary/15 px-2 py-0.5 text-[11px] font-medium text-primary">
+            {succeededUpscales.length} upscale
+            {succeededUpscales.length > 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {/* Prompt */}
+      {image.prompt && (
+        <p className="text-sm leading-relaxed text-foreground/90 line-clamp-4">
+          {image.prompt}
+        </p>
+      )}
+
+      {/* Conversation link */}
+      {image.source === "conversation" && image.conversationId && (
+        <button
+          type="button"
+          className="flex w-full items-center gap-3 rounded-lg border border-border/40 p-2.5 text-left transition-colors hover:bg-muted/50"
+          onClick={() => {
+            navigate(ROUTES.CHAT_CONVERSATION(image.conversationId as string));
+            onOpenChange(false);
+          }}
+        >
+          <ChatCircleIcon className="size-4 shrink-0 text-muted-foreground" />
+          <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+            {conversation?.title ?? "Conversation"}
+          </p>
+          <CaretRightIcon className="size-4 shrink-0 text-muted-foreground" />
+        </button>
+      )}
+
+      {/* Upscale + Versions */}
+      {image.source === "canvas" && image.generationId && (
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            className="flex-1 gap-1.5"
+            onClick={handleStandardUpscale}
+            disabled={isUpscaling || hasAnyInProgress}
+          >
+            {inProgressUpscale?.type === "standard" ? (
+              <Spinner className="size-3.5" />
+            ) : (
+              <ArrowsOutIcon className="size-3.5" />
+            )}
+            {inProgressUpscale?.type === "standard"
+              ? "Upscaling..."
+              : "Upscale"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1 gap-1.5"
+            onClick={handleCreativeUpscale}
+            disabled={isUpscaling || hasAnyInProgress}
+          >
+            {inProgressUpscale?.type === "creative" ? (
+              <Spinner className="size-3.5" />
+            ) : (
+              <SparkleIcon className="size-3.5" />
+            )}
+            {inProgressUpscale?.type === "creative"
+              ? "Enhancing..."
+              : "Enhance"}
+          </Button>
+        </div>
+      )}
+
+      {/* Version thumbnails (horizontal scroll) */}
+      {succeededUpscales.length > 0 && (
+        <div className="flex gap-2 overflow-x-auto scrollbar-none pb-1">
+          <button
+            type="button"
+            className={cn(
+              "relative size-12 shrink-0 overflow-hidden rounded-lg border-2 transition-all",
+              activeVersionId === "original"
+                ? "border-primary ring-1 ring-primary/30"
+                : "border-transparent hover:border-border"
+            )}
+            onClick={() => setActiveVersionId("original")}
+          >
+            <img
+              src={image.imageUrl}
+              alt="Original"
+              className="size-full object-cover"
+            />
+            <span className="absolute inset-x-0 bottom-0 bg-black/60 text-center text-[8px] font-medium text-white">
+              Orig
+            </span>
+          </button>
+          {succeededUpscales.map(
+            (upscale: UpscaleEntry & { imageUrl: string }) => (
+              <button
+                key={upscale.id}
+                type="button"
+                className={cn(
+                  "relative size-12 shrink-0 overflow-hidden rounded-lg border-2 transition-all",
+                  activeVersionId === upscale.id
+                    ? "border-primary ring-1 ring-primary/30"
+                    : "border-transparent hover:border-border"
+                )}
+                onClick={() => setActiveVersionId(upscale.id)}
+              >
+                <img
+                  src={upscale.imageUrl}
+                  alt={upscale.type === "standard" ? "2x" : "2x+"}
+                  className="size-full object-cover"
+                />
+                <span className="absolute inset-x-0 bottom-0 bg-black/60 text-center text-[8px] font-medium text-white">
+                  {upscale.type === "standard" ? "2x" : "2x+"}
+                </span>
+              </button>
+            )
+          )}
+        </div>
+      )}
+
+      {/* Timestamp */}
+      <p className="text-[11px] text-muted-foreground">
+        {formatTimestamp(image.createdAt)}
+      </p>
+    </div>
   );
 }
 

--- a/src/components/canvas/canvas-image-viewer.tsx
+++ b/src/components/canvas/canvas-image-viewer.tsx
@@ -602,13 +602,6 @@ export function CanvasImageViewer({
               hasAnyInProgress={hasAnyInProgress}
               isUpscaling={isUpscaling}
               isCancelingUpscale={isCancelingUpscale}
-              showUpscaleSettings={showUpscaleSettings}
-              setShowUpscaleSettings={setShowUpscaleSettings}
-              creativePreset={creativePreset}
-              setCreativePreset={setCreativePreset}
-              upscalePrompt={upscalePrompt}
-              setUpscalePrompt={setUpscalePrompt}
-              hasNonDefaultCreativeSettings={hasNonDefaultCreativeSettings}
               handleCopyImage={handleCopyImage}
               handleDownload={handleDownload}
               handleDelete={handleDelete}
@@ -621,8 +614,6 @@ export function CanvasImageViewer({
               handleUseSettings={handleUseSettings}
               onOpenChange={onOpenChange}
               navigate={navigate}
-              sourcePreviewUrl={sourcePreviewUrl}
-              setSourcePreviewUrl={setSourcePreviewUrl}
               conversation={conversation}
             />
           </div>
@@ -1200,30 +1191,55 @@ export function CanvasImageViewer({
   );
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: shared props for mobile info panel
-function ViewerInfoPanelContent(props: any) {
-  const {
-    image,
-    activeVersionId,
-    setActiveVersionId,
-    succeededUpscales,
-    inProgressUpscale,
-    failedUpscale,
-    handleCopyImage,
-    handleDownload,
-    handleDelete,
-    handleCopyText,
-    handleStandardUpscale,
-    handleCreativeUpscale,
-    handleRetryUpscale,
-    handleUseSettings,
-    onOpenChange,
-    navigate,
-    isUpscaling,
-    hasAnyInProgress,
-    conversation,
-  } = props;
+interface ViewerInfoPanelContentProps {
+  image: CanvasImage;
+  activeVersionId: string;
+  setActiveVersionId: (id: string) => void;
+  succeededUpscales: (UpscaleEntry & { imageUrl: string })[];
+  inProgressUpscale: UpscaleEntry | undefined;
+  failedUpscale: UpscaleEntry | undefined;
+  handleCopyImage: () => void;
+  handleDownload: () => void;
+  handleDelete: () => void;
+  handleCopyText: (text: string, label: string) => void;
+  handleStandardUpscale: () => void;
+  handleCreativeUpscale: () => void;
+  handleRetryUpscale: () => void;
+  handleCancelUpscale: () => void;
+  handleDeleteUpscaleVersion: (upscaleId: string) => void;
+  handleUseSettings: () => void;
+  onOpenChange: (open: boolean) => void;
+  navigate: ReturnType<typeof useNavigate>;
+  isUpscaling: boolean;
+  isCancelingUpscale: boolean;
+  hasAnyInProgress: boolean;
+  conversation: { title?: string } | null | undefined;
+}
 
+function ViewerInfoPanelContent({
+  image,
+  activeVersionId,
+  setActiveVersionId,
+  succeededUpscales,
+  inProgressUpscale,
+  failedUpscale,
+  handleCopyImage,
+  handleDownload,
+  handleDelete,
+  handleCopyText,
+  handleStandardUpscale,
+  handleCreativeUpscale,
+  handleRetryUpscale,
+  handleCancelUpscale,
+  handleDeleteUpscaleVersion,
+  handleUseSettings,
+  onOpenChange,
+  navigate,
+  isUpscaling,
+  isCancelingUpscale,
+  hasAnyInProgress,
+  conversation,
+}: ViewerInfoPanelContentProps) {
   return (
     <div className="px-4 py-3 stack-sm">
       {/* Model + actions row */}
@@ -1363,37 +1379,65 @@ function ViewerInfoPanelContent(props: any) {
       {/* Upscale + Versions */}
       {image.source === "canvas" && image.generationId && (
         <div className="flex gap-2">
-          <Button
-            size="sm"
-            className="flex-1 gap-1.5"
-            onClick={handleStandardUpscale}
-            disabled={isUpscaling || hasAnyInProgress}
-          >
-            {inProgressUpscale?.type === "standard" ? (
-              <Spinner className="size-3.5" />
-            ) : (
-              <ArrowsOutIcon className="size-3.5" />
+          <div className="relative flex-1">
+            <Button
+              size="sm"
+              className="w-full gap-1.5"
+              onClick={handleStandardUpscale}
+              disabled={isUpscaling || hasAnyInProgress}
+            >
+              {inProgressUpscale?.type === "standard" ? (
+                <Spinner className="size-3.5" />
+              ) : (
+                <ArrowsOutIcon className="size-3.5" />
+              )}
+              {inProgressUpscale?.type === "standard"
+                ? "Upscaling..."
+                : "Upscale"}
+            </Button>
+            {inProgressUpscale?.type === "standard" && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="absolute right-1 top-1/2 -translate-y-1/2"
+                onClick={handleCancelUpscale}
+                disabled={isCancelingUpscale}
+                aria-label="Cancel upscale"
+              >
+                <XIcon className="size-4" />
+              </Button>
             )}
-            {inProgressUpscale?.type === "standard"
-              ? "Upscaling..."
-              : "Upscale"}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="flex-1 gap-1.5"
-            onClick={handleCreativeUpscale}
-            disabled={isUpscaling || hasAnyInProgress}
-          >
-            {inProgressUpscale?.type === "creative" ? (
-              <Spinner className="size-3.5" />
-            ) : (
-              <SparkleIcon className="size-3.5" />
+          </div>
+          <div className="relative flex-1">
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full gap-1.5"
+              onClick={handleCreativeUpscale}
+              disabled={isUpscaling || hasAnyInProgress}
+            >
+              {inProgressUpscale?.type === "creative" ? (
+                <Spinner className="size-3.5" />
+              ) : (
+                <SparkleIcon className="size-3.5" />
+              )}
+              {inProgressUpscale?.type === "creative"
+                ? "Enhancing..."
+                : "Enhance"}
+            </Button>
+            {inProgressUpscale?.type === "creative" && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="absolute right-1 top-1/2 -translate-y-1/2"
+                onClick={handleCancelUpscale}
+                disabled={isCancelingUpscale}
+                aria-label="Cancel upscale"
+              >
+                <XIcon className="size-4" />
+              </Button>
             )}
-            {inProgressUpscale?.type === "creative"
-              ? "Enhancing..."
-              : "Enhance"}
-          </Button>
+          </div>
         </div>
       )}
 
@@ -1421,26 +1465,38 @@ function ViewerInfoPanelContent(props: any) {
           </button>
           {succeededUpscales.map(
             (upscale: UpscaleEntry & { imageUrl: string }) => (
-              <button
-                key={upscale.id}
-                type="button"
-                className={cn(
-                  "relative size-12 shrink-0 overflow-hidden rounded-lg border-2 transition-all",
-                  activeVersionId === upscale.id
-                    ? "border-primary ring-1 ring-primary/30"
-                    : "border-transparent hover:border-border"
-                )}
-                onClick={() => setActiveVersionId(upscale.id)}
-              >
-                <img
-                  src={upscale.imageUrl}
-                  alt={upscale.type === "standard" ? "2x" : "2x+"}
-                  className="size-full object-cover"
-                />
-                <span className="absolute inset-x-0 bottom-0 bg-black/60 text-center text-[8px] font-medium text-white">
-                  {upscale.type === "standard" ? "2x" : "2x+"}
-                </span>
-              </button>
+              <div key={upscale.id} className="relative shrink-0">
+                <button
+                  type="button"
+                  className={cn(
+                    "relative size-12 overflow-hidden rounded-lg border-2 transition-all",
+                    activeVersionId === upscale.id
+                      ? "border-primary ring-1 ring-primary/30"
+                      : "border-transparent hover:border-border"
+                  )}
+                  onClick={() => setActiveVersionId(upscale.id)}
+                >
+                  <img
+                    src={upscale.imageUrl}
+                    alt={upscale.type === "standard" ? "2x" : "2x+"}
+                    className="size-full object-cover"
+                  />
+                  <span className="absolute inset-x-0 bottom-0 bg-black/60 text-center text-[8px] font-medium text-white">
+                    {upscale.type === "standard" ? "2x" : "2x+"}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="absolute -right-1 -top-1 z-10 flex size-5 items-center justify-center rounded-full bg-card text-muted-foreground shadow-sm ring-1 ring-border/40 transition-colors hover:text-destructive"
+                  onClick={e => {
+                    e.stopPropagation();
+                    handleDeleteUpscaleVersion(upscale.id);
+                  }}
+                  aria-label="Remove version"
+                >
+                  <XIcon className="size-3" />
+                </button>
+              </div>
             )
           )}
         </div>

--- a/src/components/canvas/canvas-image-viewer.tsx
+++ b/src/components/canvas/canvas-image-viewer.tsx
@@ -1208,12 +1208,14 @@ function ViewerInfoPanelContent(props: any) {
     setActiveVersionId,
     succeededUpscales,
     inProgressUpscale,
+    failedUpscale,
     handleCopyImage,
     handleDownload,
     handleDelete,
     handleCopyText,
     handleStandardUpscale,
     handleCreativeUpscale,
+    handleRetryUpscale,
     handleUseSettings,
     onOpenChange,
     navigate,
@@ -1337,6 +1339,25 @@ function ViewerInfoPanelContent(props: any) {
           </p>
           <CaretRightIcon className="size-4 shrink-0 text-muted-foreground" />
         </button>
+      )}
+
+      {/* Failed upscale state */}
+      {!hasAnyInProgress && failedUpscale && (
+        <div className="stack-sm">
+          <p className="text-sm text-destructive">
+            {failedUpscale.error ?? "Upscale failed"}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full gap-2"
+            onClick={handleRetryUpscale}
+            disabled={isUpscaling}
+          >
+            <ArrowClockwiseIcon className="size-4" />
+            {isUpscaling ? "Retrying..." : "Retry"}
+          </Button>
+        </div>
       )}
 
       {/* Upscale + Versions */}

--- a/src/components/canvas/canvas-masonry-grid.tsx
+++ b/src/components/canvas/canvas-masonry-grid.tsx
@@ -409,10 +409,10 @@ export function CanvasMasonryGrid({
     const skeletonCount = columnCount * 4;
     const skeletonHeights = [180, 240, 200, 260, 220, 190, 250, 210];
     return (
-      <div ref={containerRef} className="flex items-start gap-3">
+      <div ref={containerRef} className="flex items-start gap-2 sm:gap-3">
         {Array.from({ length: columnCount }, (_, colIdx) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholder
-          <div key={colIdx} className="flex flex-1 flex-col gap-3">
+          <div key={colIdx} className="flex flex-1 flex-col gap-2 sm:gap-3">
             {Array.from(
               { length: Math.ceil(skeletonCount / columnCount) },
               (_, i) => (
@@ -471,10 +471,10 @@ export function CanvasMasonryGrid({
 
   return (
     <>
-      <div ref={containerRef} className="flex items-start gap-3">
+      <div ref={containerRef} className="flex items-start gap-2 sm:gap-3">
         {columns.map((col, colIdx) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: stable column layout, index is the only meaningful key
-          <div key={colIdx} className="flex flex-1 flex-col gap-3">
+          <div key={colIdx} className="flex flex-1 flex-col gap-2 sm:gap-3">
             {col.map(image => (
               <CanvasGridCard
                 key={image.id}
@@ -504,8 +504,8 @@ export function CanvasMasonryGrid({
 
       {/* Batch action bar */}
       {selectedCount > 0 && (
-        <div className="fixed bottom-6 left-1/2 z-modal -translate-x-1/2 flex items-center gap-3 rounded-xl bg-card px-4 py-2.5 shadow-xl ring-1 ring-border/50 backdrop-blur-md dark:ring-white/[0.08]">
-          <span className="text-sm font-medium tabular-nums">
+        <div className="fixed bottom-4 left-3 right-3 z-modal flex items-center justify-center gap-2 rounded-xl bg-card px-3 py-2 shadow-xl ring-1 ring-border/50 backdrop-blur-md dark:ring-white/[0.08] sm:bottom-6 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 sm:gap-3 sm:px-4 sm:py-2.5">
+          <span className="text-xs font-medium tabular-nums sm:text-sm">
             {selectedCount} selected
           </span>
           <div className="h-4 w-px bg-border" />
@@ -516,7 +516,7 @@ export function CanvasMasonryGrid({
             onClick={handleBatchDownload}
           >
             <DownloadSimpleIcon className="size-4" />
-            Download
+            <span className="hidden sm:inline">Download</span>
           </Button>
           {selectedDeletableCount > 0 && (
             <Button
@@ -526,7 +526,7 @@ export function CanvasMasonryGrid({
               onClick={handleBatchDelete}
             >
               <TrashSimpleIcon className="size-4" />
-              Delete
+              <span className="hidden sm:inline">Delete</span>
             </Button>
           )}
           <div className="h-4 w-px bg-border" />

--- a/src/components/canvas/canvas-masonry-grid.tsx
+++ b/src/components/canvas/canvas-masonry-grid.tsx
@@ -504,7 +504,7 @@ export function CanvasMasonryGrid({
 
       {/* Batch action bar */}
       {selectedCount > 0 && (
-        <div className="fixed bottom-4 left-3 right-3 z-modal flex items-center justify-center gap-2 rounded-xl bg-card px-3 py-2 shadow-xl ring-1 ring-border/50 backdrop-blur-md dark:ring-white/[0.08] sm:bottom-6 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 sm:gap-3 sm:px-4 sm:py-2.5">
+        <div className="fixed bottom-4 left-3 right-20 z-modal flex items-center justify-center gap-2 rounded-xl bg-card px-3 py-2 shadow-xl ring-1 ring-border/50 backdrop-blur-md dark:ring-white/[0.08] sm:bottom-6 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 sm:gap-3 sm:px-4 sm:py-2.5">
           <span className="text-xs font-medium tabular-nums sm:text-sm">
             {selectedCount} selected
           </span>

--- a/src/pages/canvas-image-page.tsx
+++ b/src/pages/canvas-image-page.tsx
@@ -331,7 +331,7 @@ export default function CanvasImagePage() {
       className="fixed inset-0 z-modal flex flex-col bg-background"
     >
       {/* Back button — always visible, top-left */}
-      <div className="absolute left-4 top-4 z-10">
+      <div className="absolute left-3 top-3 z-10 sm:left-4 sm:top-4">
         <Button
           variant="ghost"
           size="sm"
@@ -339,7 +339,7 @@ export default function CanvasImagePage() {
           onClick={handleBack}
         >
           <ArrowLeftIcon className="size-4" />
-          Canvas
+          <span className="hidden sm:inline">Canvas</span>
         </Button>
       </div>
 
@@ -354,12 +354,12 @@ export default function CanvasImagePage() {
             <Spinner className="size-5 text-muted-foreground" />
           </div>
         ) : (
-          <div className="relative flex items-center justify-center">
-            {/* Thumbnail strip — positioned outside the hero so it doesn't shift centering */}
+          <div className="relative flex flex-col items-center justify-center md:flex-row">
+            {/* Desktop: Thumbnail strip — vertical, positioned left of hero */}
             {editTree.length > 1 && (
               <div
                 ref={thumbStripRef}
-                className="absolute right-full mr-3 flex max-h-[70vh] flex-col gap-1.5 overflow-y-auto scrollbar-none"
+                className="hidden md:flex absolute right-full mr-3 max-h-[70vh] flex-col gap-1.5 overflow-y-auto scrollbar-none"
               >
                 {editTree.map((node, idx) => (
                   <Tooltip key={node._id}>
@@ -419,7 +419,7 @@ export default function CanvasImagePage() {
                         key={activeNode?._id}
                         src={heroImageUrl}
                         alt={activeNode?.prompt || "Generated image"}
-                        className="max-h-[calc(100dvh-180px)] rounded-lg object-contain drop-shadow-2xl animate-in fade-in-0 duration-300"
+                        className="max-h-[calc(100dvh-240px)] rounded-lg object-contain drop-shadow-2xl animate-in fade-in-0 duration-300 md:max-h-[calc(100dvh-180px)]"
                         draggable={false}
                         onLoad={e => {
                           const img = e.currentTarget;
@@ -588,13 +588,57 @@ export default function CanvasImagePage() {
                 return null;
               })()}
             </div>
+
+            {/* Mobile: Thumbnail strip — horizontal, below hero */}
+            {editTree.length > 1 && (
+              <div className="mt-2 flex gap-1.5 overflow-x-auto px-2 pb-1 scrollbar-none md:hidden">
+                {editTree.map((node, idx) => {
+                  const nodePending =
+                    node.status === "pending" ||
+                    node.status === "starting" ||
+                    node.status === "processing";
+                  return (
+                    <button
+                      key={node._id}
+                      type="button"
+                      data-node-id={node._id}
+                      className={cn(
+                        "relative size-11 shrink-0 overflow-hidden rounded-lg border-2 transition-all",
+                        node._id === activeNode?._id
+                          ? "border-primary ring-1 ring-primary/30"
+                          : "border-transparent hover:border-border/60"
+                      )}
+                      onClick={() => setSelectedNodeId(node._id)}
+                    >
+                      {node.imageUrl && (
+                        <img
+                          src={node.imageUrl}
+                          alt={idx === 0 ? "Original" : `Edit ${idx}`}
+                          className="h-full w-full object-cover"
+                        />
+                      )}
+                      {!node.imageUrl && nodePending && (
+                        <div className="flex h-full w-full items-center justify-center bg-muted/30">
+                          <Spinner className="size-3" />
+                        </div>
+                      )}
+                      {!(node.imageUrl || nodePending) && (
+                        <div className="flex h-full w-full items-center justify-center bg-destructive/5">
+                          <WarningCircleIcon className="size-3 text-destructive" />
+                        </div>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
         )}
       </div>
 
       {/* Bottom edit input */}
       {!isLoading && lastSucceededNode && (
-        <div className="shrink-0 px-4 pb-4 pt-2">
+        <div className="shrink-0 px-3 pb-3 pt-2 sm:px-4 sm:pb-4">
           <div className="mx-auto max-w-2xl">
             <div className="chat-input-container">
               {/* Source image thumbnail */}

--- a/src/pages/canvas-page.tsx
+++ b/src/pages/canvas-page.tsx
@@ -1,5 +1,5 @@
-import { ArrowLeftIcon } from "@phosphor-icons/react";
-import { useCallback, useRef } from "react";
+import { ArrowLeftIcon, PlusIcon } from "@phosphor-icons/react";
+import { useCallback, useRef, useState } from "react";
 import { Link, Outlet } from "react-router-dom";
 import { PanelLeftIcon } from "@/components/animate-ui/icons/panel-left";
 import { CanvasGateCheck } from "@/components/canvas/canvas-gate-check";
@@ -9,6 +9,14 @@ import {
 } from "@/components/canvas/canvas-generation-form";
 import { CanvasMasonryGrid } from "@/components/canvas/canvas-masonry-grid";
 import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { ROUTES } from "@/lib/routes";
 import type { CanvasFilterMode } from "@/stores/canvas-store";
 import { useCanvasStore } from "@/stores/canvas-store";
@@ -30,6 +38,8 @@ export default function CanvasPage() {
   const isPanelVisible = useCanvasStore(s => s.isPanelVisible);
   const togglePanel = useCanvasStore(s => s.togglePanel);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
@@ -65,8 +75,8 @@ export default function CanvasPage() {
   return (
     <CanvasGateCheck>
       <div className="flex h-[100dvh] bg-background">
-        {/* Expand zone when panel is hidden */}
-        {!isPanelVisible && (
+        {/* Desktop: Expand zone when panel is hidden */}
+        {isDesktop && !isPanelVisible && (
           <button
             type="button"
             aria-label="Expand panel"
@@ -75,90 +85,105 @@ export default function CanvasPage() {
           />
         )}
 
-        {/* Side panel (left) — matches main sidebar styling */}
-        <aside
-          className="relative flex flex-col shrink-0 bg-sidebar dark:bg-sidebar border-r border-border/40 transition-[width] duration-300 ease-out overflow-hidden"
-          style={{ width: isPanelVisible ? panelWidth : 0 }}
-        >
-          {/* Panel header — mirrors sidebar header structure */}
-          <div className="shrink-0 py-4 px-3">
-            <div className="flex items-center justify-between pl-2 pr-2">
-              <div className="flex items-center gap-2">
-                <Link
-                  className="group flex items-center gap-2 text-sidebar-foreground/90 hover:text-sidebar-foreground transition-colors"
-                  to={ROUTES.HOME}
-                  viewTransition
-                >
-                  <div
-                    className="polly-logo-gradient-unified flex-shrink-0 w-6 h-6"
-                    style={{
-                      maskImage: "url('/favicon.svg')",
-                      maskSize: "contain",
-                      maskRepeat: "no-repeat",
-                      maskPosition: "center",
-                      WebkitMaskImage: "url('/favicon.svg')",
-                      WebkitMaskSize: "contain",
-                      WebkitMaskRepeat: "no-repeat",
-                      WebkitMaskPosition: "center",
-                    }}
-                  />
-                  <span className="font-semibold text-sm tracking-tight">
-                    Polly
-                  </span>
-                </Link>
-              </div>
+        {/* Desktop: Side panel (left) — matches main sidebar styling */}
+        {isDesktop && (
+          <aside
+            className="relative flex flex-col shrink-0 bg-sidebar dark:bg-sidebar border-r border-border/40 transition-[width] duration-300 ease-out overflow-hidden"
+            style={{ width: isPanelVisible ? panelWidth : 0 }}
+          >
+            {/* Panel header — mirrors sidebar header structure */}
+            <div className="shrink-0 py-4 px-3">
+              <div className="flex items-center justify-between pl-2 pr-2">
+                <div className="flex items-center gap-2">
+                  <Link
+                    className="group flex items-center gap-2 text-sidebar-foreground/90 hover:text-sidebar-foreground transition-colors"
+                    to={ROUTES.HOME}
+                    viewTransition
+                  >
+                    <div
+                      className="polly-logo-gradient-unified flex-shrink-0 w-6 h-6"
+                      style={{
+                        maskImage: "url('/favicon.svg')",
+                        maskSize: "contain",
+                        maskRepeat: "no-repeat",
+                        maskPosition: "center",
+                        WebkitMaskImage: "url('/favicon.svg')",
+                        WebkitMaskSize: "contain",
+                        WebkitMaskRepeat: "no-repeat",
+                        WebkitMaskPosition: "center",
+                      }}
+                    />
+                    <span className="font-semibold text-sm tracking-tight">
+                      Polly
+                    </span>
+                  </Link>
+                </div>
 
-              <div className="flex items-center gap-1">
-                <Link to={ROUTES.HOME} viewTransition>
+                <div className="flex items-center gap-1">
+                  <Link to={ROUTES.HOME} viewTransition>
+                    <Button
+                      size="icon-sm"
+                      title="Back to chat"
+                      variant="ghost"
+                      className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover h-8 w-8"
+                    >
+                      <ArrowLeftIcon className="size-4.5" />
+                    </Button>
+                  </Link>
                   <Button
                     size="icon-sm"
-                    title="Back to chat"
+                    title="Collapse panel"
                     variant="ghost"
                     className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover h-8 w-8"
+                    onClick={togglePanel}
                   >
-                    <ArrowLeftIcon className="size-4.5" />
+                    <PanelLeftIcon animateOnHover className="size-4.5" />
                   </Button>
-                </Link>
-                <Button
-                  size="icon-sm"
-                  title="Collapse panel"
-                  variant="ghost"
-                  className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover h-8 w-8"
-                  onClick={togglePanel}
-                >
-                  <PanelLeftIcon animateOnHover className="size-4.5" />
-                </Button>
+                </div>
               </div>
             </div>
-          </div>
 
-          <div className="flex-1 overflow-y-auto px-3 scrollbar-thin min-h-0">
-            <CanvasGenerationForm />
-          </div>
-
-          {/* Fixed generate button footer */}
-          <div className="shrink-0 border-t border-border/40 px-3 py-3">
-            <CanvasGenerateButton />
-          </div>
-
-          {/* Resize handle */}
-          {isPanelVisible && (
-            <div
-              className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/10 active:bg-primary/20 transition-colors z-10 group"
-              onMouseDown={handleResizeStart}
-              onDoubleClick={handleDoubleClick}
-            >
-              <div className="absolute right-0 top-0 bottom-0 w-[1px] bg-transparent group-hover:bg-border/50 transition-colors" />
+            <div className="flex-1 overflow-y-auto px-3 scrollbar-thin min-h-0">
+              <CanvasGenerationForm />
             </div>
-          )}
-        </aside>
+
+            {/* Fixed generate button footer */}
+            <div className="shrink-0 border-t border-border/40 px-3 py-3">
+              <CanvasGenerateButton />
+            </div>
+
+            {/* Resize handle */}
+            {isPanelVisible && (
+              <div
+                className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/10 active:bg-primary/20 transition-colors z-10 group"
+                onMouseDown={handleResizeStart}
+                onDoubleClick={handleDoubleClick}
+              >
+                <div className="absolute right-0 top-0 bottom-0 w-[1px] bg-transparent group-hover:bg-border/50 transition-colors" />
+              </div>
+            )}
+          </aside>
+        )}
 
         {/* Main content area */}
         <div className="flex flex-1 flex-col min-w-0">
           {/* Header */}
-          <header className="flex h-16 items-center gap-3 px-4 shrink-0">
-            {/* Show expand button when panel is hidden */}
-            {!isPanelVisible && (
+          <header className="flex h-14 items-center gap-2 px-3 shrink-0 sm:h-16 sm:gap-3 sm:px-4">
+            {/* Mobile: back button */}
+            {!isDesktop && (
+              <Link to={ROUTES.HOME} viewTransition>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  className="text-muted-foreground hover:text-foreground h-8 w-8"
+                >
+                  <ArrowLeftIcon className="size-4" />
+                </Button>
+              </Link>
+            )}
+
+            {/* Desktop: Show expand button when panel is hidden */}
+            {isDesktop && !isPanelVisible && (
               <Button
                 variant="ghost"
                 size="icon-sm"
@@ -169,13 +194,13 @@ export default function CanvasPage() {
               </Button>
             )}
 
-            {/* Filter toggle — left side */}
-            <div className="flex items-center gap-1 rounded-lg bg-muted/50 p-0.5">
+            {/* Filter toggle */}
+            <div className="flex items-center gap-1 overflow-x-auto rounded-lg bg-muted/50 p-0.5 scrollbar-none">
               {FILTER_OPTIONS.map(opt => (
                 <button
                   key={opt.value}
                   type="button"
-                  className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                  className={`whitespace-nowrap rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
                     filterMode === opt.value
                       ? "bg-background text-foreground shadow-sm"
                       : "text-muted-foreground hover:text-foreground"
@@ -192,7 +217,7 @@ export default function CanvasPage() {
           <div
             ref={scrollContainerRef}
             id="canvas-grid-scroll"
-            className="flex-1 overflow-y-auto px-4 pb-4"
+            className="flex-1 overflow-y-auto px-3 pb-4 sm:px-4"
             style={{ overflowAnchor: "auto" }}
           >
             <CanvasMasonryGrid
@@ -201,6 +226,34 @@ export default function CanvasPage() {
             />
           </div>
         </div>
+
+        {/* Mobile: FAB to open generation form */}
+        {!isDesktop && (
+          <Button
+            className="fixed bottom-5 right-4 z-modal h-14 w-14 rounded-full shadow-lg"
+            onClick={() => setMobileDrawerOpen(true)}
+            aria-label="New generation"
+          >
+            <PlusIcon className="size-6" weight="bold" />
+          </Button>
+        )}
+
+        {/* Mobile: Generation form drawer */}
+        {!isDesktop && (
+          <Drawer open={mobileDrawerOpen} onOpenChange={setMobileDrawerOpen}>
+            <DrawerContent>
+              <DrawerHeader>
+                <DrawerTitle>Generate Image</DrawerTitle>
+              </DrawerHeader>
+              <DrawerBody className="scrollbar-thin">
+                <CanvasGenerationForm />
+                <div className="mt-4 pb-2">
+                  <CanvasGenerateButton />
+                </div>
+              </DrawerBody>
+            </DrawerContent>
+          </Drawer>
+        )}
       </div>
 
       {/* Child route overlay (image detail modal) */}


### PR DESCRIPTION
## Summary
This PR adds comprehensive mobile responsiveness to the canvas image viewer and related pages, transforming the desktop-optimized layout into a mobile-friendly experience that adapts to different screen sizes.

## Key Changes

### Canvas Image Viewer (`canvas-image-viewer.tsx`)
- Added `useMediaQuery` hook to detect desktop vs mobile viewports (768px breakpoint)
- Implemented mobile-specific UI with collapsible bottom sheet for image details:
  - Top action bar with close, download, and info toggle buttons
  - Expandable info panel that slides up from the bottom on mobile
  - Extracted info panel content into reusable `ViewerInfoPanelContent` component
- Desktop layout preserved as conditional render when `isDesktop` is true
- Adjusted navigation buttons and spacing for mobile:
  - Smaller button sizes on mobile (9x9) vs desktop (12x12)
  - Reduced padding and margins for mobile screens
  - Responsive icon sizes (4px mobile, 6px desktop)
- Modified image area click behavior to only close on desktop (prevents accidental closes on mobile)

### Canvas Page (`canvas-page.tsx`)
- Added mobile drawer for generation form using new `Drawer` component
- Conditional rendering of side panel (desktop only)
- Added floating action button for mobile to open generation form drawer
- Desktop panel behavior unchanged

### Canvas Image Page (`canvas-image-page.tsx`)
- Made back button responsive with hidden text on mobile
- Adjusted positioning for mobile (smaller margins)
- Converted thumbnail strip layout to responsive flex direction
- Hidden thumbnail strip on mobile, visible on desktop

### Canvas Masonry Grid (`canvas-masonry-grid.tsx`)
- Reduced gap between grid items on mobile (8px) vs desktop (12px)

### Canvas Generation Form (`canvas-generation-form.tsx`)
- Changed model picker popover from right-side to bottom placement for better mobile UX

## Implementation Details
- Uses Tailwind's `md:` breakpoint (768px) for desktop-specific styles
- Mobile-first approach with progressive enhancement for larger screens
- Maintains all existing functionality while adapting presentation
- Preserves desktop experience without regression
- Introduces new `ViewerInfoPanelContent` component to reduce duplication between mobile and desktop info panels

https://claude.ai/code/session_01RgHVrwe5ALePVqUwyFQeNR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully implements comprehensive mobile responsiveness for the canvas image viewer and related pages. The implementation follows a mobile-first approach with progressive enhancement for larger screens, using Tailwind's `md:` breakpoint (768px) consistently throughout.

**Key improvements:**
- Canvas image viewer now features a collapsible bottom sheet on mobile with proper feature parity (upscale cancel/retry, version deletion)
- Desktop sidebar converted to mobile drawer with FAB for generation form access
- Batch action bar properly positioned to avoid FAB overlap on mobile
- Thumbnail strips adapted: vertical (desktop) vs horizontal (mobile)
- All previous review feedback has been addressed, including type safety and mobile interaction parity

The changes maintain backward compatibility with desktop while adding a fully functional mobile experience. Code quality is high with proper TypeScript interfaces, accessibility attributes, and responsive design patterns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- All previous review feedback has been thoroughly addressed with proper implementations. The code demonstrates careful attention to mobile UX (preventing accidental closes, proper touch targets, no-hover delete buttons), maintains type safety with proper interfaces, and handles responsive layout transitions correctly. The implementation is clean, well-structured, and follows established patterns in the codebase.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/canvas/canvas-image-viewer.tsx | Comprehensive mobile support with collapsible bottom sheet, proper type safety via ViewerInfoPanelContentProps interface, and feature parity between mobile/desktop (upscale cancel, version deletion) |
| src/components/canvas/canvas-masonry-grid.tsx | Responsive grid gaps and batch action bar positioning that properly accounts for mobile FAB without overlap |
| src/pages/canvas-image-page.tsx | Added mobile horizontal thumbnail strip below hero image, responsive back button, and appropriate spacing/sizing adjustments for mobile layout |
| src/pages/canvas-page.tsx | Desktop sidebar converted to mobile drawer with FAB trigger, proper conditional rendering based on viewport size |

</details>


</details>


<sub>Last reviewed commit: 34bb69e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->