### PR TITLE
Improve canvas command palette with grouped actions

### DIFF
--- a/src/components/navigation/command-palette-main-menu.tsx
+++ b/src/components/navigation/command-palette-main-menu.tsx
@@ -19,10 +19,14 @@ import type {
 
 type CommandPaletteMainMenuProps = {
   isConversationPage: boolean;
+  isCanvasPage: boolean;
   hasCurrentConversation: boolean;
   isPinned?: boolean;
   filteredConversationActions: Action[];
   filteredGlobalActions: Action[];
+  filteredCanvasFilterActions: Action[];
+  filteredCanvasAspectActions: Action[];
+  filteredCanvasGenerationActions: Action[];
   filteredSettingsActions: Action[];
   conversationsToShow: ConversationType[];
   modelsToShow: DisplayModel[];
@@ -38,10 +42,14 @@ type CommandPaletteMainMenuProps = {
 
 export function CommandPaletteMainMenu({
   isConversationPage,
+  isCanvasPage,
   hasCurrentConversation,
   isPinned,
   filteredConversationActions,
   filteredGlobalActions,
+  filteredCanvasFilterActions,
+  filteredCanvasAspectActions,
+  filteredCanvasGenerationActions,
   filteredSettingsActions,
   conversationsToShow,
   modelsToShow,
@@ -54,6 +62,10 @@ export function CommandPaletteMainMenu({
   onConversationActions,
   onSelectModel,
 }: CommandPaletteMainMenuProps) {
+  const hasCanvasActions =
+    filteredCanvasFilterActions.length > 0 ||
+    filteredCanvasAspectActions.length > 0 ||
+    filteredCanvasGenerationActions.length > 0;
   return (
     <>
       {/* Conversation-specific actions - Show first when on conversation page */}
@@ -99,14 +111,98 @@ export function CommandPaletteMainMenu({
           </CommandGroup>
         )}
 
-      {/* Global actions - Show after conversation actions */}
+      {/* Canvas-specific actions - Show first when on canvas page */}
+      {isCanvasPage && hasCanvasActions && (
+        <>
+          {filteredCanvasFilterActions.length > 0 && (
+            <CommandGroup
+              heading="Filter"
+              className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
+            >
+              {filteredCanvasFilterActions.map(action => {
+                const IconComponent = action.icon;
+                return (
+                  <CommandItem
+                    key={action.id}
+                    value={action.id}
+                    onSelect={action.handler}
+                    className="flex items-center gap-3 px-4 py-3 text-sm transition-colors rounded-md mx-2"
+                    disabled={action.disabled}
+                  >
+                    <IconComponent className="size-4 flex-shrink-0 text-muted-foreground" />
+                    <span className="flex-1">{action.label}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          )}
+          {filteredCanvasAspectActions.length > 0 && (
+            <>
+              {filteredCanvasFilterActions.length > 0 && (
+                <CommandSeparator className="my-2" />
+              )}
+              <CommandGroup
+                heading="Aspect Ratio"
+                className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
+              >
+                {filteredCanvasAspectActions.map(action => {
+                  const IconComponent = action.icon;
+                  return (
+                    <CommandItem
+                      key={action.id}
+                      value={action.id}
+                      onSelect={action.handler}
+                      className="flex items-center gap-3 px-4 py-3 text-sm transition-colors rounded-md mx-2"
+                      disabled={action.disabled}
+                    >
+                      <IconComponent className="size-4 flex-shrink-0 text-muted-foreground" />
+                      <span className="flex-1">{action.label}</span>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </>
+          )}
+          {filteredCanvasGenerationActions.length > 0 && (
+            <>
+              {(filteredCanvasFilterActions.length > 0 ||
+                filteredCanvasAspectActions.length > 0) && (
+                <CommandSeparator className="my-2" />
+              )}
+              <CommandGroup
+                heading="Generation"
+                className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
+              >
+                {filteredCanvasGenerationActions.map(action => {
+                  const IconComponent = action.icon;
+                  return (
+                    <CommandItem
+                      key={action.id}
+                      value={action.id}
+                      onSelect={action.handler}
+                      className="flex items-center gap-3 px-4 py-3 text-sm transition-colors rounded-md mx-2"
+                      disabled={action.disabled}
+                    >
+                      <IconComponent className="size-4 flex-shrink-0 text-muted-foreground" />
+                      <span className="flex-1">{action.label}</span>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </>
+          )}
+        </>
+      )}
+
+      {/* Global actions - Show after conversation/canvas actions */}
       {filteredGlobalActions.length > 0 && (
         <>
-          {isConversationPage &&
+          {((isConversationPage &&
             hasCurrentConversation &&
-            filteredConversationActions.length > 0 && (
-              <CommandSeparator className="my-2" />
-            )}
+            filteredConversationActions.length > 0) ||
+            (isCanvasPage && hasCanvasActions)) && (
+            <CommandSeparator className="my-2" />
+          )}
           <CommandGroup
             heading="Actions"
             className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
@@ -134,6 +230,7 @@ export function CommandPaletteMainMenu({
       {filteredSettingsActions.length > 0 && (
         <>
           {(filteredGlobalActions.length > 0 ||
+            (isCanvasPage && hasCanvasActions) ||
             (isConversationPage &&
               hasCurrentConversation &&
               filteredConversationActions.length > 0)) && (
@@ -163,117 +260,129 @@ export function CommandPaletteMainMenu({
         </>
       )}
 
-      {conversationsToShow && conversationsToShow.length > 0 && (
-        <>
-          {(filteredGlobalActions.length > 0 ||
-            filteredSettingsActions.length > 0 ||
-            (isConversationPage &&
-              hasCurrentConversation &&
-              filteredConversationActions.length > 0)) && (
-            <CommandSeparator className="my-2" />
-          )}
-          <CommandGroup
-            heading={hasSearchQuery ? "Conversations" : "Recent Conversations"}
-            className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
-          >
-            {conversationsToShow.map((conversation: ConversationType) => (
-              <CommandItem
-                key={conversation._id}
-                value={`conversation-${conversation._id}`}
-                onSelect={() => onNavigateToConversation(conversation._id)}
-                onPointerDown={event => {
-                  if (event.metaKey || event.ctrlKey) {
-                    event.preventDefault();
-                    onConversationActions(conversation._id, conversation.title);
-                  }
-                }}
-                className="flex items-center gap-3 px-4 py-3 text-sm transition-colors rounded-md mx-2"
-                disabled={!online}
-              >
-                <ChatCircleIcon className="size-4 text-muted-foreground flex-shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <div className="truncate font-medium">
-                    {conversation.title}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  {conversation.isPinned && (
-                    <PushPinIcon
-                      className="size-3 text-muted-foreground flex-shrink-0"
-                      weight="fill"
-                    />
-                  )}
-                  {conversation.isArchived && (
-                    <ArchiveIcon className="size-3 text-muted-foreground flex-shrink-0" />
-                  )}
-                </div>
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        </>
-      )}
-
-      {modelsLoaded && modelsToShow && modelsToShow.length > 0 && (
-        <>
-          {(filteredGlobalActions.length > 0 ||
-            filteredSettingsActions.length > 0 ||
-            (isConversationPage &&
-              hasCurrentConversation &&
-              filteredConversationActions.length > 0) ||
-            conversationsToShow?.length > 0) && (
-            <CommandSeparator className="my-2" />
-          )}
-          <CommandGroup
-            heading={hasSearchQuery ? "Models" : "Switch Model"}
-            className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
-          >
-            {modelsToShow.map(model => {
-              const isSelected =
-                currentSelectedModel?.modelId === model.modelId &&
-                currentSelectedModel?.provider === model.provider;
-
-              const capabilities = getModelCapabilities(
-                model as ModelForCapabilities
-              );
-
-              return (
+      {!isCanvasPage &&
+        conversationsToShow &&
+        conversationsToShow.length > 0 && (
+          <>
+            {(filteredGlobalActions.length > 0 ||
+              filteredSettingsActions.length > 0 ||
+              (isConversationPage &&
+                hasCurrentConversation &&
+                filteredConversationActions.length > 0)) && (
+              <CommandSeparator className="my-2" />
+            )}
+            <CommandGroup
+              heading={
+                hasSearchQuery ? "Conversations" : "Recent Conversations"
+              }
+              className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
+            >
+              {conversationsToShow.map((conversation: ConversationType) => (
                 <CommandItem
-                  key={`${model.provider}-${model.modelId}`}
-                  value={`model-${model.provider}-${model.modelId}`}
-                  onSelect={() => onSelectModel(model.modelId, model.provider)}
+                  key={conversation._id}
+                  value={`conversation-${conversation._id}`}
+                  onSelect={() => onNavigateToConversation(conversation._id)}
+                  onPointerDown={event => {
+                    if (event.metaKey || event.ctrlKey) {
+                      event.preventDefault();
+                      onConversationActions(
+                        conversation._id,
+                        conversation.title
+                      );
+                    }
+                  }}
                   className="flex items-center gap-3 px-4 py-3 text-sm transition-colors rounded-md mx-2"
+                  disabled={!online}
                 >
-                  <ProviderIcon
-                    provider={model.free ? "polly" : model.provider}
-                    className="h-4 w-4 text-muted-foreground flex-shrink-0"
-                  />
+                  <ChatCircleIcon className="size-4 text-muted-foreground flex-shrink-0" />
                   <div className="flex-1 min-w-0">
-                    <div className="truncate font-medium">{model.name}</div>
+                    <div className="truncate font-medium">
+                      {conversation.title}
+                    </div>
                   </div>
-                  <div className="flex items-center gap-1">
-                    {capabilities.length > 0 &&
-                      capabilities.map((capability, index) => {
-                        const IconComponent = capability.icon;
-                        return (
-                          <div
-                            key={`${model.modelId}-${capability.label}-${index}`}
-                            className="flex h-4 w-4 items-center justify-center rounded-sm bg-muted/50"
-                            title={capability.label}
-                          >
-                            <IconComponent className="size-2.5 text-muted-foreground" />
-                          </div>
-                        );
-                      })}
-                    {isSelected && (
-                      <div className="h-2 w-2 rounded-full bg-success flex-shrink-0 ml-1" />
+                  <div className="flex items-center gap-2">
+                    {conversation.isPinned && (
+                      <PushPinIcon
+                        className="size-3 text-muted-foreground flex-shrink-0"
+                        weight="fill"
+                      />
+                    )}
+                    {conversation.isArchived && (
+                      <ArchiveIcon className="size-3 text-muted-foreground flex-shrink-0" />
                     )}
                   </div>
                 </CommandItem>
-              );
-            })}
-          </CommandGroup>
-        </>
-      )}
+              ))}
+            </CommandGroup>
+          </>
+        )}
+
+      {!isCanvasPage &&
+        modelsLoaded &&
+        modelsToShow &&
+        modelsToShow.length > 0 && (
+          <>
+            {(filteredGlobalActions.length > 0 ||
+              filteredSettingsActions.length > 0 ||
+              (isConversationPage &&
+                hasCurrentConversation &&
+                filteredConversationActions.length > 0) ||
+              conversationsToShow?.length > 0) && (
+              <CommandSeparator className="my-2" />
+            )}
+            <CommandGroup
+              heading={hasSearchQuery ? "Models" : "Switch Model"}
+              className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-4 [&_[cmdk-group-heading]]:py-3 [&_[cmdk-group-heading]]:mb-1"
+            >
+              {modelsToShow.map(model => {
+                const isSelected =
+                  currentSelectedModel?.modelId === model.modelId &&
+                  currentSelectedModel?.provider === model.provider;
+
+                const capabilities = getModelCapabilities(
+                  model as ModelForCapabilities
+                );
+
+                return (
+                  <CommandItem
+                    key={`${model.provider}-${model.modelId}`}
+                    value={`model-${model.provider}-${model.modelId}`}
+                    onSelect={() =>
+                      onSelectModel(model.modelId, model.provider)
+                    }
+                    className="flex items-center gap-3 px-4 py-3 text-sm transition-colors rounded-md mx-2"
+                  >
+                    <ProviderIcon
+                      provider={model.free ? "polly" : model.provider}
+                      className="h-4 w-4 text-muted-foreground flex-shrink-0"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="truncate font-medium">{model.name}</div>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      {capabilities.length > 0 &&
+                        capabilities.map((capability, index) => {
+                          const IconComponent = capability.icon;
+                          return (
+                            <div
+                              key={`${model.modelId}-${capability.label}-${index}`}
+                              className="flex h-4 w-4 items-center justify-center rounded-sm bg-muted/50"
+                              title={capability.label}
+                            >
+                              <IconComponent className="size-2.5 text-muted-foreground" />
+                            </div>
+                          );
+                        })}
+                      {isSelected && (
+                        <div className="h-2 w-2 rounded-full bg-success flex-shrink-0 ml-1" />
+                      )}
+                    </div>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </>
+        )}
     </>
   );
 }

--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -89,6 +89,14 @@ type CommandPaletteProps = {
 
 type AvailableModel = HydratedModel;
 
+const FILTER_LABELS: Record<CanvasFilterMode, string> = {
+  all: "All",
+  edits: "Edits",
+  upscaled: "Upscaled",
+  conversations: "Chat",
+  canvas: "Canvas",
+};
+
 function getCommandInputPlaceholder(
   currentMenu: NavigationState["currentMenu"],
   isCanvasPage?: boolean
@@ -795,14 +803,6 @@ export function CommandPalette({
     s => s.clearReferenceImages
   );
   const canvasReferenceImages = useCanvasStore(s => s.referenceImages);
-
-  const FILTER_LABELS: Record<CanvasFilterMode, string> = {
-    all: "All",
-    edits: "Edits",
-    upscaled: "Upscaled",
-    conversations: "Chat",
-    canvas: "Canvas",
-  };
 
   const canvasFilterActions = useMemo((): Action[] => {
     if (!isCanvasPage) {

--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -12,7 +12,6 @@ import {
   FileTextIcon,
   FunnelIcon,
   GearIcon,
-  ImageIcon,
   KeyIcon,
   MagnifyingGlassIcon,
   PaperclipIcon,
@@ -66,7 +65,7 @@ import { CACHE_KEYS, del } from "@/lib/local-storage";
 import { ROUTES } from "@/lib/routes";
 import { useToast } from "@/providers/toast-context";
 import { useUserIdentity } from "@/providers/user-data-context";
-import type { CanvasFilterMode } from "@/stores/canvas-store";
+import type { CanvasFilterMode, ReferenceImage } from "@/stores/canvas-store";
 import { useCanvasStore } from "@/stores/canvas-store";
 import type { ConversationId, HydratedModel } from "@/types";
 import { CommandPaletteConversationActions } from "./command-palette-conversation-actions";
@@ -88,6 +87,8 @@ type CommandPaletteProps = {
 };
 
 type AvailableModel = HydratedModel;
+
+const EMPTY_REFERENCE_IMAGES: ReferenceImage[] = [];
 
 const FILTER_LABELS: Record<CanvasFilterMode, string> = {
   all: "All",
@@ -803,7 +804,9 @@ export function CommandPalette({
   const canvasClearReferenceImages = useCanvasStore(
     s => s.clearReferenceImages
   );
-  const canvasReferenceImages = useCanvasStore(s => s.referenceImages);
+  const canvasReferenceImages = useCanvasStore(s =>
+    isCanvasPage ? s.referenceImages : EMPTY_REFERENCE_IMAGES
+  );
 
   const canvasFilterActions = useMemo((): Action[] => {
     if (!isCanvasPage) {
@@ -869,7 +872,7 @@ export function CommandPalette({
       actions.push({
         id: "canvas-clear-references",
         label: "Clear Reference Images",
-        icon: ImageIcon,
+        icon: TrashIcon,
         handler: () => {
           canvasClearReferenceImages();
           handleClose();

--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -797,6 +797,7 @@ export function CommandPalette({
   // Canvas-specific actions (filters, aspect ratio, generation)
   const canvasFilterMode = useCanvasStore(s => s.filterMode);
   const canvasSetFilterMode = useCanvasStore(s => s.setFilterMode);
+  const canvasAspectRatio = useCanvasStore(s => s.aspectRatio);
   const canvasSetAspectRatio = useCanvasStore(s => s.setAspectRatio);
   const canvasResetForm = useCanvasStore(s => s.resetForm);
   const canvasClearReferenceImages = useCanvasStore(
@@ -842,9 +843,9 @@ export function CommandPalette({
         canvasSetAspectRatio(ratio);
         handleClose();
       },
-      disabled: false,
+      disabled: canvasAspectRatio === ratio,
     }));
-  }, [isCanvasPage, canvasSetAspectRatio, handleClose]);
+  }, [isCanvasPage, canvasAspectRatio, canvasSetAspectRatio, handleClose]);
 
   const canvasGenerationActions = useMemo((): Action[] => {
     if (!isCanvasPage) {

--- a/src/components/navigation/command-palette.tsx
+++ b/src/components/navigation/command-palette.tsx
@@ -3,12 +3,16 @@ import type { Id } from "@convex/_generated/dataModel";
 import {
   ArchiveIcon,
   ArrowLeftIcon,
+  ArrowsOutSimpleIcon,
   ChatCircleIcon,
   CloudArrowDownIcon,
+  EraserIcon,
   EyeSlashIcon,
   FileCodeIcon,
   FileTextIcon,
+  FunnelIcon,
   GearIcon,
+  ImageIcon,
   KeyIcon,
   MagnifyingGlassIcon,
   PaperclipIcon,
@@ -62,6 +66,8 @@ import { CACHE_KEYS, del } from "@/lib/local-storage";
 import { ROUTES } from "@/lib/routes";
 import { useToast } from "@/providers/toast-context";
 import { useUserIdentity } from "@/providers/user-data-context";
+import type { CanvasFilterMode } from "@/stores/canvas-store";
+import { useCanvasStore } from "@/stores/canvas-store";
 import type { ConversationId, HydratedModel } from "@/types";
 import { CommandPaletteConversationActions } from "./command-palette-conversation-actions";
 import { CommandPaletteConversationBrowser } from "./command-palette-conversation-browser";
@@ -84,7 +90,8 @@ type CommandPaletteProps = {
 type AvailableModel = HydratedModel;
 
 function getCommandInputPlaceholder(
-  currentMenu: NavigationState["currentMenu"]
+  currentMenu: NavigationState["currentMenu"],
+  isCanvasPage?: boolean
 ): string {
   if (currentMenu === "conversation-actions") {
     return "Search actions...";
@@ -97,6 +104,9 @@ function getCommandInputPlaceholder(
   }
   if (currentMenu === "theme") {
     return "Search themes...";
+  }
+  if (isCanvasPage) {
+    return "Search actions...";
   }
   return "Search conversations, switch models, or take actions...";
 }
@@ -139,6 +149,7 @@ export function CommandPalette({
 
   const currentConversationId = params.conversationId;
   const isConversationPage = location.pathname.startsWith("/chat/");
+  const isCanvasPage = location.pathname.startsWith("/canvas");
 
   // Helper function to close the command palette and call onClose callback
   const handleClose = useCallback(() => {
@@ -685,6 +696,26 @@ export function CommandPalette({
   }, [handleNavigateToSettings, online, isAuthenticated]);
 
   const globalActions = useMemo((): Action[] => {
+    // Canvas mode: only navigation + universal actions (no private mode)
+    if (isCanvasPage) {
+      return [
+        {
+          id: "new-conversation",
+          label: "Go to Chat",
+          icon: ChatCircleIcon,
+          handler: handleNewConversation,
+          disabled: false,
+        },
+        {
+          id: "change-theme",
+          label: "Change Theme",
+          icon: SwatchesIcon,
+          handler: handleOpenThemeMenu,
+          disabled: false,
+        },
+      ];
+    }
+
     const actions: Action[] = [
       {
         id: "new-conversation",
@@ -745,6 +776,7 @@ export function CommandPalette({
 
     return actions;
   }, [
+    isCanvasPage,
     handleNewConversation,
     handlePrivateMode,
     handleImportConversations,
@@ -753,6 +785,133 @@ export function CommandPalette({
     online,
     isAuthenticated,
   ]);
+
+  // Canvas-specific actions (filters, aspect ratio, generation)
+  const canvasFilterMode = useCanvasStore(s => s.filterMode);
+  const canvasSetFilterMode = useCanvasStore(s => s.setFilterMode);
+  const canvasSetAspectRatio = useCanvasStore(s => s.setAspectRatio);
+  const canvasResetForm = useCanvasStore(s => s.resetForm);
+  const canvasClearReferenceImages = useCanvasStore(
+    s => s.clearReferenceImages
+  );
+  const canvasReferenceImages = useCanvasStore(s => s.referenceImages);
+
+  const FILTER_LABELS: Record<CanvasFilterMode, string> = {
+    all: "All",
+    edits: "Edits",
+    upscaled: "Upscaled",
+    conversations: "Chat",
+    canvas: "Canvas",
+  };
+
+  const canvasFilterActions = useMemo((): Action[] => {
+    if (!isCanvasPage) {
+      return [];
+    }
+
+    return (
+      [
+        "all",
+        "canvas",
+        "edits",
+        "upscaled",
+        "conversations",
+      ] as CanvasFilterMode[]
+    ).map(mode => ({
+      id: `canvas-filter-${mode}`,
+      label: `${FILTER_LABELS[mode]}`,
+      icon: FunnelIcon,
+      handler: () => {
+        canvasSetFilterMode(mode);
+        handleClose();
+      },
+      disabled: canvasFilterMode === mode,
+    }));
+  }, [isCanvasPage, canvasFilterMode, canvasSetFilterMode, handleClose]);
+
+  const canvasAspectActions = useMemo((): Action[] => {
+    if (!isCanvasPage) {
+      return [];
+    }
+
+    return ["1:1", "16:9", "9:16", "4:3", "3:4"].map(ratio => ({
+      id: `canvas-ratio-${ratio}`,
+      label: `${ratio}`,
+      icon: ArrowsOutSimpleIcon,
+      handler: () => {
+        canvasSetAspectRatio(ratio);
+        handleClose();
+      },
+      disabled: false,
+    }));
+  }, [isCanvasPage, canvasSetAspectRatio, handleClose]);
+
+  const canvasGenerationActions = useMemo((): Action[] => {
+    if (!isCanvasPage) {
+      return [];
+    }
+
+    const actions: Action[] = [
+      {
+        id: "canvas-reset-form",
+        label: "Reset Form",
+        icon: EraserIcon,
+        handler: () => {
+          canvasResetForm();
+          handleClose();
+        },
+        disabled: false,
+      },
+    ];
+
+    if (canvasReferenceImages.length > 0) {
+      actions.push({
+        id: "canvas-clear-references",
+        label: "Clear Reference Images",
+        icon: ImageIcon,
+        handler: () => {
+          canvasClearReferenceImages();
+          handleClose();
+        },
+        disabled: false,
+      });
+    }
+
+    return actions;
+  }, [
+    isCanvasPage,
+    canvasResetForm,
+    canvasClearReferenceImages,
+    canvasReferenceImages.length,
+    handleClose,
+  ]);
+
+  const filteredCanvasFilterActions = useMemo(() => {
+    if (!hasSearchQuery) {
+      return canvasFilterActions;
+    }
+    return canvasFilterActions.filter(action =>
+      action.label.toLowerCase().includes(normalizedDeferredSearch)
+    );
+  }, [hasSearchQuery, normalizedDeferredSearch, canvasFilterActions]);
+
+  const filteredCanvasAspectActions = useMemo(() => {
+    if (!hasSearchQuery) {
+      return canvasAspectActions;
+    }
+    return canvasAspectActions.filter(action =>
+      action.label.toLowerCase().includes(normalizedDeferredSearch)
+    );
+  }, [hasSearchQuery, normalizedDeferredSearch, canvasAspectActions]);
+
+  const filteredCanvasGenerationActions = useMemo(() => {
+    if (!hasSearchQuery) {
+      return canvasGenerationActions;
+    }
+    return canvasGenerationActions.filter(action =>
+      action.label.toLowerCase().includes(normalizedDeferredSearch)
+    );
+  }, [hasSearchQuery, normalizedDeferredSearch, canvasGenerationActions]);
 
   const conversationActions = useMemo(() => {
     const actions: Action[] = [
@@ -1233,7 +1392,10 @@ export function CommandPalette({
             <CommandInput
               ref={inputRef}
               className="h-14 border-0 bg-transparent text-base focus:ring-0 [&_.cmdk-input]:h-14"
-              placeholder={getCommandInputPlaceholder(navigation.currentMenu)}
+              placeholder={getCommandInputPlaceholder(
+                navigation.currentMenu,
+                isCanvasPage
+              )}
               value={search}
               onValueChange={setSearch}
             />
@@ -1269,10 +1431,16 @@ export function CommandPalette({
             {navigation.currentMenu === "main" && (
               <CommandPaletteMainMenu
                 isConversationPage={isConversationPage}
+                isCanvasPage={isCanvasPage}
                 hasCurrentConversation={!!currentConversation?.conversation}
                 isPinned={currentConversation?.conversation?.isPinned}
                 filteredConversationActions={filteredConversationActions}
                 filteredGlobalActions={filteredGlobalActions}
+                filteredCanvasFilterActions={filteredCanvasFilterActions}
+                filteredCanvasAspectActions={filteredCanvasAspectActions}
+                filteredCanvasGenerationActions={
+                  filteredCanvasGenerationActions
+                }
                 filteredSettingsActions={filteredSettingsActions}
                 conversationsToShow={conversationsToShow}
                 modelsToShow={modelsToShow}


### PR DESCRIPTION
## Summary
- Split flat canvas actions into logical groups: **Filter**, **Aspect Ratio**, **Generation** — each with its own heading and separator
- Removed sidebar toggle action from command palette
- Added missing "Canvas" filter mode
- Added conditional "Clear Reference Images" action (only visible when references exist)
- Settings section now visible on canvas page

## Test plan
- [ ] Open command palette on canvas page — verify 3 grouped sections (Filter, Aspect Ratio, Generation)
- [ ] Confirm sidebar toggle action is gone
- [ ] Search for actions — verify filtering works across all groups
- [ ] Add reference images, reopen palette — verify "Clear Reference Images" appears
- [ ] Verify settings section appears on canvas page
- [ ] Open command palette on chat page — verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorganizes the canvas command palette from a flat list of actions into three clearly labeled groups — **Filter**, **Aspect Ratio**, and **Generation** — each with its own heading and separator. The implementation is clean and well-scoped:

- Canvas-specific `useMemo` hooks are properly guarded with `isCanvasPage` checks
- `FILTER_LABELS` and `EMPTY_REFERENCE_IMAGES` are module-level constants with stable references
- The active aspect ratio is correctly reflected via `disabled: canvasAspectRatio === ratio`
- `TrashIcon` is used for the destructive "Clear Reference Images" action
- The `canvasReferenceImages` selector uses a conditional pattern to avoid unnecessary subscriptions on non-canvas pages
- Separator logic in `CommandPaletteMainMenu` correctly handles all visible/filtered section combinations
- Conversations and model switching are intentionally suppressed on canvas pages via `!isCanvasPage` guards

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no functional or runtime issues detected.
- All code changes are well-structured, follow existing patterns, properly guard canvas-specific logic with `isCanvasPage` checks, and avoid common React/Zustand pitfalls like missing dependencies or unnecessary subscriptions. No regressions or edge case issues were identified.
- No files require special attention

<sub>Last reviewed commit: c611917</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->