### PR TITLE
feat(canvas): AI-guided discovery mode for image exploration

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as ai_chat_helpers from "../ai/chat_helpers.js";
 import type * as ai_chat_stream from "../ai/chat_stream.js";
 import type * as ai_config from "../ai/config.js";
+import type * as ai_discovery_prompt from "../ai/discovery_prompt.js";
 import type * as ai_elevenlabs from "../ai/elevenlabs.js";
 import type * as ai_elevenlabs_stream from "../ai/elevenlabs_stream.js";
 import type * as ai_elevenlabs_utils from "../ai/elevenlabs_utils.js";
@@ -61,6 +62,8 @@ import type * as conversationSummary from "../conversationSummary.js";
 import type * as conversation_search from "../conversation_search.js";
 import type * as conversations from "../conversations.js";
 import type * as crons from "../crons.js";
+import type * as discovery from "../discovery.js";
+import type * as discoverySessions from "../discoverySessions.js";
 import type * as fileStorage from "../fileStorage.js";
 import type * as generations from "../generations.js";
 import type * as http from "../http.js";
@@ -168,6 +171,7 @@ declare const fullApi: ApiFromModules<{
   "ai/chat_helpers": typeof ai_chat_helpers;
   "ai/chat_stream": typeof ai_chat_stream;
   "ai/config": typeof ai_config;
+  "ai/discovery_prompt": typeof ai_discovery_prompt;
   "ai/elevenlabs": typeof ai_elevenlabs;
   "ai/elevenlabs_stream": typeof ai_elevenlabs_stream;
   "ai/elevenlabs_utils": typeof ai_elevenlabs_utils;
@@ -218,6 +222,8 @@ declare const fullApi: ApiFromModules<{
   conversation_search: typeof conversation_search;
   conversations: typeof conversations;
   crons: typeof crons;
+  discovery: typeof discovery;
+  discoverySessions: typeof discoverySessions;
   fileStorage: typeof fileStorage;
   generations: typeof generations;
   http: typeof http;

--- a/convex/ai/discovery_prompt.ts
+++ b/convex/ai/discovery_prompt.ts
@@ -1,0 +1,275 @@
+/**
+ * Prompt evolution for Discovery Mode.
+ *
+ * Takes liked/disliked context and evolves new image generation prompts,
+ * steering toward liked aesthetics and away from disliked ones.
+ * Also selects the best model and aspect ratio for each generation.
+ */
+import { v } from "convex/values";
+
+import { api } from "../_generated/api";
+import { internalAction } from "../_generated/server";
+import { generateTextWithProvider } from "./text_generation";
+
+const MODEL_SELECTION_INSTRUCTIONS = `You must also choose which image model to use. You have access to a list of available models — pick the one that best matches the style, subject, and mood of your prompt. DON'T just stick with one model. Different models have different strengths:
+- Some excel at photorealism, others at illustration, anime, painterly styles, or abstract art
+- Newer/experimental models can produce surprising and unique results
+- Match the model to the creative intent of each prompt
+
+CRITICAL: If the last 2-3 prompts used the same model, you MUST switch to a different one. Model variety is as important as prompt variety. Repeating the same model 3+ times in a row is a failure mode.
+
+If none of the available models are a great fit for what you want to create, you can suggest a Replicate search query instead. For example, if you want an anime-style model but none are available, set "searchQuery" to "anime illustration" and we'll find one on Replicate. Be specific with search queries — include the style, medium, or technique you're looking for.
+
+IMPORTANT: Vary your model choices! Don't default to the same model every time. Exploration means trying different rendering engines, not just different prompts.`;
+
+const DISCOVERY_SYSTEM_PROMPT = `You are an AI image prompt director exploring creative possibilities. Given a seed concept, liked prompts (steer toward), and disliked prompts (steer away from), write a NEW image generation prompt.
+
+RULES FOR VARIETY — you MUST vary at least 2 of these between every generation:
+- Subject matter (person, landscape, object, animal, architecture, abstract)
+- Medium (photography, oil painting, watercolor, digital art, pencil sketch, collage, 3D render)
+- Composition (close-up, wide angle, bird's eye, dutch angle, symmetrical, rule of thirds)
+- Lighting (golden hour, neon, chiaroscuro, flat, backlit, overexposed, candlelit)
+- Color palette (monochrome, complementary, analogous, neon, muted earth tones, pastel)
+- Mood/era (nostalgic, futuristic, unsettling, serene, chaotic, vintage 1970s, Art Deco)
+- Scale (macro, miniature, epic landscape, intimate portrait)
+
+Be cinematically specific — mention camera angles, textures, time of day, weather. NEVER paraphrase or lightly edit a liked prompt. Use liked prompts as directional signals for taste, then make a bold creative leap. 30-80 words, concrete and visual.
+
+You must also choose the best aspect ratio for the image from: 1:1, 16:9, 9:16, 4:3, 3:4. Pick the ratio that best suits the subject matter (e.g. landscapes → 16:9, portraits → 9:16, square for balanced compositions).
+
+${MODEL_SELECTION_INSTRUCTIONS}
+
+Also include an "explanation" field (1-2 sentences) describing your creative reasoning — why you chose this subject, style, model, or direction. This helps the user understand your thinking.
+
+Respond in this exact JSON format (no markdown fences):
+{"prompt": "your prompt here", "aspectRatio": "1:1", "modelId": "owner/model-name", "explanation": "your reasoning here"}
+
+If you want to search for a model on Replicate instead:
+{"prompt": "your prompt here", "aspectRatio": "1:1", "searchQuery": "search terms for the ideal model", "explanation": "your reasoning here"}`;
+
+const FIRST_GEN_NO_SEED_PROMPT = `Write a vivid, visually striking image generation prompt. Pick an interesting subject, setting, and style. Be concrete and specific — mention camera angle, lighting, textures, time of day. 30-80 words.
+
+Also choose the best aspect ratio from: 1:1, 16:9, 9:16, 4:3, 3:4.
+
+${MODEL_SELECTION_INSTRUCTIONS}
+
+Also include an "explanation" field (1-2 sentences) describing your creative reasoning — why you chose this subject, style, model, or direction.
+
+Respond in this exact JSON format (no markdown fences):
+{"prompt": "your prompt here", "aspectRatio": "1:1", "modelId": "owner/model-name", "explanation": "your reasoning here"}
+
+If you want to search for a model on Replicate instead:
+{"prompt": "your prompt here", "aspectRatio": "1:1", "searchQuery": "search terms for the ideal model", "explanation": "your reasoning here"}`;
+
+const VALID_ASPECT_RATIOS = ["1:1", "16:9", "9:16", "4:3", "3:4"];
+
+export type DiscoveryPromptResult = {
+	prompt: string;
+	aspectRatio: string;
+	modelId?: string;
+	searchQuery?: string;
+	explanation?: string;
+};
+
+export type AvailableModelInfo = {
+	modelId: string;
+	name: string;
+	description?: string;
+	tags?: string[];
+};
+
+function formatModelsForPrompt(models: AvailableModelInfo[]): string {
+	if (models.length === 0) {
+		return "\nNo models currently available. Use searchQuery to find one on Replicate.";
+	}
+
+	const modelLines = models.map((m) => {
+		const desc = m.description ? ` — ${m.description}` : "";
+		const tags = m.tags?.length ? ` [${m.tags.join(", ")}]` : "";
+		return `- ${m.modelId}: ${m.name}${desc}${tags}`;
+	});
+
+	return `\nAvailable models:\n${modelLines.join("\n")}`;
+}
+
+function parsePromptResult(
+	raw: string,
+	availableModelIds: Set<string>,
+): DiscoveryPromptResult {
+	// Try to parse as JSON first
+	try {
+		// Strip markdown fences if present
+		const cleaned = raw
+			.replace(/```json?\s*\n?/g, "")
+			.replace(/```\s*$/g, "")
+			.trim();
+		const parsed = JSON.parse(cleaned);
+		if (parsed.prompt && typeof parsed.prompt === "string") {
+			const result: DiscoveryPromptResult = {
+				prompt: parsed.prompt,
+				aspectRatio: VALID_ASPECT_RATIOS.includes(parsed.aspectRatio)
+					? parsed.aspectRatio
+					: "1:1",
+			};
+
+			// Handle model selection
+			if (parsed.searchQuery && typeof parsed.searchQuery === "string") {
+				result.searchQuery = parsed.searchQuery;
+			} else if (parsed.modelId && typeof parsed.modelId === "string") {
+				// Only accept if it's actually available
+				if (availableModelIds.has(parsed.modelId)) {
+					result.modelId = parsed.modelId;
+				}
+				// If not available, leave modelId undefined — orchestrator will use default
+			}
+
+			if (parsed.explanation && typeof parsed.explanation === "string") {
+				result.explanation = parsed.explanation;
+			}
+
+			return result;
+		}
+	} catch {
+		// Fall through to plain text fallback
+	}
+	// Fallback: treat the whole response as a prompt
+	return { prompt: raw.trim(), aspectRatio: "1:1" };
+}
+
+export const evolveDiscoveryPrompt = internalAction({
+	args: {
+		userId: v.id("users"),
+		seedPrompt: v.optional(v.string()),
+		seedImageDescription: v.optional(v.string()),
+		likedPrompts: v.array(v.string()),
+		dislikedPrompts: v.array(v.string()),
+		personaId: v.optional(v.id("personas")),
+		isFirstGeneration: v.boolean(),
+		hint: v.optional(
+			v.union(v.literal("remix"), v.literal("wilder"), v.literal("fresh")),
+		),
+		availableModels: v.array(
+			v.object({
+				modelId: v.string(),
+				name: v.string(),
+				description: v.optional(v.string()),
+				tags: v.optional(v.array(v.string())),
+			}),
+		),
+	},
+	handler: async (ctx, args): Promise<DiscoveryPromptResult> => {
+		const availableModelIds = new Set(
+			args.availableModels.map((m) => m.modelId),
+		);
+		const modelsContext = formatModelsForPrompt(args.availableModels);
+
+		// Resolve persona style if provided
+		let personaStyle = "";
+		if (args.personaId) {
+			const persona = await ctx.runQuery(api.personas.get, {
+				id: args.personaId,
+			});
+			if (persona?.prompt) {
+				personaStyle = `\n\nAdopt the following style and perspective:\n${persona.prompt}`;
+			}
+		}
+
+		// First generation paths
+		if (args.isFirstGeneration) {
+			const seed = args.seedPrompt || args.seedImageDescription || "";
+
+			if (seed) {
+				const raw = await generateTextWithProvider({
+					prompt: `${DISCOVERY_SYSTEM_PROMPT}${modelsContext}${personaStyle}\n\nSeed concept: ${seed}\n\nWrite a detailed image generation prompt based on this seed. Pick the best model for this concept.`,
+					maxOutputTokens: 512,
+					temperature: 0.95,
+				});
+				return parsePromptResult(raw, availableModelIds);
+			}
+
+			if (personaStyle) {
+				const raw = await generateTextWithProvider({
+					prompt: `${DISCOVERY_SYSTEM_PROMPT}${modelsContext}${personaStyle}\n\nNo seed concept provided. Generate a visually striking prompt that embodies the given style. Pick the best model for it.`,
+					maxOutputTokens: 512,
+					temperature: 1.0,
+				});
+				return parsePromptResult(raw, availableModelIds);
+			}
+
+			// Nothing at all — broad creative prompt
+			const raw = await generateTextWithProvider({
+				prompt: FIRST_GEN_NO_SEED_PROMPT + modelsContext + personaStyle,
+				maxOutputTokens: 512,
+				temperature: 1.0,
+			});
+			return parsePromptResult(raw, availableModelIds);
+		}
+
+		// Subsequent generations — evolve from context
+		const parts: string[] = [
+			DISCOVERY_SYSTEM_PROMPT + modelsContext + personaStyle,
+		];
+
+		// Determine temperature based on hint
+		let temperature = 0.9;
+
+		if (args.hint === "fresh") {
+			temperature = 1.0;
+			// Fresh: skip liked context, but include the most recently disliked prompt so AI knows what to avoid
+			if (args.seedPrompt || args.seedImageDescription) {
+				parts.push(
+					`\nOriginal seed (for distant reference only): ${args.seedPrompt || args.seedImageDescription}`,
+				);
+			}
+			if (args.dislikedPrompts.length > 0) {
+				const lastDisliked =
+					args.dislikedPrompts[args.dislikedPrompts.length - 1];
+				parts.push(
+					`\nMost recently rejected (AVOID this direction):\n${lastDisliked}`,
+				);
+			}
+			parts.push(
+				"\nForget all previous directions. Explore a completely new genre you haven't tried — pick from: street photography, art nouveau, vaporwave, ukiyo-e, brutalist architecture, macro nature, sci-fi concept art, fashion editorial, botanical illustration, glitch art, film noir, or something else entirely unexpected. Try a different model than before!",
+			);
+		} else {
+			if (args.seedPrompt || args.seedImageDescription) {
+				parts.push(
+					`\nOriginal seed: ${args.seedPrompt || args.seedImageDescription}`,
+				);
+			}
+
+			if (args.likedPrompts.length > 0) {
+				parts.push(
+					`\nLiked prompts (steer toward these):\n${args.likedPrompts.map((p, i) => `${i + 1}. ${p}`).join("\n")}`,
+				);
+			}
+
+			if (args.dislikedPrompts.length > 0) {
+				parts.push(
+					`\nDisliked prompts (steer away from these):\n${args.dislikedPrompts.map((p, i) => `${i + 1}. ${p}`).join("\n")}`,
+				);
+			}
+
+			if (args.hint === "remix") {
+				parts.push(
+					"\nREMIX MODE: Keep the EXACT same subject, but make a radical stylistic leap — change the medium entirely (e.g. photo → oil painting → pixel art), change the era, or switch to a completely different model. The subject stays; everything else transforms.",
+				);
+			} else if (args.hint === "wilder") {
+				parts.push(
+					"\nWILDER MODE: Amplify the most striking element to 11 — exaggerate scale, saturation, drama, detail. Push past good taste into the extraordinary. More contrast, more texture, more intensity. If a different model would produce more dramatic results, switch to it.",
+				);
+			}
+		}
+
+		parts.push(
+			"\nWrite the next image generation prompt with your chosen aspect ratio and model.",
+		);
+
+		const raw = await generateTextWithProvider({
+			prompt: parts.join("\n"),
+			maxOutputTokens: 512,
+			temperature,
+		});
+		return parsePromptResult(raw, availableModelIds);
+	},
+});

--- a/convex/ai/prompt_generation.ts
+++ b/convex/ai/prompt_generation.ts
@@ -37,7 +37,7 @@ Only describe what IS in the image — no negative instructions or "without" phr
 
 Keep it 30–80 words. Write ONLY the prompt. If the input is empty or vague, invent a vivid scene. Preserve the user's core idea.`;
 
-async function fetchImageData(
+export async function fetchImageData(
 	ctx: { storage: { get: (id: string) => Promise<Blob | null> } },
 	storageId: string,
 ): Promise<{ base64: string; mediaType: string }> {

--- a/convex/discovery.ts
+++ b/convex/discovery.ts
@@ -1,0 +1,297 @@
+/**
+ * Discovery Mode orchestrator.
+ *
+ * Coordinates prompt evolution and image generation for the discovery flow.
+ * The AI chooses the best model and aspect ratio for each generation,
+ * and can search Replicate for new models when needed.
+ * When a seed image is provided, it's analyzed with a vision model to extract
+ * a rich description that guides prompt evolution.
+ * Reuses existing canvas generation infrastructure.
+ */
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { generateText } from "ai";
+import { v } from "convex/values";
+import { DEFAULT_BUILTIN_VISION_MODEL_ID } from "../shared/constants";
+import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { ActionCtx } from "./_generated/server";
+import { action } from "./_generated/server";
+import { CONFIG } from "./ai/config";
+import type {
+  AvailableModelInfo,
+  DiscoveryPromptResult,
+} from "./ai/discovery_prompt";
+import { fetchImageData } from "./ai/prompt_generation";
+import { getAuthUserId } from "./lib/auth";
+import { scheduleRunAfter } from "./lib/scheduler";
+
+const IMAGE_ANALYSIS_PROMPT = `Analyze this image in detail for use as creative inspiration. Describe:
+- Subject matter and composition
+- Art style, medium, and technique (e.g. photography, oil painting, digital art, watercolor)
+- Color palette and lighting
+- Mood and atmosphere
+- Notable textures, patterns, or visual details
+- Any text, symbols, or distinctive elements
+
+Be specific and visual. This description will guide an AI image generation system, so focus on concrete details that can be reproduced or riffed on creatively. 80-150 words.`;
+
+/** Describe a seed image using the same vision model as canvas prompt generation. */
+async function describeImage(
+  ctx: ActionCtx,
+  storageId: Id<"_storage">
+): Promise<string | undefined> {
+  const apiKey = process.env[CONFIG.PROVIDER_ENV_KEYS.google];
+  if (!apiKey) {
+    console.error("Discovery: No Google API key for vision model");
+    return undefined;
+  }
+
+  try {
+    const imageData = await fetchImageData(ctx, storageId);
+    const google = createGoogleGenerativeAI({ apiKey });
+    const model = google.chat(DEFAULT_BUILTIN_VISION_MODEL_ID);
+
+    const result = await generateText({
+      model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              image: imageData.base64,
+              mediaType: imageData.mediaType,
+            },
+            { type: "text", text: IMAGE_ANALYSIS_PROMPT },
+          ],
+        },
+      ],
+      maxOutputTokens: 512,
+      temperature: 0.3,
+    });
+
+    return result.text;
+  } catch (error) {
+    console.error("Discovery: Image description failed:", error);
+    return undefined;
+  }
+}
+
+/** Fetch available models and format them for the AI prompt. */
+async function getModelsForPrompt(
+  ctx: ActionCtx,
+  userId: Id<"users">
+): Promise<{
+  models: AvailableModelInfo[];
+  allModels: Array<{
+    modelId: string;
+    name: string;
+    isBuiltIn: boolean;
+    free?: boolean;
+    description?: string;
+    tags?: string[];
+  }>;
+}> {
+  const allModels = await ctx.runQuery(
+    internal.imageModels.internalGetAvailableImageModels,
+    { userId }
+  );
+
+  const models: AvailableModelInfo[] = allModels.map(
+    (m: {
+      modelId: string;
+      name: string;
+      description?: string;
+      tags?: string[];
+    }) => ({
+      modelId: m.modelId,
+      name: m.name,
+      description: m.description,
+      tags: m.tags,
+    })
+  );
+
+  return { models, allModels };
+}
+
+/** Pick a fallback model when the AI doesn't specify one. */
+function pickFallbackModel(
+  allModels: Array<{
+    modelId: string;
+    isBuiltIn?: boolean;
+    free?: boolean;
+  }>,
+  explicitModelId?: string
+): string {
+  if (explicitModelId) {
+    return explicitModelId;
+  }
+
+  // Prefer non-free models; fall back to any active model
+  const preferred = allModels.find((m: { free?: boolean }) => !m.free);
+  const fallback = allModels[0];
+  const chosen = preferred ?? fallback;
+  if (!chosen) {
+    throw new Error("No image models available");
+  }
+  return (chosen as { modelId: string }).modelId;
+}
+
+/** Search Replicate for a model matching the AI's query and auto-add it. */
+async function searchAndAddModel(
+  ctx: ActionCtx,
+  searchQuery: string
+): Promise<string | null> {
+  try {
+    const searchResult = await ctx.runAction(
+      api.imageModels.searchReplicateModels,
+      { query: searchQuery }
+    );
+
+    if (!searchResult.models || searchResult.models.length === 0) {
+      return null;
+    }
+
+    // Pick the top result
+    const topModel = searchResult.models[0];
+    if (!topModel) {
+      return null;
+    }
+
+    // Auto-add it to the user's models
+    const addResult = await ctx.runAction(api.imageModels.addCustomImageModel, {
+      modelId: topModel.modelId,
+    });
+
+    if (addResult.success) {
+      return topModel.modelId;
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Discovery: Replicate search failed:", error);
+    return null;
+  }
+}
+
+export const startDiscoveryGeneration = action({
+  args: {
+    seedPrompt: v.optional(v.string()),
+    seedImageStorageId: v.optional(v.id("_storage")),
+    likedPrompts: v.array(v.string()),
+    dislikedPrompts: v.array(v.string()),
+    modelId: v.optional(v.string()),
+    personaId: v.optional(v.id("personas")),
+    aspectRatio: v.optional(v.string()),
+    sessionId: v.string(),
+    isFirstGeneration: v.optional(v.boolean()),
+    hint: v.optional(
+      v.union(v.literal("remix"), v.literal("wilder"), v.literal("fresh"))
+    ),
+  },
+  returns: v.object({
+    generationId: v.id("generations"),
+    prompt: v.string(),
+    aspectRatio: v.string(),
+    modelId: v.string(),
+    explanation: v.optional(v.string()),
+  }),
+  handler: async (
+    ctx,
+    args
+  ): Promise<{
+    generationId: Id<"generations">;
+    prompt: string;
+    aspectRatio: string;
+    modelId: string;
+    explanation?: string;
+  }> => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    // Fetch available models for the AI to choose from
+    const { models: availableModels, allModels } = await getModelsForPrompt(
+      ctx,
+      userId
+    );
+
+    // If seed image provided and first gen, describe it with a vision model
+    let seedImageDescription: string | undefined;
+    if (args.seedImageStorageId && args.isFirstGeneration) {
+      seedImageDescription = await describeImage(ctx, args.seedImageStorageId);
+    }
+
+    // Evolve the prompt — AI also chooses model and aspect ratio
+    const result = (await ctx.runAction(
+      internal.ai.discovery_prompt.evolveDiscoveryPrompt,
+      {
+        userId,
+        seedPrompt: args.seedPrompt,
+        seedImageDescription,
+        likedPrompts: args.likedPrompts,
+        dislikedPrompts: args.dislikedPrompts,
+        personaId: args.personaId,
+        isFirstGeneration: args.isFirstGeneration ?? false,
+        hint: args.hint,
+        availableModels,
+      }
+    )) as DiscoveryPromptResult;
+
+    const prompt = result.prompt;
+    const aspectRatio = result.aspectRatio;
+
+    // Resolve the model — AI choice → search → fallback
+    let modelId: string | undefined;
+
+    if (result.modelId) {
+      // AI picked a specific available model
+      modelId = result.modelId;
+    } else if (result.searchQuery) {
+      // AI wants a model we don't have — search Replicate
+      const foundModelId = await searchAndAddModel(ctx, result.searchQuery);
+      if (foundModelId) {
+        modelId = foundModelId;
+      }
+    }
+
+    // Final fallback: use the explicitly passed modelId or pick from available
+    if (!modelId) {
+      modelId = pickFallbackModel(allModels, args.modelId);
+    }
+
+    const explanation = result.explanation;
+
+    // Create generation row
+    const generationId: Id<"generations"> = await ctx.runMutation(
+      internal.generations.internalCreateGeneration,
+      {
+        userId,
+        prompt,
+        model: modelId,
+        provider: "replicate",
+        params: {
+          aspectRatio,
+          count: 1,
+        },
+        batchId: args.sessionId,
+        explanation,
+      }
+    );
+
+    // Schedule the actual image generation
+    await scheduleRunAfter(ctx, 0, internal.generations.runCanvasGeneration, {
+      generationId,
+      userId,
+    });
+
+    // Increment session generation count
+    await ctx.runMutation(
+      internal.discoverySessions.internalIncrementGenerationCount,
+      { sessionId: args.sessionId }
+    );
+
+    return { generationId, prompt, aspectRatio, modelId, explanation };
+  },
+});

--- a/convex/discovery.ts
+++ b/convex/discovery.ts
@@ -141,7 +141,7 @@ function pickFallbackModel(
 async function searchAndAddModel(
   ctx: ActionCtx,
   searchQuery: string
-): Promise<string | null> {
+): Promise<{ modelId: string; modelName: string } | null> {
   try {
     const searchResult = await ctx.runAction(
       api.imageModels.searchReplicateModels,
@@ -164,7 +164,10 @@ async function searchAndAddModel(
     });
 
     if (addResult.success) {
-      return topModel.modelId;
+      return {
+        modelId: topModel.modelId,
+        modelName: topModel.name ?? topModel.modelId,
+      };
     }
 
     return null;
@@ -195,6 +198,7 @@ export const startDiscoveryGeneration = action({
     aspectRatio: v.string(),
     modelId: v.string(),
     explanation: v.optional(v.string()),
+    addedModelName: v.optional(v.string()),
   }),
   handler: async (
     ctx,
@@ -205,6 +209,7 @@ export const startDiscoveryGeneration = action({
     aspectRatio: string;
     modelId: string;
     explanation?: string;
+    addedModelName?: string;
   }> => {
     const userId = await getAuthUserId(ctx);
     if (!userId) {
@@ -244,15 +249,17 @@ export const startDiscoveryGeneration = action({
 
     // Resolve the model — AI choice → search → fallback
     let modelId: string | undefined;
+    let addedModelName: string | undefined;
 
     if (result.modelId) {
       // AI picked a specific available model
       modelId = result.modelId;
     } else if (result.searchQuery) {
       // AI wants a model we don't have — search Replicate
-      const foundModelId = await searchAndAddModel(ctx, result.searchQuery);
-      if (foundModelId) {
-        modelId = foundModelId;
+      const found = await searchAndAddModel(ctx, result.searchQuery);
+      if (found) {
+        modelId = found.modelId;
+        addedModelName = found.modelName;
       }
     }
 
@@ -286,12 +293,19 @@ export const startDiscoveryGeneration = action({
       userId,
     });
 
-    // Increment session generation count
+    // Increment session generation count and backfill metadata
     await ctx.runMutation(
       internal.discoverySessions.internalIncrementGenerationCount,
-      { sessionId: args.sessionId }
+      { sessionId: args.sessionId, modelId, aspectRatio }
     );
 
-    return { generationId, prompt, aspectRatio, modelId, explanation };
+    return {
+      generationId,
+      prompt,
+      aspectRatio,
+      modelId,
+      explanation,
+      addedModelName,
+    };
   },
 });

--- a/convex/discoverySessions.ts
+++ b/convex/discoverySessions.ts
@@ -142,9 +142,9 @@ export const create = mutation({
     sessionId: v.string(),
     seedPrompt: v.optional(v.string()),
     seedImageStorageId: v.optional(v.id("_storage")),
-    modelId: v.string(),
+    modelId: v.optional(v.string()),
     personaId: v.optional(v.id("personas")),
-    aspectRatio: v.string(),
+    aspectRatio: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
@@ -222,17 +222,28 @@ export const recordReaction = mutation({
     }
 
     // Update liked/disliked prompt sliding windows
+    const previousReaction =
+      existingIdx >= 0 ? session.reactions[existingIdx]?.reaction : undefined;
     let { likedPrompts, dislikedPrompts } = session;
-    if (args.reaction === "liked") {
+
+    if (args.reaction === "liked" && previousReaction !== "liked") {
       likedPrompts = [
         ...likedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
         args.prompt,
       ];
-    } else if (args.reaction === "disliked") {
+      dislikedPrompts = dislikedPrompts.filter(p => p !== args.prompt);
+    } else if (
+      args.reaction === "disliked" &&
+      previousReaction !== "disliked"
+    ) {
       dislikedPrompts = [
         ...dislikedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
         args.prompt,
       ];
+      likedPrompts = likedPrompts.filter(p => p !== args.prompt);
+    } else if (args.reaction === "saved") {
+      // Saved is a positive signal — keep in liked if present, remove from disliked
+      dislikedPrompts = dislikedPrompts.filter(p => p !== args.prompt);
     }
 
     await ctx.db.patch(session._id, {
@@ -351,7 +362,11 @@ export const remove = mutation({
  * Called from the discovery action after creating a generation.
  */
 export const internalIncrementGenerationCount = internalMutation({
-  args: { sessionId: v.string() },
+  args: {
+    sessionId: v.string(),
+    modelId: v.optional(v.string()),
+    aspectRatio: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const session = await ctx.db
       .query("discoverySessions")
@@ -362,9 +377,19 @@ export const internalIncrementGenerationCount = internalMutation({
       return;
     }
 
-    await ctx.db.patch(session._id, {
+    const patch: Record<string, unknown> = {
       generationCount: session.generationCount + 1,
       updatedAt: Date.now(),
-    });
+    };
+
+    // Backfill modelId/aspectRatio from the first generation
+    if (args.modelId && !session.modelId) {
+      patch.modelId = args.modelId;
+    }
+    if (args.aspectRatio && !session.aspectRatio) {
+      patch.aspectRatio = args.aspectRatio;
+    }
+
+    await ctx.db.patch(session._id, patch);
   },
 });

--- a/convex/discoverySessions.ts
+++ b/convex/discoverySessions.ts
@@ -1,0 +1,370 @@
+import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
+import { internalMutation, mutation, query } from "./_generated/server";
+import { getAuthUserId } from "./lib/auth";
+
+const MAX_CONTEXT_PROMPTS = 10;
+
+// ============================================================================
+// Queries
+// ============================================================================
+
+/**
+ * List discovery sessions for the current user, newest first.
+ */
+export const list = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      return [];
+    }
+
+    const limit = args.limit ?? 50;
+
+    const sessions = await ctx.db
+      .query("discoverySessions")
+      .withIndex("by_user_updated", q => q.eq("userId", userId))
+      .order("desc")
+      .take(limit);
+
+    return sessions;
+  },
+});
+
+/**
+ * Get a session by its UUID string (used for resume).
+ */
+export const getBySessionId = query({
+  args: { sessionId: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      return null;
+    }
+
+    const session = await ctx.db
+      .query("discoverySessions")
+      .withIndex("by_session_id", q => q.eq("sessionId", args.sessionId))
+      .first();
+
+    if (!session || session.userId !== userId) {
+      return null;
+    }
+
+    return session;
+  },
+});
+
+/**
+ * Get session with its generation history (joined via by_batch index).
+ * Reactions from the session doc are merged into the generation entries.
+ */
+export const getWithHistory = query({
+  args: { sessionId: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      return null;
+    }
+
+    const session = await ctx.db
+      .query("discoverySessions")
+      .withIndex("by_session_id", q => q.eq("sessionId", args.sessionId))
+      .first();
+
+    if (!session || session.userId !== userId) {
+      return null;
+    }
+
+    // Fetch generations for this session via the by_batch index
+    const generations = await ctx.db
+      .query("generations")
+      .withIndex("by_batch", q => q.eq("batchId", args.sessionId))
+      .order("asc")
+      .collect();
+
+    // Build reaction lookup
+    const reactionMap = new Map<
+      Id<"generations">,
+      "liked" | "disliked" | "saved"
+    >();
+    for (const r of session.reactions) {
+      reactionMap.set(r.generationId, r.reaction);
+    }
+
+    // Resolve image URLs and merge reactions
+    const entries = await Promise.all(
+      generations
+        .filter(g => !g.isArchived)
+        .map(async gen => {
+          let imageUrl: string | null = null;
+          if (gen.storageIds?.[0]) {
+            imageUrl = await ctx.storage.getUrl(gen.storageIds[0]);
+          }
+
+          let status: "succeeded" | "failed" | "generating";
+          if (gen.status === "succeeded") {
+            status = "succeeded";
+          } else if (gen.status === "failed" || gen.status === "canceled") {
+            status = "failed";
+          } else {
+            status = "generating";
+          }
+
+          return {
+            generationId: gen._id,
+            prompt: gen.prompt,
+            imageUrl,
+            aspectRatio: gen.params?.aspectRatio ?? "1:1",
+            status,
+            reaction: reactionMap.get(gen._id) ?? null,
+            explanation: gen.explanation,
+          };
+        })
+    );
+
+    return { session, entries };
+  },
+});
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+/**
+ * Create a new discovery session.
+ */
+export const create = mutation({
+  args: {
+    sessionId: v.string(),
+    seedPrompt: v.optional(v.string()),
+    seedImageStorageId: v.optional(v.id("_storage")),
+    modelId: v.string(),
+    personaId: v.optional(v.id("personas")),
+    aspectRatio: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const now = Date.now();
+    const id = await ctx.db.insert("discoverySessions", {
+      userId,
+      sessionId: args.sessionId,
+      seedPrompt: args.seedPrompt,
+      seedImageStorageId: args.seedImageStorageId,
+      modelId: args.modelId,
+      personaId: args.personaId,
+      aspectRatio: args.aspectRatio,
+      likedPrompts: [],
+      dislikedPrompts: [],
+      reactions: [],
+      generationCount: 0,
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return id;
+  },
+});
+
+/**
+ * Record a reaction (like/dislike/save) on a generation within a session.
+ * Updates the reactions array and likedPrompts/dislikedPrompts sliding windows.
+ */
+export const recordReaction = mutation({
+  args: {
+    sessionId: v.string(),
+    generationId: v.id("generations"),
+    prompt: v.string(),
+    reaction: v.union(
+      v.literal("liked"),
+      v.literal("disliked"),
+      v.literal("saved")
+    ),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const session = await ctx.db
+      .query("discoverySessions")
+      .withIndex("by_session_id", q => q.eq("sessionId", args.sessionId))
+      .first();
+
+    if (!session || session.userId !== userId) {
+      throw new Error("Session not found");
+    }
+
+    // Update or add reaction
+    const existingIdx = session.reactions.findIndex(
+      r => r.generationId === args.generationId
+    );
+    const updatedReactions = [...session.reactions];
+    if (existingIdx >= 0) {
+      updatedReactions[existingIdx] = {
+        generationId: args.generationId,
+        reaction: args.reaction,
+      };
+    } else {
+      updatedReactions.push({
+        generationId: args.generationId,
+        reaction: args.reaction,
+      });
+    }
+
+    // Update liked/disliked prompt sliding windows
+    let { likedPrompts, dislikedPrompts } = session;
+    if (args.reaction === "liked") {
+      likedPrompts = [
+        ...likedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
+        args.prompt,
+      ];
+    } else if (args.reaction === "disliked") {
+      dislikedPrompts = [
+        ...dislikedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
+        args.prompt,
+      ];
+    }
+
+    await ctx.db.patch(session._id, {
+      reactions: updatedReactions,
+      likedPrompts,
+      dislikedPrompts,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/**
+ * Pause a session (on exit via Escape). Keeps all generations visible.
+ */
+export const pause = mutation({
+  args: { sessionId: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const session = await ctx.db
+      .query("discoverySessions")
+      .withIndex("by_session_id", q => q.eq("sessionId", args.sessionId))
+      .first();
+
+    if (!session || session.userId !== userId) {
+      return;
+    }
+
+    await ctx.db.patch(session._id, {
+      status: "paused",
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/**
+ * Mark a session as completed (explicit "End Session").
+ */
+export const complete = mutation({
+  args: { sessionId: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const session = await ctx.db
+      .query("discoverySessions")
+      .withIndex("by_session_id", q => q.eq("sessionId", args.sessionId))
+      .first();
+
+    if (!session || session.userId !== userId) {
+      return;
+    }
+
+    await ctx.db.patch(session._id, {
+      status: "completed",
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/**
+ * Remove a session. Archives non-saved generations.
+ */
+export const remove = mutation({
+  args: { sessionId: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const session = await ctx.db
+      .query("discoverySessions")
+      .withIndex("by_session_id", q => q.eq("sessionId", args.sessionId))
+      .first();
+
+    if (!session || session.userId !== userId) {
+      return;
+    }
+
+    // Get saved generation IDs
+    const savedIds = new Set(
+      session.reactions
+        .filter(r => r.reaction === "saved")
+        .map(r => r.generationId)
+    );
+
+    // Archive non-saved generations
+    const generations = await ctx.db
+      .query("generations")
+      .withIndex("by_batch", q => q.eq("batchId", args.sessionId))
+      .collect();
+
+    for (const gen of generations) {
+      if (!(savedIds.has(gen._id) || gen.isArchived)) {
+        await ctx.db.patch(gen._id, { isArchived: true });
+      }
+    }
+
+    // Delete the session doc
+    await ctx.db.delete(session._id);
+  },
+});
+
+// ============================================================================
+// Internal mutations (called from actions)
+// ============================================================================
+
+/**
+ * Increment the generation count on a session.
+ * Called from the discovery action after creating a generation.
+ */
+export const internalIncrementGenerationCount = internalMutation({
+  args: { sessionId: v.string() },
+  handler: async (ctx, args) => {
+    const session = await ctx.db
+      .query("discoverySessions")
+      .withIndex("by_session_id", q => q.eq("sessionId", args.sessionId))
+      .first();
+
+    if (!session) {
+      return;
+    }
+
+    await ctx.db.patch(session._id, {
+      generationCount: session.generationCount + 1,
+      updatedAt: Date.now(),
+    });
+  },
+});

--- a/convex/generations.ts
+++ b/convex/generations.ts
@@ -843,6 +843,7 @@ export const internalCreateGeneration = internalMutation({
     batchId: v.optional(v.string()),
     parentGenerationId: v.optional(v.id("generations")),
     rootGenerationId: v.optional(v.id("generations")),
+    explanation: v.optional(v.string()),
   },
   handler: (ctx, args) => {
     return ctx.db.insert("generations", {
@@ -855,6 +856,7 @@ export const internalCreateGeneration = internalMutation({
       batchId: args.batchId,
       parentGenerationId: args.parentGenerationId,
       rootGenerationId: args.rootGenerationId,
+      explanation: args.explanation,
       createdAt: Date.now(),
     });
   },

--- a/convex/imageModels.ts
+++ b/convex/imageModels.ts
@@ -8,6 +8,7 @@ import {
 } from "./_generated/server";
 import {
   getAvailableImageModelsHandler,
+  getAvailableImageModelsInternalHandler,
   getBuiltInImageModelByModelIdHandler,
   getBuiltInImageModelsHandler,
   getModelDefinitionHandler,
@@ -59,6 +60,11 @@ export const getBuiltInImageModelByModelId = internalQuery({
 export const getAvailableImageModels = query({
   args: {},
   handler: getAvailableImageModelsHandler,
+});
+
+export const internalGetAvailableImageModels = internalQuery({
+  args: { userId: v.id("users") },
+  handler: getAvailableImageModelsInternalHandler,
 });
 
 export const getSelectedImageModelWithFallback = query({

--- a/convex/lib/image_models/handlers.ts
+++ b/convex/lib/image_models/handlers.ts
@@ -99,6 +99,48 @@ export async function getAvailableImageModelsHandler(ctx: QueryCtx) {
   return [...userModelsWithFlag, ...availableBuiltInModels];
 }
 
+export async function getAvailableImageModelsInternalHandler(
+  ctx: QueryCtx,
+  args: { userId: Id<"users"> }
+) {
+  const userId = args.userId;
+
+  // Get built-in image models
+  const builtInModels = await ctx.db
+    .query("builtInImageModels")
+    .filter(q => q.eq(q.field("isActive"), true))
+    .collect();
+
+  // Get user's image models
+  const userModels = await ctx.db
+    .query("userImageModels")
+    .withIndex("by_user", q => q.eq("userId", userId))
+    .collect();
+
+  // Create a set of user model keys to filter out conflicts
+  const userModelKeys = new Set(
+    userModels.map(model => `${model.modelId}:${model.provider}`)
+  );
+
+  // Filter out built-in models that have been overridden by user models
+  const availableBuiltInModels = builtInModels
+    .filter(
+      builtInModel =>
+        !userModelKeys.has(`${builtInModel.modelId}:${builtInModel.provider}`)
+    )
+    .map(model => ({
+      ...model,
+      isBuiltIn: true as const,
+    }));
+
+  const userModelsWithFlag = userModels.map(model => ({
+    ...model,
+    isBuiltIn: false as const,
+  }));
+
+  return [...userModelsWithFlag, ...availableBuiltInModels];
+}
+
 export async function getSelectedImageModelWithFallbackHandler(ctx: QueryCtx) {
   const userId = await getAuthUserId(ctx);
 

--- a/convex/lib/image_models/handlers.ts
+++ b/convex/lib/image_models/handlers.ts
@@ -108,7 +108,7 @@ export async function getAvailableImageModelsInternalHandler(
   // Get built-in image models
   const builtInModels = await ctx.db
     .query("builtInImageModels")
-    .filter(q => q.eq(q.field("isActive"), true))
+    .withIndex("by_active", q => q.eq("isActive", true))
     .collect();
 
   // Get user's image models

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -1124,9 +1124,9 @@ export const discoverySessionSchema = v.object({
   sessionId: v.string(),
   seedPrompt: v.optional(v.string()),
   seedImageStorageId: v.optional(v.id("_storage")),
-  modelId: v.string(),
+  modelId: v.optional(v.string()),
   personaId: v.optional(v.id("personas")),
-  aspectRatio: v.string(),
+  aspectRatio: v.optional(v.string()),
   likedPrompts: v.array(v.string()),
   dislikedPrompts: v.array(v.string()),
   reactions: v.array(

--- a/convex/lib/schemas.ts
+++ b/convex/lib/schemas.ts
@@ -1083,6 +1083,7 @@ export const generationSchema = v.object({
     completedAt: v.optional(v.number()),
   })),
   upscales: v.optional(v.array(upscaleEntrySchema)),
+  explanation: v.optional(v.string()),
   isArchived: v.optional(v.boolean()),
   createdAt: v.number(),
   completedAt: v.optional(v.number()),
@@ -1113,3 +1114,37 @@ export type UpdateUserSettingsArgs = Infer<typeof userSettingsUpdateSchema>;
 export type CreateUserModelArgs = Infer<typeof userModelSchema>;
 export type GenerationDoc = Infer<typeof generationSchema>;
 export type UpscaleEntryDoc = Infer<typeof upscaleEntrySchema>;
+
+// ============================================================================
+// Discovery Sessions
+// ============================================================================
+
+export const discoverySessionSchema = v.object({
+  userId: v.id("users"),
+  sessionId: v.string(),
+  seedPrompt: v.optional(v.string()),
+  seedImageStorageId: v.optional(v.id("_storage")),
+  modelId: v.string(),
+  personaId: v.optional(v.id("personas")),
+  aspectRatio: v.string(),
+  likedPrompts: v.array(v.string()),
+  dislikedPrompts: v.array(v.string()),
+  reactions: v.array(
+    v.object({
+      generationId: v.id("generations"),
+      reaction: v.union(
+        v.literal("liked"),
+        v.literal("disliked"),
+        v.literal("saved")
+      ),
+    })
+  ),
+  generationCount: v.number(),
+  status: v.union(
+    v.literal("active"),
+    v.literal("paused"),
+    v.literal("completed")
+  ),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4,6 +4,7 @@ import {
   builtInImageModelSchema,
   builtInModelSchema,
   conversationSchema,
+  discoverySessionSchema,
   generationSchema,
   imageModelDefinitionSchema,
   messageFavoriteSchema,
@@ -170,6 +171,10 @@ export default defineSchema({
     .index("by_batch", ["batchId", "createdAt"])
     .index("by_parent", ["parentGenerationId", "createdAt"])
     .index("by_root", ["rootGenerationId", "createdAt"]),
+
+  discoverySessions: defineTable(discoverySessionSchema)
+    .index("by_user_updated", ["userId", "updatedAt"])
+    .index("by_session_id", ["sessionId"]),
 
   userFiles: defineTable(userFileSchema)
     .index("by_user_created", ["userId", "createdAt"])

--- a/src/components/canvas/discovery-layout.tsx
+++ b/src/components/canvas/discovery-layout.tsx
@@ -1,0 +1,91 @@
+import { ListIcon } from "@phosphor-icons/react";
+import { PanelLeftIcon } from "@/components/animate-ui/icons/panel-left";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DiscoveryLayoutProps {
+  children: React.ReactNode;
+  /** When true, header auto-hides and uses translucent overlay style */
+  immersive?: boolean;
+  /** Whether the header is visible (only applies when immersive) */
+  showHeader?: boolean;
+  /** Whether the sidebar panel is collapsed */
+  isPanelCollapsed?: boolean;
+  /** Called to expand the sidebar panel */
+  onExpandPanel?: () => void;
+}
+
+export function DiscoveryLayout({
+  children,
+  immersive = false,
+  showHeader = true,
+  isPanelCollapsed = false,
+  onExpandPanel,
+}: DiscoveryLayoutProps) {
+  return (
+    <div className="flex flex-1 flex-col min-w-0">
+      {/* Header */}
+      {immersive ? (
+        isPanelCollapsed &&
+        onExpandPanel && (
+          <div
+            className={cn(
+              "fixed top-0 left-0 z-popover pointer-events-none transition-opacity duration-300",
+              showHeader ? "opacity-100" : "opacity-0"
+            )}
+          >
+            <div className="py-4 px-3 pl-4">
+              {/* Desktop: panel expand icon */}
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                title="Expand panel"
+                onClick={onExpandPanel}
+                className="pointer-events-auto hidden sm:flex"
+              >
+                <PanelLeftIcon className="size-4" />
+              </Button>
+              {/* Mobile: menu icon to toggle sidebar overlay */}
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                title="Sessions"
+                onClick={onExpandPanel}
+                className="pointer-events-auto flex sm:hidden"
+              >
+                <ListIcon className="size-4" weight="bold" />
+              </Button>
+            </div>
+          </div>
+        )
+      ) : (
+        <header className="flex h-16 items-center gap-3 px-4 shrink-0">
+          {isPanelCollapsed && onExpandPanel && (
+            <>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                title="Expand panel"
+                onClick={onExpandPanel}
+                className="hidden sm:flex"
+              >
+                <PanelLeftIcon className="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                title="Sessions"
+                onClick={onExpandPanel}
+                className="flex sm:hidden"
+              >
+                <ListIcon className="size-4" weight="bold" />
+              </Button>
+            </>
+          )}
+        </header>
+      )}
+
+      {children}
+    </div>
+  );
+}

--- a/src/components/canvas/discovery-mode.tsx
+++ b/src/components/canvas/discovery-mode.tsx
@@ -1,0 +1,797 @@
+import { api } from "@convex/_generated/api";
+import {
+  ArrowDownIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ArrowUpIcon,
+  BookmarkSimpleIcon,
+  FireIcon,
+  HeartIcon,
+  InfoIcon,
+  ShuffleIcon,
+  SparkleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { useAction, useQuery } from "convex/react";
+import {
+  AnimatePresence,
+  motion,
+  type PanInfo,
+  useMotionValue,
+  useTransform,
+} from "framer-motion";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { DiscoveryLayout } from "@/components/canvas/discovery-layout";
+import { Spinner } from "@/components/ui/spinner";
+import { useDiscoverySessionSync } from "@/hooks/use-discovery-session-sync";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { ROUTES } from "@/lib/routes";
+import { useToast } from "@/providers/toast-context";
+import { useDiscoveryStore } from "@/stores/discovery-store";
+
+type ReactionFlash = "liked" | "disliked" | "saved" | null;
+
+function getSwipeExitAnimation(dir: "left" | "right" | null) {
+  if (dir === "right") {
+    return { x: 400, opacity: 0, rotate: 15 };
+  }
+  if (dir === "left") {
+    return { x: -400, opacity: 0, rotate: -15 };
+  }
+  return { opacity: 0, scale: 0.97 };
+}
+
+export function DiscoveryMode() {
+  const isActive = useDiscoveryStore(s => s.isActive);
+  const history = useDiscoveryStore(s => s.history);
+  const currentIndex = useDiscoveryStore(s => s.currentIndex);
+  const isGenerating = useDiscoveryStore(s => s.isGenerating);
+  const sessionId = useDiscoveryStore(s => s.sessionId);
+
+  const addEntry = useDiscoveryStore(s => s.addEntry);
+  const updateEntry = useDiscoveryStore(s => s.updateEntry);
+  const reactLike = useDiscoveryStore(s => s.reactLike);
+  const reactDislike = useDiscoveryStore(s => s.reactDislike);
+  const reactRemix = useDiscoveryStore(s => s.reactRemix);
+  const reactWilder = useDiscoveryStore(s => s.reactWilder);
+  const reactFresh = useDiscoveryStore(s => s.reactFresh);
+  const saveCurrentToCollection = useDiscoveryStore(
+    s => s.saveCurrentToCollection
+  );
+  const browseUp = useDiscoveryStore(s => s.browseUp);
+  const browseDown = useDiscoveryStore(s => s.browseDown);
+  const stop = useDiscoveryStore(s => s.stop);
+  const isPanelVisible = useDiscoveryStore(s => s.isPanelVisible);
+  const togglePanel = useDiscoveryStore(s => s.togglePanel);
+
+  const startGeneration = useAction(api.discovery.startDiscoveryGeneration);
+  const { syncReaction, syncPause } = useDiscoverySessionSync();
+  const managedToast = useToast();
+
+  const [showHud, setShowHud] = useState(true);
+  const [showExplanation, setShowExplanation] = useState(false);
+  const [reactionFlash, setReactionFlash] = useState<ReactionFlash>(null);
+  const [swipeExit, setSwipeExit] = useState<"left" | "right" | null>(null);
+  const hudTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const generatingLockRef = useRef(false);
+
+  const isMobile = useMediaQuery("(max-width: 640px)");
+
+  const currentEntry = history[currentIndex] ?? null;
+
+  // Swipe gesture state
+  const dragX = useMotionValue(0);
+  const dragRotate = useTransform(dragX, [-200, 0, 200], [-12, 0, 12]);
+  const dragScale = useTransform(dragX, [-200, 0, 200], [0.95, 1, 0.95]);
+  const likeOverlayOpacity = useTransform(dragX, [0, 80], [0, 0.4]);
+  const dislikeOverlayOpacity = useTransform(dragX, [-80, 0], [0.4, 0]);
+
+  // Reset explanation toggle when navigating between entries
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on index change only
+  useEffect(() => {
+    setShowExplanation(false);
+  }, [currentIndex]);
+
+  // Subscribe to current generation status
+  const generationData = useQuery(
+    api.generations.getGeneration,
+    currentEntry?.generationId ? { id: currentEntry.generationId } : "skip"
+  );
+
+  // Update entry when generation data changes
+  useEffect(() => {
+    if (!(generationData && currentEntry)) {
+      return;
+    }
+
+    let newStatus: "succeeded" | "failed" | "generating";
+    if (generationData.status === "succeeded") {
+      newStatus = "succeeded";
+    } else if (
+      generationData.status === "failed" ||
+      generationData.status === "canceled"
+    ) {
+      newStatus = "failed";
+    } else {
+      newStatus = "generating";
+    }
+
+    const newImageUrl = generationData.imageUrls?.[0] ?? null;
+
+    if (
+      newStatus !== currentEntry.status ||
+      newImageUrl !== currentEntry.imageUrl
+    ) {
+      updateEntry(currentEntry.generationId, {
+        status: newStatus,
+        imageUrl: newImageUrl,
+      });
+    }
+  }, [generationData, currentEntry, updateEntry]);
+
+  // Flash a reaction icon briefly
+  const flashReaction = useCallback((type: ReactionFlash) => {
+    setReactionFlash(type);
+    setTimeout(() => setReactionFlash(null), 500);
+  }, []);
+
+  // Trigger a new generation
+  const triggerGeneration = useCallback(async () => {
+    if (isGenerating || generatingLockRef.current) {
+      return;
+    }
+
+    generatingLockRef.current = true;
+    const state = useDiscoveryStore.getState();
+
+    try {
+      const result = await startGeneration({
+        seedPrompt: state.seedPrompt || undefined,
+        seedImageStorageId: state.seedImageStorageId ?? undefined,
+        likedPrompts: state.likedPrompts,
+        dislikedPrompts: state.dislikedPrompts,
+        modelId: state.modelId || undefined,
+        personaId: state.personaId ?? undefined,
+        aspectRatio: state.aspectRatio || undefined,
+        sessionId: state.sessionId,
+        isFirstGeneration: state.history.length === 0,
+        hint: state.hint || undefined,
+      });
+
+      addEntry({
+        generationId: result.generationId,
+        prompt: result.prompt,
+        imageUrl: null,
+        aspectRatio: result.aspectRatio ?? "1:1",
+        status: "pending",
+        reaction: null,
+        explanation: result.explanation,
+      });
+    } catch (err) {
+      console.error("Discovery generation failed:", err);
+      managedToast.error("Generation failed", {
+        description:
+          err instanceof Error ? err.message : "Something went wrong",
+      });
+    } finally {
+      generatingLockRef.current = false;
+    }
+  }, [isGenerating, startGeneration, addEntry, managedToast]);
+
+  // Auto-start first generation when a new session begins
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only trigger on new session
+  useEffect(() => {
+    if (isActive && history.length === 0) {
+      triggerGeneration();
+    }
+  }, [sessionId]);
+
+  // HUD auto-hide on mouse inactivity (desktop only)
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    // On mobile, always show HUD
+    if (isMobile) {
+      setShowHud(true);
+      return;
+    }
+
+    const handleMouseMove = () => {
+      setShowHud(true);
+      if (hudTimeoutRef.current) {
+        clearTimeout(hudTimeoutRef.current);
+      }
+      hudTimeoutRef.current = setTimeout(() => setShowHud(false), 2000);
+    };
+
+    handleMouseMove(); // show initially
+    document.addEventListener("mousemove", handleMouseMove);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      if (hudTimeoutRef.current) {
+        clearTimeout(hudTimeoutRef.current);
+      }
+    };
+  }, [isActive, isMobile]);
+
+  const navigate = useNavigate();
+
+  // Handle exit — pause session instead of archiving
+  const handleExit = useCallback(() => {
+    const { sessionId: sid } = stop();
+    syncPause(sid);
+    navigate(ROUTES.DISCOVER);
+  }, [stop, syncPause, navigate]);
+
+  // Like → sync + trigger next
+  const handleLike = useCallback(() => {
+    if (!currentEntry || currentEntry.status !== "succeeded") {
+      return;
+    }
+    reactLike();
+    flashReaction("liked");
+    syncReaction(
+      sessionId,
+      currentEntry.generationId,
+      currentEntry.prompt,
+      "liked"
+    );
+    triggerGeneration();
+  }, [
+    currentEntry,
+    reactLike,
+    flashReaction,
+    syncReaction,
+    sessionId,
+    triggerGeneration,
+  ]);
+
+  // Dislike → sync + trigger next
+  const handleDislike = useCallback(() => {
+    if (!currentEntry || currentEntry.status !== "succeeded") {
+      return;
+    }
+    reactDislike();
+    flashReaction("disliked");
+    syncReaction(
+      sessionId,
+      currentEntry.generationId,
+      currentEntry.prompt,
+      "disliked"
+    );
+    triggerGeneration();
+  }, [
+    currentEntry,
+    reactDislike,
+    flashReaction,
+    syncReaction,
+    sessionId,
+    triggerGeneration,
+  ]);
+
+  // Save → sync + flash
+  const handleSave = useCallback(() => {
+    if (!currentEntry || currentEntry.status !== "succeeded") {
+      return;
+    }
+    saveCurrentToCollection();
+    flashReaction("saved");
+    syncReaction(
+      sessionId,
+      currentEntry.generationId,
+      currentEntry.prompt,
+      "saved"
+    );
+  }, [
+    currentEntry,
+    saveCurrentToCollection,
+    flashReaction,
+    syncReaction,
+    sessionId,
+  ]);
+
+  // Remix → same subject, different style
+  const handleRemix = useCallback(() => {
+    if (!currentEntry || currentEntry.status !== "succeeded") {
+      return;
+    }
+    reactRemix();
+    syncReaction(
+      sessionId,
+      currentEntry.generationId,
+      currentEntry.prompt,
+      "liked"
+    );
+    triggerGeneration();
+  }, [currentEntry, reactRemix, syncReaction, sessionId, triggerGeneration]);
+
+  // Wilder → amplify what's working
+  const handleWilder = useCallback(() => {
+    if (!currentEntry || currentEntry.status !== "succeeded") {
+      return;
+    }
+    reactWilder();
+    syncReaction(
+      sessionId,
+      currentEntry.generationId,
+      currentEntry.prompt,
+      "liked"
+    );
+    triggerGeneration();
+  }, [currentEntry, reactWilder, syncReaction, sessionId, triggerGeneration]);
+
+  // Fresh → completely new direction
+  const handleFresh = useCallback(() => {
+    if (!currentEntry || currentEntry.status !== "succeeded") {
+      return;
+    }
+    reactFresh();
+    syncReaction(
+      sessionId,
+      currentEntry.generationId,
+      currentEntry.prompt,
+      "disliked"
+    );
+    triggerGeneration();
+  }, [currentEntry, reactFresh, syncReaction, sessionId, triggerGeneration]);
+
+  // Swipe gesture handlers
+  const handleDragEnd = useCallback(
+    (_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+      const threshold = 80;
+      const velocityThreshold = 300;
+      const shouldSwipeRight =
+        info.offset.x > threshold || info.velocity.x > velocityThreshold;
+      const shouldSwipeLeft =
+        info.offset.x < -threshold || info.velocity.x < -velocityThreshold;
+
+      if (shouldSwipeRight) {
+        setSwipeExit("right");
+        handleLike();
+      } else if (shouldSwipeLeft) {
+        setSwipeExit("left");
+        handleDislike();
+      }
+      // Below threshold — framer-motion springs back via dragConstraints
+    },
+    [handleLike, handleDislike]
+  );
+
+  // Keyboard handler
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowRight":
+          e.preventDefault();
+          handleLike();
+          break;
+        case "ArrowLeft":
+          e.preventDefault();
+          handleDislike();
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          browseUp();
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          browseDown();
+          break;
+        case " ":
+          e.preventDefault();
+          handleSave();
+          break;
+        case "r":
+        case "R":
+          e.preventDefault();
+          handleRemix();
+          break;
+        case "w":
+        case "W":
+          e.preventDefault();
+          handleWilder();
+          break;
+        case "f":
+        case "F":
+          e.preventDefault();
+          handleFresh();
+          break;
+        case "Escape":
+          e.preventDefault();
+          handleExit();
+          break;
+        default:
+          break;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () =>
+      document.removeEventListener("keydown", handleKeyDown, {
+        capture: true,
+      });
+  }, [
+    isActive,
+    handleLike,
+    handleDislike,
+    handleSave,
+    handleRemix,
+    handleWilder,
+    handleFresh,
+    browseUp,
+    browseDown,
+    handleExit,
+  ]);
+
+  if (!isActive) {
+    return null;
+  }
+
+  const imageReady =
+    currentEntry?.status === "succeeded" && !!currentEntry.imageUrl;
+
+  const historyCounter =
+    history.length > 0 ? `${currentIndex + 1}/${history.length}` : null;
+
+  return (
+    <DiscoveryLayout
+      immersive
+      showHeader={showHud}
+      isPanelCollapsed={!isPanelVisible}
+      onExpandPanel={togglePanel}
+    >
+      {/* Vertical stack: image on top, toolbar below */}
+      <div className="flex flex-1 flex-col items-center justify-center w-full overflow-hidden">
+        {/* Image area */}
+        <div className="relative flex flex-1 items-center justify-center w-full min-h-0 px-4 sm:px-8 py-4 sm:py-8">
+          {/* Unified crossfade between loading / failed / image states */}
+          <AnimatePresence mode="wait">
+            {/* Loading state — skeleton matching image aspect ratio */}
+            {(!currentEntry ||
+              currentEntry.status === "pending" ||
+              currentEntry.status === "generating") && (
+              <motion.div
+                key="loading"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.25 }}
+                className="skeleton-surface rounded-lg flex flex-col items-center justify-center gap-3 p-6 max-w-full"
+                style={{
+                  aspectRatio: (currentEntry?.aspectRatio ?? "1:1").replace(
+                    ":",
+                    "/"
+                  ),
+                  maxHeight: "calc(100dvh - 12rem)",
+                }}
+              >
+                <Spinner className="size-6 text-muted-foreground/60" />
+                {currentEntry?.prompt && (
+                  <p className="max-w-sm text-center text-xs text-muted-foreground/70 line-clamp-3">
+                    {currentEntry.prompt}
+                  </p>
+                )}
+              </motion.div>
+            )}
+
+            {/* Failed state */}
+            {currentEntry?.status === "failed" && (
+              <motion.div
+                key="failed"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.25 }}
+                className="flex flex-col items-center gap-3 text-muted-foreground"
+              >
+                <p className="text-sm">Generation failed</p>
+                <button
+                  type="button"
+                  className="text-xs underline hover:text-foreground"
+                  onClick={triggerGeneration}
+                >
+                  Try again
+                </button>
+              </motion.div>
+            )}
+
+            {/* Succeeded — show image */}
+            {imageReady && (
+              <motion.div
+                key={currentEntry.generationId}
+                className="relative max-h-[calc(100dvh-12rem)] max-w-full"
+                initial={{ opacity: 0, scale: 0.97 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={getSwipeExitAnimation(swipeExit)}
+                onAnimationComplete={() => {
+                  if (swipeExit) {
+                    setSwipeExit(null);
+                  }
+                }}
+                transition={{ duration: 0.3 }}
+                drag="x"
+                dragConstraints={{ left: 0, right: 0 }}
+                dragElastic={0.7}
+                onDragEnd={handleDragEnd}
+                style={{
+                  x: dragX,
+                  rotate: dragRotate,
+                  ...(isMobile ? { scale: dragScale } : {}),
+                }}
+                whileDrag={{ cursor: "grabbing" }}
+              >
+                {/* Swipe color overlays */}
+                <motion.div
+                  className="absolute inset-0 rounded-lg bg-green-500/40 pointer-events-none z-10"
+                  style={{ opacity: likeOverlayOpacity }}
+                />
+                <motion.div
+                  className="absolute inset-0 rounded-lg bg-red-500/40 pointer-events-none z-10"
+                  style={{ opacity: dislikeOverlayOpacity }}
+                />
+                <img
+                  src={currentEntry.imageUrl as string}
+                  alt={currentEntry.prompt}
+                  className="max-h-[calc(100dvh-12rem)] max-w-full object-contain rounded-lg shadow-xl shadow-black/25"
+                  draggable={false}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* Reaction burst animation */}
+          <AnimatePresence>
+            {reactionFlash && (
+              <motion.div
+                key={reactionFlash}
+                initial={{ opacity: 0.7, scale: 0.5 }}
+                animate={{ opacity: 0, scale: 1.5 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.5, ease: "easeOut" }}
+                className="absolute inset-0 flex items-center justify-center pointer-events-none z-20"
+              >
+                {reactionFlash === "liked" && (
+                  <HeartIcon className="size-24 text-green-500" weight="fill" />
+                )}
+                {reactionFlash === "disliked" && (
+                  <XIcon className="size-24 text-red-500" weight="bold" />
+                )}
+                {reactionFlash === "saved" && (
+                  <BookmarkSimpleIcon
+                    className="size-24 text-blue-500"
+                    weight="fill"
+                  />
+                )}
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* Reaction indicator on current entry */}
+          {currentEntry?.reaction === "liked" && (
+            <div className="absolute top-4 left-1/2 -translate-x-1/2 flex items-center gap-1.5 rounded-full bg-green-100 px-3 py-1.5 text-xs font-medium text-green-700 dark:bg-green-900 dark:text-green-200 animate-in fade-in-0 zoom-in-95 duration-200">
+              <HeartIcon className="size-3.5" weight="fill" />
+              Liked
+            </div>
+          )}
+          {currentEntry?.reaction === "disliked" && (
+            <div className="absolute top-4 left-1/2 -translate-x-1/2 flex items-center gap-1.5 rounded-full bg-red-100 px-3 py-1.5 text-xs font-medium text-red-700 dark:bg-red-900 dark:text-red-200 animate-in fade-in-0 zoom-in-95 duration-200">
+              <XIcon className="size-3.5" weight="bold" />
+              Nope
+            </div>
+          )}
+          {currentEntry?.reaction === "saved" && (
+            <div className="absolute top-4 left-1/2 -translate-x-1/2 flex items-center gap-1.5 rounded-full bg-blue-100 px-3 py-1.5 text-xs font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-200 animate-in fade-in-0 zoom-in-95 duration-200">
+              <BookmarkSimpleIcon className="size-3.5" weight="fill" />
+              Saved
+            </div>
+          )}
+        </div>
+
+        {/* Bottom toolbar */}
+        <div className="flex flex-col items-center gap-3 px-4 sm:px-6 py-3 sm:py-4 pb-safe">
+          {/* Prompt + explanation — only show when image is ready (loading state shows its own prompt) */}
+          <AnimatePresence mode="wait">
+            {imageReady && currentEntry?.prompt && (
+              <motion.div
+                key={currentEntry.prompt}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="flex flex-col items-center gap-1 max-w-2xl"
+              >
+                <p className="text-center text-xs text-muted-foreground">
+                  {currentEntry.prompt}
+                </p>
+                {currentEntry.explanation && (
+                  <button
+                    type="button"
+                    onClick={() => setShowExplanation(prev => !prev)}
+                    className="flex items-center gap-1 text-[10px] text-muted-foreground/50 hover:text-muted-foreground/80 transition-colors"
+                  >
+                    <InfoIcon className="size-3" />
+                    {showExplanation ? "Hide" : "Why this?"}
+                  </button>
+                )}
+                {showExplanation && currentEntry.explanation && (
+                  <p className="text-center text-[11px] italic text-muted-foreground/60 animate-in fade-in-0 slide-in-from-top-1 duration-200">
+                    {currentEntry.explanation}
+                  </p>
+                )}
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* Mobile toolbar */}
+          {isMobile ? (
+            <div className="flex flex-col items-center gap-2 w-full max-w-sm">
+              {/* Primary row: Nope / More */}
+              <div className="flex items-center gap-2 w-full">
+                <button
+                  type="button"
+                  onClick={handleDislike}
+                  disabled={!imageReady}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-full bg-muted px-4 py-3 text-sm font-medium text-muted-foreground transition-colors active:bg-accent disabled:opacity-30"
+                >
+                  <ArrowLeftIcon className="size-4" weight="bold" />
+                  Nope
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={!imageReady}
+                  className="flex items-center justify-center rounded-full bg-muted px-3 py-3 text-sm text-muted-foreground transition-colors active:bg-accent disabled:opacity-30"
+                >
+                  <BookmarkSimpleIcon className="size-4" weight="bold" />
+                </button>
+                <button
+                  type="button"
+                  onClick={handleLike}
+                  disabled={!imageReady}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-full bg-muted px-4 py-3 text-sm font-medium text-muted-foreground transition-colors active:bg-accent disabled:opacity-30"
+                >
+                  More
+                  <ArrowRightIcon className="size-4" weight="bold" />
+                </button>
+              </div>
+              {/* Secondary row: Remix / Wilder / Fresh */}
+              <div className="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={handleRemix}
+                  disabled={!imageReady}
+                  className="flex items-center gap-1 rounded-full bg-muted/60 px-3 py-1.5 text-xs text-muted-foreground transition-colors active:bg-accent disabled:opacity-30"
+                >
+                  <ShuffleIcon className="size-3.5" weight="bold" />
+                  Remix
+                </button>
+                <button
+                  type="button"
+                  onClick={handleWilder}
+                  disabled={!imageReady}
+                  className="flex items-center gap-1 rounded-full bg-muted/60 px-3 py-1.5 text-xs text-muted-foreground transition-colors active:bg-accent disabled:opacity-30"
+                >
+                  <FireIcon className="size-3.5" weight="bold" />
+                  Wilder
+                </button>
+                <button
+                  type="button"
+                  onClick={handleFresh}
+                  disabled={!imageReady}
+                  className="flex items-center gap-1 rounded-full bg-muted/60 px-3 py-1.5 text-xs text-muted-foreground transition-colors active:bg-accent disabled:opacity-30"
+                >
+                  <SparkleIcon className="size-3.5" weight="bold" />
+                  Fresh
+                </button>
+              </div>
+              {/* History nav row */}
+              <div className="flex items-center gap-2 text-xs text-muted-foreground/60">
+                <button
+                  type="button"
+                  onClick={browseUp}
+                  disabled={currentIndex <= 0}
+                  className="rounded p-1 transition-colors active:bg-accent disabled:opacity-30"
+                >
+                  <ArrowUpIcon className="size-3.5" />
+                </button>
+                {historyCounter && (
+                  <span className="tabular-nums">{historyCounter}</span>
+                )}
+                <button
+                  type="button"
+                  onClick={browseDown}
+                  disabled={currentIndex >= history.length - 1}
+                  className="rounded p-1 transition-colors active:bg-accent disabled:opacity-30"
+                >
+                  <ArrowDownIcon className="size-3.5" />
+                </button>
+              </div>
+            </div>
+          ) : (
+            /* Desktop toolbar */
+            <div className="flex items-center gap-1 rounded-full bg-muted px-2 py-1.5 text-xs text-muted-foreground">
+              <button
+                type="button"
+                onClick={handleDislike}
+                disabled={!imageReady}
+                className="flex items-center gap-1 rounded-full px-3 py-1 transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none"
+              >
+                <ArrowLeftIcon className="size-3.5" weight="bold" /> Nope
+              </button>
+              <span className="text-muted-foreground/30">·</span>
+              <button
+                type="button"
+                onClick={handleLike}
+                disabled={!imageReady}
+                className="flex items-center gap-1 rounded-full px-3 py-1 transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none"
+              >
+                More <ArrowRightIcon className="size-3.5" weight="bold" />
+              </button>
+              <span className="text-muted-foreground/30">·</span>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!imageReady}
+                className="flex items-center gap-1 rounded-full px-3 py-1 transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none"
+              >
+                <BookmarkSimpleIcon className="size-3.5" weight="bold" />
+                Save
+                <kbd className="ml-0.5 text-[10px] opacity-40">Space</kbd>
+              </button>
+              <span className="text-muted-foreground/30">·</span>
+              <button
+                type="button"
+                onClick={handleRemix}
+                disabled={!imageReady}
+                className="flex items-center gap-1 rounded-full px-3 py-1 transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none"
+              >
+                <ShuffleIcon className="size-3.5" weight="bold" />
+                Remix
+                <kbd className="ml-0.5 text-[10px] opacity-40">R</kbd>
+              </button>
+              <span className="text-muted-foreground/30">·</span>
+              <button
+                type="button"
+                onClick={handleWilder}
+                disabled={!imageReady}
+                className="flex items-center gap-1 rounded-full px-3 py-1 transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none"
+              >
+                <FireIcon className="size-3.5" weight="bold" />
+                Wilder
+                <kbd className="ml-0.5 text-[10px] opacity-40">W</kbd>
+              </button>
+              <span className="text-muted-foreground/30">·</span>
+              <button
+                type="button"
+                onClick={handleFresh}
+                disabled={!imageReady}
+                className="flex items-center gap-1 rounded-full px-3 py-1 transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none"
+              >
+                <SparkleIcon className="size-3.5" weight="bold" />
+                Fresh
+                <kbd className="ml-0.5 text-[10px] opacity-40">F</kbd>
+              </button>
+              <span className="text-muted-foreground/30">·</span>
+              <span className="flex items-center gap-1 px-2 py-1">
+                <ArrowUpIcon className="size-3" />
+                <ArrowDownIcon className="size-3" /> Browse
+                {historyCounter && (
+                  <span className="ml-1 tabular-nums text-muted-foreground/50">
+                    {historyCounter}
+                  </span>
+                )}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </DiscoveryLayout>
+  );
+}

--- a/src/components/canvas/discovery-mode.tsx
+++ b/src/components/canvas/discovery-mode.tsx
@@ -24,7 +24,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { DiscoveryLayout } from "@/components/canvas/discovery-layout";
 import { Spinner } from "@/components/ui/spinner";
-import { useDiscoverySessionSync } from "@/hooks/use-discovery-session-sync";
+import { useDiscoverySessionSync } from "@/hooks";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { ROUTES } from "@/lib/routes";
 import { useToast } from "@/providers/toast-context";
@@ -40,6 +40,18 @@ function getSwipeExitAnimation(dir: "left" | "right" | null) {
     return { x: -400, opacity: 0, rotate: -15 };
   }
   return { opacity: 0, scale: 0.97 };
+}
+
+function mapGenerationStatus(
+  dbStatus: string
+): "succeeded" | "failed" | "generating" {
+  if (dbStatus === "succeeded") {
+    return "succeeded";
+  }
+  if (dbStatus === "failed" || dbStatus === "canceled") {
+    return "failed";
+  }
+  return "generating";
 }
 
 export function DiscoveryMode() {
@@ -93,30 +105,34 @@ export function DiscoveryMode() {
     setShowExplanation(false);
   }, [currentIndex]);
 
+  // The latest entry may be generating while the user browses history.
+  // Subscribe to both the current entry AND the latest entry so status
+  // updates (and isGenerating) resolve even when the user is viewing older images.
+  const latestEntry = history[history.length - 1] ?? null;
+  const latestIsInFlight =
+    latestEntry &&
+    latestEntry !== currentEntry &&
+    (latestEntry.status === "pending" || latestEntry.status === "generating");
+
   // Subscribe to current generation status
   const generationData = useQuery(
     api.generations.getGeneration,
     currentEntry?.generationId ? { id: currentEntry.generationId } : "skip"
   );
 
-  // Update entry when generation data changes
+  // Subscribe to latest in-flight generation (when user browsed away)
+  const latestGenerationData = useQuery(
+    api.generations.getGeneration,
+    latestIsInFlight ? { id: latestEntry.generationId } : "skip"
+  );
+
+  // Update current entry when generation data changes
   useEffect(() => {
     if (!(generationData && currentEntry)) {
       return;
     }
 
-    let newStatus: "succeeded" | "failed" | "generating";
-    if (generationData.status === "succeeded") {
-      newStatus = "succeeded";
-    } else if (
-      generationData.status === "failed" ||
-      generationData.status === "canceled"
-    ) {
-      newStatus = "failed";
-    } else {
-      newStatus = "generating";
-    }
-
+    const newStatus = mapGenerationStatus(generationData.status);
     const newImageUrl = generationData.imageUrls?.[0] ?? null;
 
     if (
@@ -130,11 +146,45 @@ export function DiscoveryMode() {
     }
   }, [generationData, currentEntry, updateEntry]);
 
+  // Update latest in-flight entry when its generation data changes
+  useEffect(() => {
+    if (!(latestGenerationData && latestIsInFlight)) {
+      return;
+    }
+
+    const newStatus = mapGenerationStatus(latestGenerationData.status);
+    const newImageUrl = latestGenerationData.imageUrls?.[0] ?? null;
+
+    if (
+      newStatus !== latestEntry.status ||
+      newImageUrl !== latestEntry.imageUrl
+    ) {
+      updateEntry(latestEntry.generationId, {
+        status: newStatus,
+        imageUrl: newImageUrl,
+      });
+    }
+  }, [latestGenerationData, latestIsInFlight, latestEntry, updateEntry]);
+
   // Flash a reaction icon briefly
+  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const flashReaction = useCallback((type: ReactionFlash) => {
+    if (flashTimeoutRef.current) {
+      clearTimeout(flashTimeoutRef.current);
+    }
     setReactionFlash(type);
-    setTimeout(() => setReactionFlash(null), 500);
+    flashTimeoutRef.current = setTimeout(() => setReactionFlash(null), 500);
   }, []);
+
+  useEffect(
+    () => () => {
+      if (flashTimeoutRef.current) {
+        clearTimeout(flashTimeoutRef.current);
+      }
+    },
+    []
+  );
 
   // Trigger a new generation
   const triggerGeneration = useCallback(async () => {
@@ -168,6 +218,10 @@ export function DiscoveryMode() {
         reaction: null,
         explanation: result.explanation,
       });
+
+      if (result.addedModelName) {
+        managedToast.success(`Model added: ${result.addedModelName}`);
+      }
     } catch (err) {
       console.error("Discovery generation failed:", err);
       managedToast.error("Generation failed", {
@@ -344,9 +398,11 @@ export function DiscoveryMode() {
       const threshold = 80;
       const velocityThreshold = 300;
       const shouldSwipeRight =
-        info.offset.x > threshold || info.velocity.x > velocityThreshold;
+        info.offset.x > threshold ||
+        (info.offset.x > 0 && info.velocity.x > velocityThreshold);
       const shouldSwipeLeft =
-        info.offset.x < -threshold || info.velocity.x < -velocityThreshold;
+        info.offset.x < -threshold ||
+        (info.offset.x < 0 && info.velocity.x < -velocityThreshold);
 
       if (shouldSwipeRight) {
         setSwipeExit("right");

--- a/src/components/canvas/discovery-sidebar.tsx
+++ b/src/components/canvas/discovery-sidebar.tsx
@@ -38,13 +38,10 @@ export function DiscoverySidebar({ onResumeSession }: DiscoverySidebarProps) {
     string | null
   >(null);
 
-  const handleDeleteClick = useCallback(
-    (e: React.MouseEvent, sessionId: string) => {
-      e.stopPropagation();
-      setPendingDeleteSessionId(sessionId);
-    },
-    []
-  );
+  const handleDeleteClick = (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    setPendingDeleteSessionId(sessionId);
+  };
 
   const handleConfirmDelete = useCallback(() => {
     if (pendingDeleteSessionId) {

--- a/src/components/canvas/discovery-sidebar.tsx
+++ b/src/components/canvas/discovery-sidebar.tsx
@@ -1,0 +1,245 @@
+import { api } from "@convex/_generated/api";
+import type { Doc } from "@convex/_generated/dataModel";
+import {
+  ArrowLeftIcon,
+  BookmarkSimpleIcon,
+  ImagesIcon,
+  PauseIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
+import { useMutation, useQuery } from "convex/react";
+import { formatDistanceToNow } from "date-fns";
+import { useCallback, useState } from "react";
+import { Link } from "react-router-dom";
+import { PanelLeftIcon } from "@/components/animate-ui/icons/panel-left";
+import { SquarePenIcon } from "@/components/animate-ui/icons/square-pen";
+import { Button } from "@/components/ui/button";
+import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
+import {
+  SidebarShell,
+  SidebarShellContent,
+  SidebarShellHeader,
+} from "@/components/ui/sidebar-shell";
+import { ROUTES } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+import { useDiscoveryStore } from "@/stores/discovery-store";
+
+interface DiscoverySidebarProps {
+  onResumeSession: (sessionId: string) => void;
+}
+
+export function DiscoverySidebar({ onResumeSession }: DiscoverySidebarProps) {
+  const sessions = useQuery(api.discoverySessions.list, { limit: 50 });
+  const removeSession = useMutation(api.discoverySessions.remove);
+  const completeSession = useMutation(api.discoverySessions.complete);
+  const activeSessionId = useDiscoveryStore(s => s.sessionId);
+
+  const [pendingDeleteSessionId, setPendingDeleteSessionId] = useState<
+    string | null
+  >(null);
+
+  const handleDeleteClick = useCallback(
+    (e: React.MouseEvent, sessionId: string) => {
+      e.stopPropagation();
+      setPendingDeleteSessionId(sessionId);
+    },
+    []
+  );
+
+  const handleConfirmDelete = useCallback(() => {
+    if (pendingDeleteSessionId) {
+      removeSession({ sessionId: pendingDeleteSessionId });
+      setPendingDeleteSessionId(null);
+    }
+  }, [pendingDeleteSessionId, removeSession]);
+
+  const handleComplete = useCallback(
+    (e: React.MouseEvent, sessionId: string) => {
+      e.stopPropagation();
+      completeSession({ sessionId });
+    },
+    [completeSession]
+  );
+
+  return (
+    <div className="px-2 stack-xs">
+      {sessions === undefined && (
+        <div className="px-2 py-8 text-center text-xs text-muted-foreground/50">
+          Loading...
+        </div>
+      )}
+      {sessions?.length === 0 && (
+        <div className="px-2 py-8 text-center text-xs text-muted-foreground/50">
+          No sessions yet
+        </div>
+      )}
+      {sessions?.map(session => (
+        <SessionItem
+          key={session._id}
+          session={session}
+          isActive={session.sessionId === activeSessionId}
+          onResume={() => onResumeSession(session.sessionId)}
+          onDelete={e => handleDeleteClick(e, session.sessionId)}
+          onComplete={e => handleComplete(e, session.sessionId)}
+        />
+      ))}
+
+      <ConfirmationDialog
+        open={pendingDeleteSessionId !== null}
+        onOpenChange={open => {
+          if (!open) {
+            setPendingDeleteSessionId(null);
+          }
+        }}
+        title="Delete session"
+        description="This will permanently delete this discovery session and all its history. This action cannot be undone."
+        confirmText="Delete"
+        variant="destructive"
+        onConfirm={handleConfirmDelete}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DiscoveryPanelSidebar — full sidebar shell, reused across entry form & session
+// ---------------------------------------------------------------------------
+
+interface DiscoveryPanelSidebarProps {
+  onResumeSession: (sessionId: string) => void;
+}
+
+export function DiscoveryPanelSidebar({
+  onResumeSession,
+}: DiscoveryPanelSidebarProps) {
+  const isPanelVisible = useDiscoveryStore(s => s.isPanelVisible);
+  const panelWidth = useDiscoveryStore(s => s.panelWidth);
+  const togglePanel = useDiscoveryStore(s => s.togglePanel);
+  const setPanelWidth = useDiscoveryStore(s => s.setPanelWidth);
+  const setIsResizing = useDiscoveryStore(s => s.setIsResizing);
+  const resetPanelWidth = useDiscoveryStore(s => s.resetPanelWidth);
+
+  return (
+    <SidebarShell
+      width={panelWidth}
+      resizable
+      onWidthChange={setPanelWidth}
+      onResizeStart={() => setIsResizing(true)}
+      onResizeEnd={() => setIsResizing(false)}
+      onDoubleClickHandle={resetPanelWidth}
+      collapsed={!isPanelVisible}
+      onExpand={togglePanel}
+      side="left"
+    >
+      <SidebarShellHeader>
+        <Link to={ROUTES.CANVAS} viewTransition>
+          <Button size="icon-sm" title="Back to canvas" variant="ghost">
+            <ArrowLeftIcon className="size-4.5" />
+          </Button>
+        </Link>
+        <Link to={ROUTES.DISCOVER}>
+          <Button size="icon-sm" title="New session" variant="ghost">
+            <SquarePenIcon animateOnHover className="size-4.5" />
+          </Button>
+        </Link>
+        <Button
+          size="icon-sm"
+          title="Collapse panel"
+          variant="ghost"
+          onClick={togglePanel}
+        >
+          <PanelLeftIcon animateOnHover className="size-4.5" />
+        </Button>
+      </SidebarShellHeader>
+      <SidebarShellContent>
+        <DiscoverySidebar onResumeSession={onResumeSession} />
+      </SidebarShellContent>
+    </SidebarShell>
+  );
+}
+
+function SessionItem({
+  session,
+  isActive,
+  onResume,
+  onDelete,
+  onComplete,
+}: {
+  session: Doc<"discoverySessions">;
+  isActive: boolean;
+  onResume: () => void;
+  onDelete: (e: React.MouseEvent) => void;
+  onComplete: (e: React.MouseEvent) => void;
+}) {
+  const savedCount = session.reactions.filter(
+    r => r.reaction === "saved"
+  ).length;
+
+  const label = session.seedPrompt || "Random exploration";
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "group w-full rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted/50",
+        isActive && "bg-muted/70"
+      )}
+      onClick={onResume}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm text-foreground/90">{label}</p>
+          <div className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground/60">
+            <span className="flex items-center gap-0.5">
+              <ImagesIcon className="size-3" />
+              {session.generationCount}
+            </span>
+            {savedCount > 0 && (
+              <span className="flex items-center gap-0.5">
+                <BookmarkSimpleIcon className="size-3" />
+                {savedCount}
+              </span>
+            )}
+            <span>
+              {formatDistanceToNow(session.updatedAt, { addSuffix: true })}
+            </span>
+          </div>
+        </div>
+
+        {/* Status badge */}
+        {session.status === "active" && (
+          <span className="mt-0.5 shrink-0 rounded-full bg-green-500/15 px-1.5 py-0.5 text-[10px] text-green-500">
+            Active
+          </span>
+        )}
+        {session.status === "paused" && (
+          <span className="mt-0.5 shrink-0 rounded-full bg-yellow-500/15 px-1.5 py-0.5 text-[10px] text-yellow-500">
+            Paused
+          </span>
+        )}
+      </div>
+
+      {/* Action buttons — show on hover, always visible on mobile */}
+      <div className="mt-1.5 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 max-sm:opacity-100">
+        {session.status !== "completed" && (
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+            onClick={onComplete}
+          >
+            <PauseIcon className="size-3" />
+            End
+          </button>
+        )}
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground/60 transition-colors hover:bg-red-500/10 hover:text-red-500"
+          onClick={onDelete}
+        >
+          <TrashIcon className="size-3" />
+          Delete
+        </button>
+      </div>
+    </button>
+  );
+}

--- a/src/components/layouts/discovery-route-layout.tsx
+++ b/src/components/layouts/discovery-route-layout.tsx
@@ -8,8 +8,7 @@ import {
   DiscoverySidebar,
 } from "@/components/canvas/discovery-sidebar";
 import { Button } from "@/components/ui/button";
-import { useDiscoverySessionSync } from "@/hooks/use-discovery-session-sync";
-import { useMediaQuery } from "@/hooks/use-media-query";
+import { useDiscoverySessionSync, useMediaQuery } from "@/hooks";
 import { ROUTES } from "@/lib/routes";
 import { useDiscoveryStore } from "@/stores/discovery-store";
 

--- a/src/components/layouts/discovery-route-layout.tsx
+++ b/src/components/layouts/discovery-route-layout.tsx
@@ -1,0 +1,110 @@
+import { ArrowLeftIcon, XIcon } from "@phosphor-icons/react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useCallback } from "react";
+import { Link, Outlet, useNavigate } from "react-router-dom";
+import { SquarePenIcon } from "@/components/animate-ui/icons/square-pen";
+import {
+  DiscoveryPanelSidebar,
+  DiscoverySidebar,
+} from "@/components/canvas/discovery-sidebar";
+import { Button } from "@/components/ui/button";
+import { useDiscoverySessionSync } from "@/hooks/use-discovery-session-sync";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { ROUTES } from "@/lib/routes";
+import { useDiscoveryStore } from "@/stores/discovery-store";
+
+/**
+ * Wraps all /discover routes so the sidebar stays mounted across navigations
+ * (entry form ↔ session).
+ */
+export default function DiscoveryRouteLayout() {
+  const navigate = useNavigate();
+  const { syncPause } = useDiscoverySessionSync();
+  const isMobile = useMediaQuery("(max-width: 640px)");
+  const isPanelVisible = useDiscoveryStore(s => s.isPanelVisible);
+  const togglePanel = useDiscoveryStore(s => s.togglePanel);
+
+  const handleResumeSession = useCallback(
+    (sessionId: string) => {
+      const state = useDiscoveryStore.getState();
+      if (state.isActive && sessionId !== state.sessionId) {
+        syncPause(state.sessionId);
+      }
+      // Close panel on mobile after selecting
+      if (isMobile && isPanelVisible) {
+        togglePanel();
+      }
+      navigate(ROUTES.DISCOVER_SESSION(sessionId));
+    },
+    [syncPause, navigate, isMobile, isPanelVisible, togglePanel]
+  );
+
+  return (
+    <div className="flex h-[100dvh] bg-background">
+      {/* Desktop: normal resizable sidebar */}
+      {!isMobile && (
+        <DiscoveryPanelSidebar onResumeSession={handleResumeSession} />
+      )}
+
+      {/* Mobile: overlay sidebar */}
+      {isMobile && (
+        <AnimatePresence>
+          {isPanelVisible && (
+            <>
+              {/* Backdrop */}
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="fixed inset-0 z-sidebar bg-black/40"
+                onClick={togglePanel}
+              />
+              {/* Panel */}
+              <motion.div
+                initial={{ x: "-100%" }}
+                animate={{ x: 0 }}
+                exit={{ x: "-100%" }}
+                transition={{ type: "spring", damping: 25, stiffness: 300 }}
+                className="fixed inset-y-0 left-0 z-modal w-72 bg-sidebar border-r border-border/40 flex flex-col"
+              >
+                {/* Header */}
+                <div className="flex items-center justify-between px-3 py-3">
+                  <div className="flex items-center gap-1">
+                    <Link to={ROUTES.CANVAS} viewTransition>
+                      <Button
+                        size="icon-sm"
+                        title="Back to canvas"
+                        variant="ghost"
+                      >
+                        <ArrowLeftIcon className="size-4.5" />
+                      </Button>
+                    </Link>
+                    <Link to={ROUTES.DISCOVER}>
+                      <Button
+                        size="icon-sm"
+                        title="New session"
+                        variant="ghost"
+                        onClick={togglePanel}
+                      >
+                        <SquarePenIcon animateOnHover className="size-4.5" />
+                      </Button>
+                    </Link>
+                  </div>
+                  <Button variant="ghost" size="icon-sm" onClick={togglePanel}>
+                    <XIcon className="size-4" />
+                  </Button>
+                </div>
+                {/* Session list */}
+                <div className="flex-1 overflow-y-auto">
+                  <DiscoverySidebar onResumeSession={handleResumeSession} />
+                </div>
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
+      )}
+
+      <Outlet />
+    </div>
+  );
+}

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -1,4 +1,5 @@
 import { api } from "@convex/_generated/api";
+import { CompassIcon } from "@phosphor-icons/react";
 import { useQuery } from "convex/react";
 import {
   AnimatePresence,
@@ -471,6 +472,17 @@ export const Sidebar = ({ forceHidden = false }: { forceHidden?: boolean }) => {
                       </Button>
                     </Link>
                   )}
+
+                  <Link to={ROUTES.DISCOVER} viewTransition>
+                    <Button
+                      size="icon-sm"
+                      title="Discover"
+                      variant="ghost"
+                      className="text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover h-8 w-8"
+                    >
+                      <CompassIcon className="size-4.5" />
+                    </Button>
+                  </Link>
 
                   <Link to={ROUTES.CANVAS} viewTransition>
                     <Button

--- a/src/components/ui/sidebar-shell.tsx
+++ b/src/components/ui/sidebar-shell.tsx
@@ -1,0 +1,267 @@
+import { useCallback, useRef } from "react";
+import { Link } from "react-router-dom";
+import { ROUTES } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+
+function noop() {
+  // intentionally empty
+}
+
+// ---------------------------------------------------------------------------
+// PollyBrand — extracted logo used across all sidebars
+// ---------------------------------------------------------------------------
+
+const pollyLogoStyle: React.CSSProperties = {
+  maskImage: "url('/favicon.svg')",
+  maskSize: "contain",
+  maskRepeat: "no-repeat",
+  maskPosition: "center",
+  WebkitMaskImage: "url('/favicon.svg')",
+  WebkitMaskSize: "contain",
+  WebkitMaskRepeat: "no-repeat",
+  WebkitMaskPosition: "center",
+};
+
+export function PollyBrand({ className }: { className?: string }) {
+  return (
+    <Link
+      className={cn(
+        "group flex items-center gap-2 text-sidebar-foreground/90 hover:text-sidebar-foreground transition-colors",
+        className
+      )}
+      to={ROUTES.HOME}
+      viewTransition
+    >
+      <div
+        className="polly-logo-gradient-unified flex-shrink-0 w-6 h-6"
+        style={pollyLogoStyle}
+      />
+      <span className="font-semibold text-sm tracking-tight">Polly</span>
+    </Link>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// useResizeDrag — shared drag-to-resize logic
+// ---------------------------------------------------------------------------
+
+interface UseResizeDragOptions {
+  width: number;
+  onWidthChange: (width: number) => void;
+  onResizeStart?: () => void;
+  onResizeEnd?: () => void;
+  /** Which side the handle sits on — determines drag direction */
+  side?: "left" | "right";
+}
+
+export function useResizeDrag({
+  width,
+  onWidthChange,
+  onResizeStart,
+  onResizeEnd,
+  side = "left",
+}: UseResizeDragOptions) {
+  const widthRef = useRef(width);
+  widthRef.current = width;
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      onResizeStart?.();
+
+      const startX = e.clientX;
+      const startWidth = widthRef.current;
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        const deltaX = moveEvent.clientX - startX;
+        const newWidth =
+          side === "left" ? startWidth + deltaX : startWidth - deltaX;
+        onWidthChange(newWidth);
+      };
+
+      const handleMouseUp = () => {
+        onResizeEnd?.();
+        document.documentElement.classList.remove("select-none");
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.documentElement.classList.add("select-none");
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [onWidthChange, onResizeStart, onResizeEnd, side]
+  );
+
+  return handleMouseDown;
+}
+
+// ---------------------------------------------------------------------------
+// SidebarShell — Root aside container
+// ---------------------------------------------------------------------------
+
+interface SidebarShellProps {
+  width: number;
+  resizable?: boolean;
+  onWidthChange?: (width: number) => void;
+  onResizeStart?: () => void;
+  onResizeEnd?: () => void;
+  onDoubleClickHandle?: () => void;
+  collapsed?: boolean;
+  onExpand?: () => void;
+  side?: "left" | "right";
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function SidebarShell({
+  width,
+  resizable = false,
+  onWidthChange,
+  onResizeStart,
+  onResizeEnd,
+  onDoubleClickHandle,
+  collapsed = false,
+  onExpand,
+  side = "left",
+  className,
+  children,
+}: SidebarShellProps) {
+  const handleMouseDown = useResizeDrag({
+    width,
+    onWidthChange: onWidthChange ?? noop,
+    onResizeStart,
+    onResizeEnd,
+    side,
+  });
+
+  const borderClass = side === "left" ? "border-r" : "border-l";
+
+  return (
+    <>
+      {/* Expand zone when collapsed */}
+      {collapsed && onExpand && (
+        <button
+          type="button"
+          aria-label="Expand panel"
+          className={cn(
+            "fixed inset-y-0 z-sidebar w-5 cursor-e-resize bg-transparent transition-colors duration-200 hover:bg-muted/40",
+            side === "left" ? "left-0" : "right-0"
+          )}
+          onClick={onExpand}
+        />
+      )}
+
+      <aside
+        className={cn(
+          "relative flex flex-col shrink-0 bg-sidebar dark:bg-sidebar text-sidebar-foreground",
+          borderClass,
+          "border-border/40 transition-[width] duration-300 ease-out overflow-hidden",
+          className
+        )}
+        style={{ width: collapsed ? 0 : width }}
+      >
+        {children}
+
+        {/* Resize handle */}
+        {resizable && onWidthChange && !collapsed && (
+          <div
+            className={cn(
+              "absolute top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/10 active:bg-primary/20 transition-colors z-10 group",
+              side === "left" ? "right-0" : "left-0"
+            )}
+            onMouseDown={handleMouseDown}
+            onDoubleClick={onDoubleClickHandle}
+          >
+            <div
+              className={cn(
+                "absolute top-0 bottom-0 w-[1px] bg-transparent group-hover:bg-border/50 transition-colors",
+                side === "left" ? "right-0" : "left-0"
+              )}
+            />
+          </div>
+        )}
+      </aside>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SidebarShellHeader — Top section with optional PollyBrand
+// ---------------------------------------------------------------------------
+
+interface SidebarShellHeaderProps {
+  children?: React.ReactNode;
+  showLogo?: boolean;
+  className?: string;
+}
+
+export function SidebarShellHeader({
+  children,
+  showLogo = true,
+  className,
+}: SidebarShellHeaderProps) {
+  return (
+    <div className={cn("shrink-0 py-4 px-3", className)}>
+      <div
+        className={cn(
+          "flex items-center pl-2 pr-2",
+          showLogo ? "justify-between" : "gap-2"
+        )}
+      >
+        {showLogo && (
+          <div className="flex items-center gap-2">
+            <PollyBrand />
+          </div>
+        )}
+        {children && (
+          <div
+            className={cn("flex items-center", showLogo ? "gap-1" : "gap-2")}
+          >
+            {children}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SidebarShellContent — Scrollable middle section
+// ---------------------------------------------------------------------------
+
+interface SidebarShellContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SidebarShellContent({
+  children,
+  className,
+}: SidebarShellContentProps) {
+  return (
+    <div className={cn("flex-1 overflow-y-auto min-h-0", className)}>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SidebarShellFooter — Bottom pinned section
+// ---------------------------------------------------------------------------
+
+interface SidebarShellFooterProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SidebarShellFooter({
+  children,
+  className,
+}: SidebarShellFooterProps) {
+  return (
+    <div className={cn("shrink-0 border-t border-border/50", className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -134,4 +134,5 @@ export { useWordBasedUndo } from "./use-word-based-undo";
 
 export { useBackgroundJobs } from "./use-background-jobs";
 export { useBulkActions } from "./use-bulk-actions";
+export { useDiscoverySessionSync } from "./use-discovery-session-sync";
 export { useMessageSentCount } from "./use-message-sent-count";

--- a/src/hooks/use-discovery-session-sync.ts
+++ b/src/hooks/use-discovery-session-sync.ts
@@ -1,0 +1,59 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useMutation } from "convex/react";
+import { useCallback } from "react";
+import { useDiscoveryStore } from "@/stores/discovery-store";
+
+/**
+ * Bridge between Zustand discovery store and Convex DB.
+ * Provides fire-and-forget methods for persisting session state.
+ */
+export function useDiscoverySessionSync() {
+  const createSession = useMutation(api.discoverySessions.create);
+  const recordReaction = useMutation(api.discoverySessions.recordReaction);
+  const pauseSession = useMutation(api.discoverySessions.pause);
+
+  const persistNewSession = useCallback(
+    async (opts: {
+      sessionId: string;
+      modelId: string;
+      aspectRatio: string;
+      seedPrompt?: string;
+      seedImageStorageId?: Id<"_storage">;
+      personaId?: Id<"personas">;
+    }) => {
+      const dbId = await createSession({
+        sessionId: opts.sessionId,
+        modelId: opts.modelId,
+        aspectRatio: opts.aspectRatio,
+        seedPrompt: opts.seedPrompt,
+        seedImageStorageId: opts.seedImageStorageId,
+        personaId: opts.personaId,
+      });
+      useDiscoveryStore.setState({ dbSessionId: dbId });
+      return dbId;
+    },
+    [createSession]
+  );
+
+  const syncReaction = useCallback(
+    (
+      sessionId: string,
+      generationId: Id<"generations">,
+      prompt: string,
+      reaction: "liked" | "disliked" | "saved"
+    ) => {
+      recordReaction({ sessionId, generationId, prompt, reaction });
+    },
+    [recordReaction]
+  );
+
+  const syncPause = useCallback(
+    (sessionId: string) => {
+      pauseSession({ sessionId });
+    },
+    [pauseSession]
+  );
+
+  return { persistNewSession, syncReaction, syncPause };
+}

--- a/src/hooks/use-discovery-session-sync.ts
+++ b/src/hooks/use-discovery-session-sync.ts
@@ -16,8 +16,8 @@ export function useDiscoverySessionSync() {
   const persistNewSession = useCallback(
     async (opts: {
       sessionId: string;
-      modelId: string;
-      aspectRatio: string;
+      modelId?: string;
+      aspectRatio?: string;
       seedPrompt?: string;
       seedImageStorageId?: Id<"_storage">;
       personaId?: Id<"personas">;

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -28,6 +28,8 @@ export const CACHE_KEYS = {
   canvasSelections: "canvas-selections",
   canvasPanelVisible: "canvas-panel-visible",
   canvasLastEditModel: "canvas-last-edit-model",
+  discoveryPanelWidth: "discovery-panel-width",
+  discoveryPanelVisible: "discovery-panel-visible",
 } as const;
 
 export type CacheKey = (typeof CACHE_KEYS)[keyof typeof CACHE_KEYS];

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -21,6 +21,8 @@ export const ROUTES = {
   },
   CANVAS: "/canvas",
   CANVAS_IMAGE: (generationId: string) => `/canvas/image/${generationId}`,
+  DISCOVER: "/discover",
+  DISCOVER_SESSION: (sessionId: string) => `/discover/${sessionId}`,
   FAVORITES: "/chat/favorites",
   NOT_FOUND: "/404",
 } as const;

--- a/src/pages/canvas-page.tsx
+++ b/src/pages/canvas-page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon } from "@phosphor-icons/react";
+import { ArrowLeftIcon, CompassIcon } from "@phosphor-icons/react";
 import { useCallback, useRef } from "react";
 import { Link, Outlet } from "react-router-dom";
 import { PanelLeftIcon } from "@/components/animate-ui/icons/panel-left";
@@ -185,6 +185,19 @@ export default function CanvasPage() {
                   {opt.label}
                 </button>
               ))}
+            </div>
+
+            <div className="ml-auto">
+              <Link to={ROUTES.DISCOVER}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="gap-1.5 text-muted-foreground hover:text-foreground"
+                >
+                  <CompassIcon className="size-4" />
+                  Discover
+                </Button>
+              </Link>
             </div>
           </header>
 

--- a/src/pages/discovery-page.tsx
+++ b/src/pages/discovery-page.tsx
@@ -16,8 +16,8 @@ import { FileUploadButton } from "@/components/chat/input/file-upload-button";
 import { PersonaPicker } from "@/components/chat/input/pickers/persona-picker";
 import { AttachmentStrip } from "@/components/chat/message/attachment-strip";
 import { Button } from "@/components/ui/button";
+import { useDiscoverySessionSync } from "@/hooks";
 import { useChatScopedState } from "@/hooks/use-chat-scoped-state";
-import { useDiscoverySessionSync } from "@/hooks/use-discovery-session-sync";
 import { ROUTES } from "@/lib/routes";
 import { useDiscoveryStore } from "@/stores/discovery-store";
 
@@ -74,8 +74,6 @@ export default function DiscoveryPage() {
     const state = useDiscoveryStore.getState();
     persistNewSession({
       sessionId: state.sessionId,
-      modelId: "",
-      aspectRatio: "1:1",
       seedPrompt: seedPrompt.trim() || undefined,
       seedImageStorageId: seedImageStorageId ?? undefined,
       personaId: personaId ?? undefined,

--- a/src/pages/discovery-page.tsx
+++ b/src/pages/discovery-page.tsx
@@ -1,0 +1,239 @@
+import type { Id } from "@convex/_generated/dataModel";
+import {
+  ArrowDownIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ArrowUpIcon,
+  CompassIcon,
+  PlayIcon,
+} from "@phosphor-icons/react";
+import { motion } from "framer-motion";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { DiscoveryLayout } from "@/components/canvas/discovery-layout";
+import { FileLibraryButton } from "@/components/chat/input/file-library-button";
+import { FileUploadButton } from "@/components/chat/input/file-upload-button";
+import { PersonaPicker } from "@/components/chat/input/pickers/persona-picker";
+import { AttachmentStrip } from "@/components/chat/message/attachment-strip";
+import { Button } from "@/components/ui/button";
+import { useChatScopedState } from "@/hooks/use-chat-scoped-state";
+import { useDiscoverySessionSync } from "@/hooks/use-discovery-session-sync";
+import { ROUTES } from "@/lib/routes";
+import { useDiscoveryStore } from "@/stores/discovery-store";
+
+export default function DiscoveryPage() {
+  const [seedPrompt, setSeedPrompt] = useState("");
+  const [personaId, setPersonaId] = useState<Id<"personas"> | null>(null);
+  const [seedImageStorageId, setSeedImageStorageId] =
+    useState<Id<"_storage"> | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const navigate = useNavigate();
+
+  const startDiscovery = useDiscoveryStore(s => s.start);
+  const isPanelVisible = useDiscoveryStore(s => s.isPanelVisible);
+  const togglePanel = useDiscoveryStore(s => s.togglePanel);
+  const { persistNewSession, syncPause } = useDiscoverySessionSync();
+
+  // If we land on the entry form while a session is active (e.g. "New" button),
+  // pause and stop the current session
+  useEffect(() => {
+    const state = useDiscoveryStore.getState();
+    if (state.isActive) {
+      const { sessionId } = state.stop();
+      syncPause(sessionId);
+    }
+  }, [syncPause]);
+
+  // Read attachments from the shared chat scoped state (file upload/library buttons write here)
+  const { attachments, setAttachmentsForKey } = useChatScopedState();
+
+  // Sync first image attachment storageId to local state for discovery
+  useEffect(() => {
+    const imageAttachment = attachments.find(
+      a => a.storageId && a.mimeType?.startsWith("image/")
+    );
+    setSeedImageStorageId(
+      (imageAttachment?.storageId as Id<"_storage">) ?? null
+    );
+  }, [attachments]);
+
+  const handleRemoveAttachment = useCallback(
+    (index: number) => {
+      setAttachmentsForKey(prev => prev.filter((_, i) => i !== index));
+    },
+    [setAttachmentsForKey]
+  );
+
+  const handleStart = useCallback(() => {
+    startDiscovery({
+      personaId: personaId ?? undefined,
+      seedPrompt: seedPrompt.trim() || undefined,
+      seedImageStorageId: seedImageStorageId ?? undefined,
+    });
+    // Persist new session to DB
+    const state = useDiscoveryStore.getState();
+    persistNewSession({
+      sessionId: state.sessionId,
+      modelId: "",
+      aspectRatio: "1:1",
+      seedPrompt: seedPrompt.trim() || undefined,
+      seedImageStorageId: seedImageStorageId ?? undefined,
+      personaId: personaId ?? undefined,
+    });
+    // Clean up shared state
+    setAttachmentsForKey([]);
+    // Navigate to session route
+    navigate(ROUTES.DISCOVER_SESSION(state.sessionId));
+  }, [
+    personaId,
+    seedPrompt,
+    seedImageStorageId,
+    startDiscovery,
+    persistNewSession,
+    setAttachmentsForKey,
+    navigate,
+  ]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleStart();
+      }
+    },
+    [handleStart]
+  );
+
+  const hintItems = [
+    {
+      icon: <ArrowRightIcon className="size-3" />,
+      label: "Like",
+    },
+    {
+      icon: <ArrowLeftIcon className="size-3" />,
+      label: "Nope",
+    },
+    {
+      icon: <span className="text-[10px] font-medium leading-none">Space</span>,
+      label: "Save",
+    },
+    {
+      icon: (
+        <span className="flex items-center gap-0.5">
+          <ArrowUpIcon className="size-3" />
+          <ArrowDownIcon className="size-3" />
+        </span>
+      ),
+      label: "Browse",
+    },
+    {
+      icon: <span className="text-[10px] font-medium leading-none">Esc</span>,
+      label: "Exit",
+    },
+  ];
+
+  return (
+    <DiscoveryLayout
+      isPanelCollapsed={!isPanelVisible}
+      onExpandPanel={togglePanel}
+    >
+      {/* Center content */}
+      <div className="flex flex-1 flex-col items-center justify-center px-4 pb-16 sm:pb-32">
+        <div className="w-full max-w-xl stack-lg">
+          {/* Title */}
+          <div className="stack-xs text-center">
+            <div className="flex items-center justify-center gap-2 text-foreground/80">
+              <CompassIcon className="size-5" weight="duotone" />
+              <h1 className="text-lg font-medium tracking-tight">Discover</h1>
+            </div>
+            <p className="text-xs text-muted-foreground/60">
+              Keyboard-driven image exploration. Like or dislike to steer the
+              aesthetic.
+            </p>
+          </div>
+
+          {/* Input area — chat-input style */}
+          <div className="chat-input-container">
+            {/* Attachment thumbnails */}
+            <AttachmentStrip
+              attachments={attachments}
+              onRemove={handleRemoveAttachment}
+              className="mt-0 flex-nowrap overflow-x-auto px-4 pt-3 pb-0"
+            />
+
+            {/* Textarea */}
+            <textarea
+              ref={textareaRef}
+              placeholder="Describe a mood, subject, or style..."
+              value={seedPrompt}
+              onChange={e => setSeedPrompt(e.target.value)}
+              onKeyDown={handleKeyDown}
+              rows={2}
+              className="w-full resize-none bg-transparent px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none"
+            />
+
+            {/* Bottom bar */}
+            <div className="flex items-center justify-between px-2 pb-2">
+              <div className="flex items-center gap-1">
+                <PersonaPicker
+                  compact
+                  selectedPersonaId={personaId}
+                  onPersonaSelect={setPersonaId}
+                />
+              </div>
+
+              <div className="flex items-center gap-0.5 sm:gap-2">
+                <FileUploadButton
+                  disabled={false}
+                  isSubmitting={false}
+                  selectedModel={{ supportsImages: true }}
+                />
+                <FileLibraryButton
+                  disabled={false}
+                  isSubmitting={false}
+                  selectedModel={{ supportsImages: true }}
+                />
+                <Button
+                  size="sm"
+                  className="gap-1.5 rounded-full px-4"
+                  onClick={handleStart}
+                  disabled={false}
+                >
+                  <PlayIcon className="size-3.5" weight="fill" />
+                  Start
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {/* Keyboard shortcuts — hidden on mobile, staggered animation */}
+          <motion.div
+            className="hidden sm:flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-[11px] text-muted-foreground/40"
+            initial="hidden"
+            animate="visible"
+            variants={{
+              hidden: {},
+              visible: { transition: { staggerChildren: 0.05 } },
+            }}
+          >
+            {hintItems.map(item => (
+              <motion.span
+                key={item.label}
+                className="flex items-center gap-1.5"
+                variants={{
+                  hidden: { opacity: 0, y: 4 },
+                  visible: { opacity: 1, y: 0 },
+                }}
+              >
+                <span className="flex items-center justify-center rounded border border-muted-foreground/15 bg-muted/30 px-1.5 py-0.5 text-muted-foreground/50">
+                  {item.icon}
+                </span>
+                <span>{item.label}</span>
+              </motion.span>
+            ))}
+          </motion.div>
+        </div>
+      </div>
+    </DiscoveryLayout>
+  );
+}

--- a/src/pages/discovery-session-page.tsx
+++ b/src/pages/discovery-session-page.tsx
@@ -29,9 +29,9 @@ export default function DiscoverySessionPage() {
     resumeDiscovery({
       sessionId: session.sessionId,
       dbSessionId: session._id,
-      modelId: session.modelId,
+      modelId: session.modelId ?? "",
       personaId: session.personaId ?? undefined,
-      aspectRatio: session.aspectRatio,
+      aspectRatio: session.aspectRatio ?? "1:1",
       seedPrompt: session.seedPrompt ?? undefined,
       seedImageStorageId: session.seedImageStorageId ?? undefined,
       history: entries,
@@ -41,6 +41,11 @@ export default function DiscoverySessionPage() {
   }, [sessionData, needsHydration, resumeDiscovery]);
 
   if (!sessionId) {
+    return <Navigate to={ROUTES.DISCOVER} replace />;
+  }
+
+  // sessionData === undefined → still loading; null → not found / unauthorized
+  if (needsHydration && sessionData === null) {
     return <Navigate to={ROUTES.DISCOVER} replace />;
   }
 

--- a/src/pages/discovery-session-page.tsx
+++ b/src/pages/discovery-session-page.tsx
@@ -1,0 +1,56 @@
+import { api } from "@convex/_generated/api";
+import { useQuery } from "convex/react";
+import { useEffect } from "react";
+import { Navigate, useParams } from "react-router-dom";
+import { DiscoveryMode } from "@/components/canvas/discovery-mode";
+import { Spinner } from "@/components/ui/spinner";
+import { ROUTES } from "@/lib/routes";
+import { useDiscoveryStore } from "@/stores/discovery-store";
+
+export default function DiscoverySessionPage() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const storeSessionId = useDiscoveryStore(s => s.sessionId);
+  const isActive = useDiscoveryStore(s => s.isActive);
+  const resumeDiscovery = useDiscoveryStore(s => s.resume);
+
+  const needsHydration = !isActive || storeSessionId !== sessionId;
+
+  const sessionData = useQuery(
+    api.discoverySessions.getWithHistory,
+    needsHydration && sessionId ? { sessionId } : "skip"
+  );
+
+  useEffect(() => {
+    if (!(sessionData && needsHydration)) {
+      return;
+    }
+
+    const { session, entries } = sessionData;
+    resumeDiscovery({
+      sessionId: session.sessionId,
+      dbSessionId: session._id,
+      modelId: session.modelId,
+      personaId: session.personaId ?? undefined,
+      aspectRatio: session.aspectRatio,
+      seedPrompt: session.seedPrompt ?? undefined,
+      seedImageStorageId: session.seedImageStorageId ?? undefined,
+      history: entries,
+      likedPrompts: session.likedPrompts,
+      dislikedPrompts: session.dislikedPrompts,
+    });
+  }, [sessionData, needsHydration, resumeDiscovery]);
+
+  if (!sessionId) {
+    return <Navigate to={ROUTES.DISCOVER} replace />;
+  }
+
+  if (!isActive || storeSessionId !== sessionId) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Spinner className="size-8" />
+      </div>
+    );
+  }
+
+  return <DiscoveryMode />;
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -54,6 +54,13 @@ const SettingsEditPersonaPage = lazy(
 );
 const CanvasPage = lazy(() => import("./pages/canvas-page"));
 const CanvasImagePage = lazy(() => import("./pages/canvas-image-page"));
+const DiscoveryRouteLayout = lazy(
+  () => import("./components/layouts/discovery-route-layout")
+);
+const DiscoveryPage = lazy(() => import("./pages/discovery-page"));
+const DiscoverySessionPage = lazy(
+  () => import("./pages/discovery-session-page")
+);
 const SignOutPage = lazy(() => import("./pages/sign-out-page"));
 
 const PageLoader = ({
@@ -148,6 +155,25 @@ export const routes: RouteObject[] = [
           {
             path: "image/:generationId",
             element: withSuspense(<CanvasImagePage />),
+          },
+        ],
+      },
+      {
+        path: "discover",
+        element: (
+          <ProtectedSuspense fallback={<PageLoader size="full" />}>
+            <DiscoveryRouteLayout />
+          </ProtectedSuspense>
+        ),
+        errorElement: routeErrorElement,
+        children: [
+          {
+            index: true,
+            element: withSuspense(<DiscoveryPage />),
+          },
+          {
+            path: ":sessionId",
+            element: withSuspense(<DiscoverySessionPage />),
           },
         ],
       },

--- a/src/stores/discovery-store.ts
+++ b/src/stores/discovery-store.ts
@@ -1,0 +1,398 @@
+import type { Id } from "@convex/_generated/dataModel";
+import { devtools } from "zustand/middleware";
+import { shallow } from "zustand/shallow";
+import { useStoreWithEqualityFn } from "zustand/traditional";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { CACHE_KEYS, get, set } from "@/lib/local-storage";
+
+const MAX_CONTEXT_PROMPTS = 10;
+
+const MIN_PANEL_WIDTH = 240;
+const MAX_PANEL_WIDTH = 400;
+const DEFAULT_PANEL_WIDTH = 280;
+
+function getInitialPanelWidth(): number {
+  if (typeof window === "undefined") {
+    return DEFAULT_PANEL_WIDTH;
+  }
+  const saved = get(CACHE_KEYS.discoveryPanelWidth, DEFAULT_PANEL_WIDTH);
+  return Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH, saved));
+}
+
+function getInitialPanelVisible(): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+  return get(CACHE_KEYS.discoveryPanelVisible, true);
+}
+
+export type DiscoveryReaction = "liked" | "disliked" | "saved" | null;
+
+export type DiscoveryEntry = {
+  generationId: Id<"generations">;
+  prompt: string;
+  imageUrl: string | null;
+  aspectRatio: string;
+  status: "pending" | "generating" | "succeeded" | "failed";
+  reaction: DiscoveryReaction;
+  explanation?: string;
+};
+
+export type DiscoveryStopResult = {
+  unsaved: DiscoveryEntry[];
+  sessionId: string;
+};
+
+export type DiscoveryHint = "remix" | "wilder" | "fresh" | null;
+
+export type DiscoveryState = {
+  isActive: boolean;
+  sessionId: string;
+  dbSessionId: Id<"discoverySessions"> | null;
+  modelId: string;
+  personaId: Id<"personas"> | null;
+  aspectRatio: string;
+  history: DiscoveryEntry[];
+  currentIndex: number;
+  likedPrompts: string[];
+  dislikedPrompts: string[];
+  isGenerating: boolean;
+  seedPrompt: string;
+  seedImageStorageId: Id<"_storage"> | null;
+  hint: DiscoveryHint;
+
+  // Panel state
+  isPanelVisible: boolean;
+  panelWidth: number;
+  isResizing: boolean;
+
+  // Actions
+  start: (opts: {
+    modelId?: string;
+    personaId?: Id<"personas">;
+    aspectRatio?: string;
+    seedPrompt?: string;
+    seedImageStorageId?: Id<"_storage">;
+  }) => void;
+  resume: (opts: {
+    sessionId: string;
+    dbSessionId: Id<"discoverySessions">;
+    modelId: string;
+    personaId?: Id<"personas">;
+    aspectRatio: string;
+    seedPrompt?: string;
+    seedImageStorageId?: Id<"_storage">;
+    history: DiscoveryEntry[];
+    likedPrompts: string[];
+    dislikedPrompts: string[];
+  }) => void;
+  setDbSessionId: (id: Id<"discoverySessions">) => void;
+  stop: () => DiscoveryStopResult;
+  addEntry: (entry: DiscoveryEntry) => void;
+  updateEntry: (
+    generationId: Id<"generations">,
+    updates: Partial<Pick<DiscoveryEntry, "imageUrl" | "status">>
+  ) => void;
+  reactLike: () => void;
+  reactDislike: () => void;
+  reactRemix: () => void;
+  reactWilder: () => void;
+  reactFresh: () => void;
+  saveCurrentToCollection: () => void;
+  browseUp: () => void;
+  browseDown: () => void;
+  togglePanel: () => void;
+  setPanelWidth: (width: number) => void;
+  setIsResizing: (resizing: boolean) => void;
+  resetPanelWidth: () => void;
+};
+
+type DiscoveryStoreApi = StoreApi<DiscoveryState>;
+
+const INITIAL_STATE = {
+  isActive: false,
+  sessionId: "",
+  dbSessionId: null as Id<"discoverySessions"> | null,
+  modelId: "",
+  personaId: null as Id<"personas"> | null,
+  aspectRatio: "1:1",
+  history: [] as DiscoveryEntry[],
+  currentIndex: -1,
+  likedPrompts: [] as string[],
+  dislikedPrompts: [] as string[],
+  isGenerating: false,
+  hint: null as DiscoveryHint,
+  seedPrompt: "",
+  seedImageStorageId: null as Id<"_storage"> | null,
+  isPanelVisible: getInitialPanelVisible(),
+  panelWidth: getInitialPanelWidth(),
+  isResizing: false,
+};
+
+function createDiscoveryState(
+  set_: DiscoveryStoreApi["setState"],
+  get_: DiscoveryStoreApi["getState"]
+): DiscoveryState {
+  return {
+    ...INITIAL_STATE,
+
+    start: opts => {
+      set_({
+        isActive: true,
+        sessionId: crypto.randomUUID(),
+        dbSessionId: null,
+        modelId: opts.modelId ?? "",
+        personaId: opts.personaId ?? null,
+        aspectRatio: opts.aspectRatio ?? "1:1",
+        seedPrompt: opts.seedPrompt ?? "",
+        seedImageStorageId: opts.seedImageStorageId ?? null,
+        history: [],
+        currentIndex: -1,
+        likedPrompts: [],
+        dislikedPrompts: [],
+        isGenerating: false,
+        isPanelVisible: false,
+      });
+      set(CACHE_KEYS.discoveryPanelVisible, false);
+    },
+
+    resume: opts => {
+      set_({
+        isActive: true,
+        sessionId: opts.sessionId,
+        dbSessionId: opts.dbSessionId,
+        modelId: opts.modelId,
+        personaId: opts.personaId ?? null,
+        aspectRatio: opts.aspectRatio,
+        seedPrompt: opts.seedPrompt ?? "",
+        seedImageStorageId: opts.seedImageStorageId ?? null,
+        history: opts.history,
+        currentIndex: opts.history.length > 0 ? opts.history.length - 1 : -1,
+        likedPrompts: opts.likedPrompts,
+        dislikedPrompts: opts.dislikedPrompts,
+        isGenerating: false,
+      });
+    },
+
+    setDbSessionId: id => {
+      set_({ dbSessionId: id });
+    },
+
+    stop: () => {
+      const { history, sessionId, isPanelVisible, panelWidth } = get_();
+      const unsaved = history.filter(
+        e => e.reaction !== "saved" && e.status === "succeeded"
+      );
+      set_({ ...INITIAL_STATE, isPanelVisible, panelWidth });
+      return { unsaved, sessionId };
+    },
+
+    addEntry: entry => {
+      const { history } = get_();
+      set_({
+        history: [...history, entry],
+        currentIndex: history.length,
+        isGenerating:
+          entry.status === "pending" || entry.status === "generating",
+        hint: null,
+      });
+    },
+
+    updateEntry: (generationId, updates) => {
+      const { history } = get_();
+      set_({
+        history: history.map(e =>
+          e.generationId === generationId ? { ...e, ...updates } : e
+        ),
+        isGenerating: (() => {
+          if (updates.status === "pending" || updates.status === "generating") {
+            return true;
+          }
+          if (updates.status != null) {
+            return false;
+          }
+          return get_().isGenerating;
+        })(),
+      });
+    },
+
+    reactLike: () => {
+      const { history, currentIndex, likedPrompts } = get_();
+      const current = history[currentIndex];
+      if (!current) {
+        return;
+      }
+
+      const updatedHistory = history.map((e, i) =>
+        i === currentIndex ? { ...e, reaction: "liked" as const } : e
+      );
+      const updatedLiked = [
+        ...likedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
+        current.prompt,
+      ];
+      set_({ history: updatedHistory, likedPrompts: updatedLiked });
+    },
+
+    reactDislike: () => {
+      const { history, currentIndex, dislikedPrompts } = get_();
+      const current = history[currentIndex];
+      if (!current) {
+        return;
+      }
+
+      const updatedHistory = history.map((e, i) =>
+        i === currentIndex ? { ...e, reaction: "disliked" as const } : e
+      );
+      const updatedDisliked = [
+        ...dislikedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
+        current.prompt,
+      ];
+      set_({ history: updatedHistory, dislikedPrompts: updatedDisliked });
+    },
+
+    reactRemix: () => {
+      const { history, currentIndex, likedPrompts } = get_();
+      const current = history[currentIndex];
+      if (!current) {
+        return;
+      }
+
+      const updatedHistory = history.map((e, i) =>
+        i === currentIndex ? { ...e, reaction: "liked" as const } : e
+      );
+      const updatedLiked = [
+        ...likedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
+        current.prompt,
+      ];
+      set_({
+        history: updatedHistory,
+        likedPrompts: updatedLiked,
+        hint: "remix",
+      });
+    },
+
+    reactWilder: () => {
+      const { history, currentIndex, likedPrompts } = get_();
+      const current = history[currentIndex];
+      if (!current) {
+        return;
+      }
+
+      const updatedHistory = history.map((e, i) =>
+        i === currentIndex ? { ...e, reaction: "liked" as const } : e
+      );
+      const updatedLiked = [
+        ...likedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
+        current.prompt,
+      ];
+      set_({
+        history: updatedHistory,
+        likedPrompts: updatedLiked,
+        hint: "wilder",
+      });
+    },
+
+    reactFresh: () => {
+      const { history, currentIndex } = get_();
+      const current = history[currentIndex];
+      if (!current) {
+        return;
+      }
+
+      const updatedHistory = history.map((e, i) =>
+        i === currentIndex ? { ...e, reaction: "disliked" as const } : e
+      );
+      set_({
+        history: updatedHistory,
+        likedPrompts: [],
+        dislikedPrompts: [current.prompt],
+        hint: "fresh",
+      });
+    },
+
+    saveCurrentToCollection: () => {
+      const { history, currentIndex } = get_();
+      const current = history[currentIndex];
+      if (!current) {
+        return;
+      }
+
+      set_({
+        history: history.map((e, i) =>
+          i === currentIndex ? { ...e, reaction: "saved" as const } : e
+        ),
+      });
+    },
+
+    browseUp: () => {
+      const { currentIndex } = get_();
+      if (currentIndex > 0) {
+        set_({ currentIndex: currentIndex - 1 });
+      }
+    },
+
+    browseDown: () => {
+      const { currentIndex, history } = get_();
+      if (currentIndex < history.length - 1) {
+        set_({ currentIndex: currentIndex + 1 });
+      }
+    },
+
+    togglePanel: () => {
+      const next = !get_().isPanelVisible;
+      set_({ isPanelVisible: next });
+      set(CACHE_KEYS.discoveryPanelVisible, next);
+    },
+
+    setPanelWidth: (width: number) => {
+      const clamped = Math.max(
+        MIN_PANEL_WIDTH,
+        Math.min(MAX_PANEL_WIDTH, width)
+      );
+      set_({ panelWidth: clamped });
+      set(CACHE_KEYS.discoveryPanelWidth, clamped);
+    },
+
+    setIsResizing: (resizing: boolean) => set_({ isResizing: resizing }),
+
+    resetPanelWidth: () => {
+      set_({ panelWidth: DEFAULT_PANEL_WIDTH });
+      set(CACHE_KEYS.discoveryPanelWidth, DEFAULT_PANEL_WIDTH);
+    },
+  };
+}
+
+export const createDiscoveryStore = () =>
+  createStore<DiscoveryState>()(
+    devtools((s, g) => createDiscoveryState(s, g), {
+      name: "DiscoveryStore",
+    })
+  );
+
+const discoveryStoreApi: DiscoveryStoreApi = createDiscoveryStore();
+
+type DiscoverySelector<T> = (state: DiscoveryState) => T;
+
+function useDiscoveryStoreBase<T>(
+  selector: DiscoverySelector<T>,
+  equalityFn?: (a: T, b: T) => boolean
+): T {
+  return useStoreWithEqualityFn(
+    discoveryStoreApi,
+    selector,
+    equalityFn ?? shallow
+  );
+}
+
+export const useDiscoveryStore = Object.assign(useDiscoveryStoreBase, {
+  getState: () => discoveryStoreApi.getState(),
+  setState: (
+    partial:
+      | DiscoveryState
+      | Partial<DiscoveryState>
+      | ((state: DiscoveryState) => DiscoveryState | Partial<DiscoveryState>),
+    replace?: false
+  ) => discoveryStoreApi.setState(partial, replace),
+  subscribe: (...args: Parameters<DiscoveryStoreApi["subscribe"]>) =>
+    discoveryStoreApi.subscribe(...args),
+});

--- a/src/stores/discovery-store.ts
+++ b/src/stores/discovery-store.ts
@@ -217,9 +217,9 @@ function createDiscoveryState(
     },
 
     reactLike: () => {
-      const { history, currentIndex, likedPrompts } = get_();
+      const { history, currentIndex, likedPrompts, dislikedPrompts } = get_();
       const current = history[currentIndex];
-      if (!current) {
+      if (!current || current.reaction === "liked") {
         return;
       }
 
@@ -230,13 +230,18 @@ function createDiscoveryState(
         ...likedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
         current.prompt,
       ];
-      set_({ history: updatedHistory, likedPrompts: updatedLiked });
+      const updatedDisliked = dislikedPrompts.filter(p => p !== current.prompt);
+      set_({
+        history: updatedHistory,
+        likedPrompts: updatedLiked,
+        dislikedPrompts: updatedDisliked,
+      });
     },
 
     reactDislike: () => {
-      const { history, currentIndex, dislikedPrompts } = get_();
+      const { history, currentIndex, likedPrompts, dislikedPrompts } = get_();
       const current = history[currentIndex];
-      if (!current) {
+      if (!current || current.reaction === "disliked") {
         return;
       }
 
@@ -247,11 +252,16 @@ function createDiscoveryState(
         ...dislikedPrompts.slice(-(MAX_CONTEXT_PROMPTS - 1)),
         current.prompt,
       ];
-      set_({ history: updatedHistory, dislikedPrompts: updatedDisliked });
+      const updatedLiked = likedPrompts.filter(p => p !== current.prompt);
+      set_({
+        history: updatedHistory,
+        dislikedPrompts: updatedDisliked,
+        likedPrompts: updatedLiked,
+      });
     },
 
     reactRemix: () => {
-      const { history, currentIndex, likedPrompts } = get_();
+      const { history, currentIndex, likedPrompts, dislikedPrompts } = get_();
       const current = history[currentIndex];
       if (!current) {
         return;
@@ -267,12 +277,13 @@ function createDiscoveryState(
       set_({
         history: updatedHistory,
         likedPrompts: updatedLiked,
+        dislikedPrompts: dislikedPrompts.filter(p => p !== current.prompt),
         hint: "remix",
       });
     },
 
     reactWilder: () => {
-      const { history, currentIndex, likedPrompts } = get_();
+      const { history, currentIndex, likedPrompts, dislikedPrompts } = get_();
       const current = history[currentIndex];
       if (!current) {
         return;
@@ -288,6 +299,7 @@ function createDiscoveryState(
       set_({
         history: updatedHistory,
         likedPrompts: updatedLiked,
+        dislikedPrompts: dislikedPrompts.filter(p => p !== current.prompt),
         hint: "wilder",
       });
     },


### PR DESCRIPTION
## Summary
- Add a new **Discovery** mode where users iteratively explore visual directions via an AI feedback loop
- Users start with an optional seed (text prompt, uploaded image, or style persona) and react to generated images with like/dislike/save
- The AI evolves prompts, selects models, and adapts aspect ratios in real time based on user preferences
- Includes full-screen immersive viewer with keyboard shortcuts (arrows, space, R/W/F for remix/wilder/fresh) and mobile swipe gestures

## What's included
- **Backend**: Discovery session CRUD, AI prompt evolution with taste learning, vision-powered seed image analysis, model auto-selection
- **Frontend**: Discovery page, session page, immersive mode component, resizable sidebar, Zustand store, route layout
- **Integration**: Sidebar nav link, canvas page link, route definitions, schema + index additions

## Test plan
- [ ] Start a discovery session with a text seed and verify generations appear
- [ ] Start a session with an uploaded image seed
- [ ] Like/dislike images and confirm the AI adapts prompt direction
- [ ] Use keyboard shortcuts (←/→ for dislike/like, Space for save, R/W/F for hints)
- [ ] Verify session persistence — pause and resume a session
- [ ] Test mobile swipe gestures
- [ ] Verify sidebar navigation link works from chat and canvas views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a full AI-guided Discovery mode — a Tinder-style image exploration loop where the AI evolves prompts and selects models based on user like/dislike signals. The feature is well-architected with backend idempotency, Zustand state management, and an immersive full-screen UI.

Three logic issues require attention:

1. **Spurious generations from browsed-back entries** — `handleLike` and `handleDislike` do not guard against already-reacted entries before calling `triggerGeneration()`. Browsing back to a previously liked/disliked image and pressing the shortcut again spawns a spurious generation, wasting API credits.

2. **`reactFresh` server/client divergence** — The "Fresh" action clears `likedPrompts: []` in Zustand for the next generation, but the backend only receives a "disliked" signal and never clears its own `likedPrompts` array. On session resume, all old liked prompts are restored from the server, silently reversing the directional reset the user intended.

3. **Start button vulnerable to double-click** — `disabled={false}` is hardcoded, so rapid double-clicks create duplicate orphaned sessions in the sidebar.

The backend session CRUD is solid and idempotency is correctly handled in `recordReaction`. However, these three client-side logic gaps need targeted fixes before shipping.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — three logic bugs can waste API credits and silently break core features.
- The backend session CRUD is solid and idempotency is correctly handled. However, three client-side logic bugs are reproducible and impact user experience: (1) spurious generations when browsing back to already-reacted entries; (2) the "Fresh" directional reset feature is broken across page reloads because the server never clears liked context; (3) the Start button allows rapid double-clicks to create orphaned duplicate sessions. These are not style nitpicks or speculative issues — they're concrete bugs that trigger real API calls and incorrect behavior.
- `src/components/canvas/discovery-mode.tsx` (handleLike/handleDislike guards), `src/stores/discovery-store.ts` + `convex/discoverySessions.ts` (reactFresh server persistence), and `src/pages/discovery-page.tsx` (Start button disable state).

<sub>Last reviewed commit: d224c0e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->