### PR TITLE
feat: add sort by date to text models settings

### DIFF
--- a/convex/lib/user_models/query_handlers.ts
+++ b/convex/lib/user_models/query_handlers.ts
@@ -424,6 +424,7 @@ export async function getAllProviderModelsHandler(
     supportsImages: model.inputModalities.includes("image"),
     supportsFiles:
       model.supportsAttachments ?? model.inputModalities.includes("file"),
+    releaseDate: model.releaseDate,
     isAvailable: true, // Models in cache are available
   }));
 }

--- a/src/components/settings/models-tab/model-filters.tsx
+++ b/src/components/settings/models-tab/model-filters.tsx
@@ -1,5 +1,6 @@
 import { api } from "@convex/_generated/api";
 import {
+  ArrowsDownUpIcon,
   CaretDownIcon,
   FunnelIcon,
   MagnifyingGlassIcon,
@@ -16,13 +17,15 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { getAllCapabilities } from "@/lib/model-capabilities";
 import type { FetchedModel } from "@/types";
-import type { FilterState } from "./text-models-tab";
+import type { FilterState, SortDirection, SortOption } from "./text-models-tab";
 
 interface ModelFiltersProps {
   filterState: FilterState;
@@ -37,6 +40,9 @@ interface ModelFiltersProps {
   } | null;
   enabledModelsCount?: number;
   isPending: boolean;
+  sortBy: SortOption;
+  sortDirection: SortDirection;
+  onSortChange: (sortBy: SortOption, sortDirection: SortDirection) => void;
   onModelsFetched: (models: FetchedModel[]) => void;
   onLoadingChange: (isLoading: boolean) => void;
   onError: (error: Error | null) => void;
@@ -53,6 +59,9 @@ export const ModelFilters = memo(
     stats,
     enabledModelsCount,
     isPending,
+    sortBy,
+    sortDirection,
+    onSortChange,
     onModelsFetched,
     onLoadingChange,
     onError,
@@ -212,6 +221,49 @@ export const ModelFilters = memo(
                   </DropdownMenuCheckboxItem>
                 ))}
               </div>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger>
+              <Button
+                className="gap-1.5 h-9 text-sm"
+                size="sm"
+                variant="secondary"
+              >
+                <ArrowsDownUpIcon className="size-4 shrink-0" />
+                <span className="hidden sm:inline">Sort</span>
+                <CaretDownIcon className="ml-auto size-4 opacity-50 sm:ml-1" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Sort models</DropdownMenuLabel>
+              </DropdownMenuGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuRadioGroup
+                value={`${sortBy}-${sortDirection}`}
+                onValueChange={value => {
+                  const [by, dir] = value.split("-") as [
+                    SortOption,
+                    SortDirection,
+                  ];
+                  onSortChange(by, dir);
+                }}
+              >
+                <DropdownMenuRadioItem value="releaseDate-desc">
+                  Newest first
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="releaseDate-asc">
+                  Oldest first
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="name-asc">
+                  Name A–Z
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="name-desc">
+                  Name Z–A
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/src/components/settings/models-tab/model-filters.tsx
+++ b/src/components/settings/models-tab/model-filters.tsx
@@ -40,8 +40,6 @@ interface ModelFiltersProps {
   } | null;
   enabledModelsCount?: number;
   isPending: boolean;
-  sortBy: SortOption;
-  sortDirection: SortDirection;
   onSortChange: (sortBy: SortOption, sortDirection: SortDirection) => void;
   onModelsFetched: (models: FetchedModel[]) => void;
   onLoadingChange: (isLoading: boolean) => void;
@@ -59,8 +57,6 @@ export const ModelFilters = memo(
     stats,
     enabledModelsCount,
     isPending,
-    sortBy,
-    sortDirection,
     onSortChange,
     onModelsFetched,
     onLoadingChange,
@@ -242,12 +238,11 @@ export const ModelFilters = memo(
               </DropdownMenuGroup>
               <DropdownMenuSeparator />
               <DropdownMenuRadioGroup
-                value={`${sortBy}-${sortDirection}`}
+                value={`${filterState.sortBy}-${filterState.sortDirection}`}
                 onValueChange={value => {
-                  const [by, dir] = value.split("-") as [
-                    SortOption,
-                    SortDirection,
-                  ];
+                  const lastDash = value.lastIndexOf("-");
+                  const by = value.slice(0, lastDash) as SortOption;
+                  const dir = value.slice(lastDash + 1) as SortDirection;
                   onSortChange(by, dir);
                 }}
               >

--- a/src/components/settings/models-tab/text-models-tab.tsx
+++ b/src/components/settings/models-tab/text-models-tab.tsx
@@ -32,11 +32,16 @@ import { ActiveFilters } from "./active-filters";
 import { ModelFilters } from "./model-filters";
 import { ProviderSummary } from "./provider-summary";
 
+export type SortOption = "name" | "releaseDate";
+export type SortDirection = "asc" | "desc";
+
 export type FilterState = {
   searchQuery: string;
   selectedProviders: string[];
   selectedCapabilities: string[];
   showOnlySelected: boolean;
+  sortBy: SortOption;
+  sortDirection: SortDirection;
 };
 
 type FilterAction =
@@ -46,13 +51,19 @@ type FilterAction =
   | { type: "TOGGLE_SHOW_SELECTED" }
   | { type: "CLEAR_PROVIDERS" }
   | { type: "CLEAR_CAPABILITIES" }
-  | { type: "CLEAR_ALL" };
+  | { type: "CLEAR_ALL" }
+  | {
+      type: "SET_SORT";
+      payload: { sortBy: SortOption; sortDirection: SortDirection };
+    };
 
 const initialFilterState: FilterState = {
   searchQuery: "",
   selectedProviders: [],
   selectedCapabilities: [],
   showOnlySelected: false,
+  sortBy: "releaseDate",
+  sortDirection: "desc",
 };
 
 function filterReducer(state: FilterState, action: FilterAction): FilterState {
@@ -81,6 +92,12 @@ function filterReducer(state: FilterState, action: FilterAction): FilterState {
       return { ...state, selectedProviders: [] };
     case "CLEAR_CAPABILITIES":
       return { ...state, selectedCapabilities: [] };
+    case "SET_SORT":
+      return {
+        ...state,
+        sortBy: action.payload.sortBy,
+        sortDirection: action.payload.sortDirection,
+      };
     case "CLEAR_ALL":
       return initialFilterState;
     default:
@@ -303,8 +320,30 @@ export const TextModelsTab = () => {
           return true;
         });
 
-    // Show unavailable models first, then available models
-    return [...filteredUnavailable, ...available];
+    // Sort available models
+    const sortedAvailable = [...available].sort((a, b) => {
+      const dir = debouncedFilters.sortDirection === "asc" ? 1 : -1;
+      if (debouncedFilters.sortBy === "releaseDate") {
+        const aDate = a.releaseDate ?? "";
+        const bDate = b.releaseDate ?? "";
+        // Models without releaseDate go to the end regardless of direction
+        if (!(aDate || bDate)) {
+          return a.name.localeCompare(b.name);
+        }
+        if (!aDate) {
+          return 1;
+        }
+        if (!bDate) {
+          return -1;
+        }
+        const cmp = aDate.localeCompare(bDate);
+        return cmp !== 0 ? cmp * dir : a.name.localeCompare(b.name);
+      }
+      return a.name.localeCompare(b.name) * dir;
+    });
+
+    // Show unavailable models first, then sorted available models
+    return [...filteredUnavailable, ...sortedAvailable];
   }, [
     fuzzySearchResults,
     debouncedFilters,
@@ -363,6 +402,15 @@ export const TextModelsTab = () => {
     });
   }, []);
 
+  const handleSortChange = useCallback(
+    (sortBy: SortOption, sortDirection: SortDirection) => {
+      startTransition(() => {
+        dispatch({ type: "SET_SORT", payload: { sortBy, sortDirection } });
+      });
+    },
+    []
+  );
+
   const clearAllFilters = useCallback(() => {
     startTransition(() => {
       dispatch({ type: "CLEAR_ALL" });
@@ -420,6 +468,9 @@ export const TextModelsTab = () => {
           stats={stats}
           enabledModelsCount={enabledModels.length}
           isPending={isPending}
+          sortBy={filterState.sortBy}
+          sortDirection={filterState.sortDirection}
+          onSortChange={handleSortChange}
           onModelsFetched={setUnfilteredModels}
           onLoadingChange={setIsLoading}
           onError={setError}

--- a/src/components/settings/models-tab/text-models-tab.tsx
+++ b/src/components/settings/models-tab/text-models-tab.tsx
@@ -468,8 +468,6 @@ export const TextModelsTab = () => {
           stats={stats}
           enabledModelsCount={enabledModels.length}
           isPending={isPending}
-          sortBy={filterState.sortBy}
-          sortDirection={filterState.sortDirection}
           onSortChange={handleSortChange}
           onModelsFetched={setUnfilteredModels}
           onLoadingChange={setIsLoading}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -540,6 +540,7 @@ export type FetchedModel = {
   supportsImages: boolean;
   supportsFiles: boolean;
   isAvailable?: boolean;
+  releaseDate?: string;
 };
 
 export type FetchedImageModel = {


### PR DESCRIPTION
## Summary
- Pass `releaseDate` from `modelsDevCache` through the data pipeline to the frontend (`FetchedModel` type)
- Add sort state (`sortBy` / `sortDirection`) to the `FilterState` reducer in text models tab
- Add a sort dropdown to the filter bar with 4 options: Newest first (default), Oldest first, Name A–Z, Name Z–A
- Models without a release date sort to the end when sorting by date; unavailable models always appear first

## Test plan
- [ ] Open Settings → Text Models, verify sort dropdown appears after Capabilities filter
- [ ] Default sort is "Newest first" — recently released models appear at top
- [ ] Switch to "Oldest first" — order reverses, models without dates stay at bottom
- [ ] Switch to "Name A–Z" / "Name Z–A" — alphabetical sorting works
- [ ] Unavailable models still appear first regardless of sort
- [ ] "Clear all filters" resets sort to default (Newest first)
- [ ] `bun run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads `releaseDate` from the models dev cache through the data pipeline and adds a sort dropdown (Newest first / Oldest first / Name A–Z / Name Z–A) to the Text Models settings tab. The feature is well-scoped and integrates cleanly with the existing `FilterState` reducer and `ModelFilters` component patterns.

- `releaseDate` is correctly typed as optional on `FetchedModel`, so existing code paths that don't set it continue to work and those models are sorted to the end as intended.
- The sort comparator correctly handles three cases: both dates present (ISO lexicographic comparison with direction multiplier), one date missing (always sent to end, direction-independent), and both missing (stable alphabetical tie-break).
- `handleSortChange` is correctly wrapped in `startTransition`, consistent with the other filter handlers.
- The new sort dropdown follows the exact same `DropdownMenuTrigger > Button` pattern already used for the Provider and Capability dropdowns in the same file.
- No issues with the data flow; `onSortChange` is passed cleanly and `filterState.sortBy`/`sortDirection` are read directly inside `ModelFilters` from `filterState`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the feature is well-implemented and follows existing patterns throughout the codebase.
- The sorting logic is correct for ISO date strings, state management follows the established reducer pattern, and all edge cases (missing dates, sort direction, tie-breaking) are handled properly. The data flow is clean with no redundant props or unsafe value parsing. All four modified files integrate cohesively with no concerns.
- No files require special attention.

<sub>Last reviewed commit: 800d28d</sub>

<!-- /greptile_comment -->