### PR TITLE
Adopt React 19 use() hook and remove use client directives

### DIFF
--- a/src/components/animate-ui/icons/a-large-small.tsx
+++ b/src/components/animate-ui/icons/a-large-small.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/copy.tsx
+++ b/src/components/animate-ui/icons/copy.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/download.tsx
+++ b/src/components/animate-ui/icons/download.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/gallery-horizontal.tsx
+++ b/src/components/animate-ui/icons/gallery-horizontal.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/git-branch.tsx
+++ b/src/components/animate-ui/icons/git-branch.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/heart.tsx
+++ b/src/components/animate-ui/icons/heart.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/icon.tsx
+++ b/src/components/animate-ui/icons/icon.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   type HTMLMotionProps,
   type LegacyAnimationControls,
@@ -95,7 +93,7 @@ const AnimateIconContext = React.createContext<AnimateIconContextValue | null>(
 );
 
 function useAnimateIconContext() {
-  const context = React.useContext(AnimateIconContext);
+  const context = React.use(AnimateIconContext);
   if (!context) {
     return {
       controls: undefined,
@@ -503,7 +501,7 @@ function IconWrapper<T extends string>({
   className,
   ...props
 }: IconWrapperProps<T>) {
-  const context = React.useContext(AnimateIconContext);
+  const context = React.use(AnimateIconContext);
 
   if (context) {
     const {

--- a/src/components/animate-ui/icons/panel-left.tsx
+++ b/src/components/animate-ui/icons/panel-left.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/refresh-cw.tsx
+++ b/src/components/animate-ui/icons/refresh-cw.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/search.tsx
+++ b/src/components/animate-ui/icons/search.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/square-pen.tsx
+++ b/src/components/animate-ui/icons/square-pen.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/trash.tsx
+++ b/src/components/animate-ui/icons/trash.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/icons/volume-2.tsx
+++ b/src/components/animate-ui/icons/volume-2.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { motion, type Variants } from "motion/react";
 import * as React from "react";
 

--- a/src/components/animate-ui/primitives/animate/slot.tsx
+++ b/src/components/animate-ui/primitives/animate/slot.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { type HTMLMotionProps, isMotionComponent, motion } from "motion/react";
 import * as React from "react";
 import { cn } from "@/lib/utils";

--- a/src/components/chat/message/image-gallery-carousel.tsx
+++ b/src/components/chat/message/image-gallery-carousel.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { CaretLeft, CaretRight } from "@phosphor-icons/react";
 import useEmblaCarousel from "embla-carousel-react";
 import * as React from "react";

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { CaretLeft, CaretRight } from "@phosphor-icons/react";
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
@@ -7,8 +5,8 @@ import useEmblaCarousel, {
 import type * as React from "react";
 import {
   createContext,
+  use,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useState,
@@ -40,7 +38,7 @@ type CarouselContextProps = {
 const CarouselContext = createContext<CarouselContextProps | null>(null);
 
 function useCarousel() {
-  const context = useContext(CarouselContext);
+  const context = use(CarouselContext);
 
   if (!context) {
     throw new Error("useCarousel must be used within a <Carousel />");

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 

--- a/src/components/ui/emoji-picker-drawer.tsx
+++ b/src/components/ui/emoji-picker-drawer.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { MagnifyingGlass, Smiley } from "@phosphor-icons/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -4,8 +4,8 @@ import type * as React from "react";
 import {
   createContext,
   type RefCallback,
+  use,
   useCallback,
-  useContext,
   useMemo,
   useState,
 } from "react";
@@ -61,7 +61,7 @@ function SelectTrigger({
   ref,
   ...rest
 }: SelectTriggerProps) {
-  const { setWidth } = useContext(TriggerWidthCtx);
+  const { setWidth } = use(TriggerWidthCtx);
 
   const measure: RefCallback<HTMLElement> = useCallback(
     node => {
@@ -124,7 +124,7 @@ function SelectContent({
   sideOffset = 4,
   ...rest
 }: SelectContentProps) {
-  const { width } = useContext(TriggerWidthCtx);
+  const { width } = use(TriggerWidthCtx);
 
   return (
     <Select.Portal>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as SliderPrimitive from "@base-ui/react/slider";
 import type * as React from "react";
 

--- a/src/components/ui/streaming-markdown.tsx
+++ b/src/components/ui/streaming-markdown.tsx
@@ -3,8 +3,8 @@ import { throttleBasic, useLLMOutput } from "@llm-ui/react";
 import {
   createContext,
   memo,
+  use,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -29,7 +29,7 @@ const StreamingContext = createContext<StreamingContextValue>({
   isStreaming: false,
 });
 
-export const useIsStreaming = () => useContext(StreamingContext).isStreaming;
+export const useIsStreaming = () => use(StreamingContext).isStreaming;
 
 // Burst-then-throttle strategy:
 // - No throttling for the very first moments to minimize TTFT.

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as TooltipPrimitive from "@base-ui/react/tooltip";
 import type * as React from "react";
 

--- a/src/hooks/use-speech-input-context.ts
+++ b/src/hooks/use-speech-input-context.ts
@@ -1,11 +1,11 @@
-import { useContext } from "react";
+import { use } from "react";
 import {
   SpeechInputContext,
   type SpeechInputContextValue,
 } from "@/providers/speech-input-context";
 
 export function useSpeechInputContext(): SpeechInputContextValue {
-  const context = useContext(SpeechInputContext);
+  const context = use(SpeechInputContext);
   if (context === undefined) {
     throw new Error(
       "useSpeechInputContext must be used within a SpeechInputProvider"

--- a/src/providers/batch-selection-context.tsx
+++ b/src/providers/batch-selection-context.tsx
@@ -69,7 +69,7 @@ const BatchSelectionContext = React.createContext<BatchSelectionContextValue>({
 });
 
 export function useBatchSelection() {
-  const context = React.useContext(BatchSelectionContext);
+  const context = React.use(BatchSelectionContext);
   if (!context) {
     throw new Error(
       "useBatchSelection must be used within a BatchSelectionProvider"
@@ -89,7 +89,7 @@ const SidebarHoverSetterContext = React.createContext<
 });
 
 export function useSidebarHoverSetter() {
-  const setter = React.useContext(SidebarHoverSetterContext);
+  const setter = React.use(SidebarHoverSetterContext);
   if (!setter) {
     throw new Error(
       "useSidebarHoverSetter must be used within a BatchSelectionProvider"

--- a/src/providers/citation-context.tsx
+++ b/src/providers/citation-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo } from "react";
+import { createContext, use, useMemo } from "react";
 import type { WebSearchCitation } from "@/types";
 
 type CitationContextType = {
@@ -30,7 +30,7 @@ export function CitationProvider({
 }
 
 export function useCitations() {
-  const context = useContext(CitationContext);
+  const context = use(CitationContext);
   if (!context) {
     return { citations: [], messageId: undefined };
   }

--- a/src/providers/private-mode-context.tsx
+++ b/src/providers/private-mode-context.tsx
@@ -1,8 +1,8 @@
 import {
   createContext,
   type ReactNode,
+  use,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useState,
@@ -113,7 +113,7 @@ export function PrivateModeProvider({ children }: { children: ReactNode }) {
 }
 
 export function usePrivateMode() {
-  const context = useContext(PrivateModeContext);
+  const context = use(PrivateModeContext);
   if (context === undefined) {
     throw new Error("usePrivateMode must be used within a PrivateModeProvider");
   }

--- a/src/providers/scroll-container-context.tsx
+++ b/src/providers/scroll-container-context.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { createContext, useCallback, useContext, useMemo, useRef } from "react";
+import { createContext, use, useCallback, useMemo, useRef } from "react";
 
 type ScrollContainerContextValue = {
   scrollContainerRef: React.RefObject<HTMLElement | null>;
@@ -36,7 +36,7 @@ export function useScrollContainer(): {
   ref: React.RefObject<HTMLElement | null>;
   isInScrollContainerContext: boolean;
 } | null {
-  const context = useContext(ScrollContainerContext);
+  const context = use(ScrollContainerContext);
   if (!context) {
     return null;
   }
@@ -49,6 +49,6 @@ export function useScrollContainer(): {
 export function useSetScrollContainer():
   | ((element: HTMLElement | null) => void)
   | undefined {
-  const context = useContext(ScrollContainerContext);
+  const context = use(ScrollContainerContext);
   return context?.setScrollContainer;
 }

--- a/src/providers/sidebar-width-context.tsx
+++ b/src/providers/sidebar-width-context.tsx
@@ -1,8 +1,8 @@
 import {
   createContext,
   type ReactNode,
+  use,
   useCallback,
-  useContext,
   useMemo,
   useState,
 } from "react";
@@ -53,7 +53,7 @@ export function SidebarWidthProvider({ children }: { children: ReactNode }) {
 }
 
 export function useSidebarWidth() {
-  const context = useContext(SidebarWidthContext);
+  const context = use(SidebarWidthContext);
   if (!context) {
     throw new Error(
       "useSidebarWidth must be used within a SidebarWidthProvider"

--- a/src/providers/toast-context.tsx
+++ b/src/providers/toast-context.tsx
@@ -1,8 +1,8 @@
 import type React from "react";
 import {
   createContext,
+  use,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -191,7 +191,7 @@ export function ToastProvider({ children }: ToastProviderProps) {
 }
 
 export function useToast(): ToastContextValue {
-  const context = useContext(ToastContext);
+  const context = use(ToastContext);
   if (context === undefined) {
     throw new Error("useToast must be used within a ToastProvider");
   }

--- a/src/providers/ui-provider.tsx
+++ b/src/providers/ui-provider.tsx
@@ -38,7 +38,7 @@ const UIContext = React.createContext<UIContextValue>({
 });
 
 export function useUI() {
-  const context = React.useContext(UIContext);
+  const context = React.use(UIContext);
   if (!context) {
     throw new Error("useUI must be used within a UIProvider");
   }

--- a/src/providers/user-data-context.tsx
+++ b/src/providers/user-data-context.tsx
@@ -8,7 +8,7 @@ import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
 import type React from "react";
 import {
   createContext,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -413,7 +413,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({
 };
 
 export function useUserDataContext() {
-  const ctx = useContext(UserDataContext);
+  const ctx = use(UserDataContext);
   if (!ctx) {
     throw new Error(
       "useUserDataContext must be used within a UserDataProvider"
@@ -423,7 +423,7 @@ export function useUserDataContext() {
 }
 
 export function useUserIdentity(): UserIdentity {
-  const ctx = useContext(UserIdentityContext);
+  const ctx = use(UserIdentityContext);
   if (!ctx) {
     throw new Error("useUserIdentity must be used within a UserDataProvider");
   }
@@ -431,7 +431,7 @@ export function useUserIdentity(): UserIdentity {
 }
 
 export function useUserCapabilities(): UserCapabilities {
-  const ctx = useContext(UserCapabilitiesContext);
+  const ctx = use(UserCapabilitiesContext);
   if (!ctx) {
     throw new Error(
       "useUserCapabilities must be used within a UserDataProvider"
@@ -441,7 +441,7 @@ export function useUserCapabilities(): UserCapabilities {
 }
 
 export function useUserUsage(): UserUsage {
-  const ctx = useContext(UserUsageContext);
+  const ctx = use(UserUsageContext);
   if (!ctx) {
     throw new Error("useUserUsage must be used within a UserDataProvider");
   }


### PR DESCRIPTION
## Summary
- Migrated all `useContext()` calls to React 19's `use()` API across 13 files (7 providers, 1 hook, 4 UI components)
- Removed unnecessary `"use client"` directives from 20 files (not needed in a Vite CSR app)

## Test plan
- [x] `bun run check` passes (lint + types + build)
- [ ] Smoke test app in browser — context-dependent features (sidebar, toasts, private mode, batch selection, carousel, streaming markdown) work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs two clean, mechanical modernizations across 31 files: it adopts React 19's `use()` hook as a drop-in replacement for `useContext()` across all 13 context-consuming files, and strips the Next.js-specific `"use client"` directive from 20 files where it is meaningless in this Vite CSR app.

- `use(Context)` is functionally identical to `useContext(Context)` for synchronous context access in React 19 — both subscribe to the nearest provider and trigger re-renders on value changes. All existing null/undefined guards remain correct.
- The removed `"use client"` directives were inert in a Vite build and their absence has no runtime effect.
- All automated checks (`biome` lint, type-check, `vite build`) pass per the test plan.
- No logic, API surfaces, or component behavior has been changed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all changes are mechanical, semantics-preserving substitutions with no behavioral impact.
- React 19.2.3 is confirmed in `package.json`, making `use()` for contexts fully supported. Every `use(X)` call is an unconditional top-level call inside a hook or component, identical in semantics to the `useContext(X)` it replaces. The `"use client"` removals are correct for Vite CSR. Build and lint checks pass.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/providers/user-data-context.tsx | Four `useContext()` calls replaced with `use()` across `useUserDataContext`, `useUserIdentity`, `useUserCapabilities`, and `useUserUsage` — straightforward and correct. |
| src/providers/batch-selection-context.tsx | Both `useBatchSelection` and `useSidebarHoverSetter` migrated to `use()`; context default values are non-null, so the `!context` / `!setter` guards were already dead code prior to this PR. |
| src/components/ui/streaming-markdown.tsx | `useIsStreaming` custom hook migrated to `use(StreamingContext)` with a non-null default; change is safe and functionally identical. |
| src/components/animate-ui/icons/icon.tsx | Both `useAnimateIconContext` hook and `IconWrapper` component migrated from `React.useContext` to `React.use`; `AnimateIconContext` defaults to `null` so the null-check guard remains correct. |
| src/components/ui/select.tsx | `SelectTrigger` and `SelectContent` now use `use(TriggerWidthCtx)`; `TriggerWidthCtx` always has a non-null default so no behavior change. |
| src/components/ui/carousel.tsx | `useCarousel` migrated to `use(CarouselContext)`; error guard (`null` check) remains correct. `"use client"` directive also removed. |
| src/providers/toast-context.tsx | `useToast` migrated to `use(ToastContext)`; the `undefined` check still works correctly because the context defaults to `undefined`. |
| src/providers/private-mode-context.tsx | `usePrivateMode` migrated to `use()`; clean change with no semantic difference. |
| src/providers/sidebar-width-context.tsx | `useSidebarWidth` migrated to `use(SidebarWidthContext)`; clean and correct. |
| src/providers/scroll-container-context.tsx | Both `useScrollContainer` and `useSetScrollContainer` migrated; `null` default means existing null-guards remain valid. |
| src/providers/citation-context.tsx | `useCitations` migrated to `use(CitationContext)`; fallback return is preserved correctly. |
| src/hooks/use-speech-input-context.ts | `useSpeechInputContext` migrated from `useContext` to `use`; import updated accordingly. |
| src/providers/ui-provider.tsx | `useUI` migrated to `React.use(UIContext)`; no issues. |

</details>


</details>


<sub>Last reviewed commit: 432abfe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->